### PR TITLE
fix: referee UI layout shift and sidebar width

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,90 @@
 # CLAUDE.md — DartEvent Manager
 
 ## Meine Rolle
-Ich agiere als **Team Lead**. Ich entscheide selbstständig, wann eine Aufgabe aufgeteilt werden muss und spawne bei Bedarf Sub-Agents (Backend-Agent, Frontend-Agent, etc.) parallel. Der User muss das nicht explizit anfordern.
+Ich agiere als **Team Lead**. Ich entscheide selbstständig, wann eine Aufgabe aufgeteilt werden muss und spawne bei Bedarf Sub-Agents parallel. Der User muss das nicht explizit anfordern.
 
 **Lerndatei:** Fehler und Korrekturen werden dokumentiert unter:
 `~/.claude/projects/-home-moritzwolf-dartsturnier/memory/feedback_mistakes.md`
 → Diese Datei wird bei jedem Fehler aktualisiert. Vor Beginn einer Aufgabe lesen.
+
+---
+
+## Team — Agent-Definitionen
+
+### UX-EXPERT-AGENT
+
+**Rolle:** UX-Experte und UI-Qualitätssicherung
+**Wann spawnen:** Bei neuen Features, UI-Überarbeitungen, auf explizite Anfrage des Users oder wenn ein Flow mehr als 3 Taps für eine Kernaufgabe benötigt.
+
+**Kernkompetenzen:**
+- Mobile-first UX-Analyse (primär iOS/Android Smartphone)
+- Touch-Target-Prüfung (min. 64px — PFLICHT laut Design-Vorgaben)
+- Informationsarchitektur und Navigation
+- Konsistenz über alle Seiten hinweg (Farben, Abstände, Typografie)
+- Feedback-Mechanismen (Loading-States, Fehlermeldungen, Erfolgsmeldungen)
+- Barrierefreiheit (Kontrast, Lesbarkeit, Tap-Abstände)
+
+**Arbeitsweise:**
+1. Betroffene Komponenten/Pages lesen und analysieren
+2. UX-Probleme konkret benennen (mit Dateipfad + Zeilennummer)
+3. Lösungsvorschläge direkt im Code umsetzen — keine reinen Empfehlungslisten
+4. P Entertainment Corporate Design dabei strikt einhalten
+5. Änderungen auf eigenem Branch (`ux/beschreibung`) mit eigenem PR
+
+**Prüfkriterien (Checkliste bei jedem Review):**
+- [ ] Touch-Targets ≥ 64px auf allen interaktiven Elementen
+- [ ] Schrift: Verdana, Geneva, sans-serif — keine Ausnahmen
+- [ ] PE Design Tokens verwendet (keine hardcodierten Farben außer den Tokens)
+- [ ] Dark Mode konsistent (kein weißer Hintergrund, kein Light-Mode-Leak)
+- [ ] Ladezustände vorhanden (kein leeres Flackern)
+- [ ] Fehlermeldungen sichtbar und verständlich (nicht nur Konsole)
+- [ ] Navigation klar: User weiß immer wo er ist und wie er zurückkommt
+- [ ] Keine überflüssigen Klicks für häufige Aktionen (max. 3 Taps zu Kernfunktionen)
+- [ ] Formular-Feedback: Disabled-State bei Submit, Fehler inline angezeigt
+
+**Nicht im Scope:**
+- Backend-Logik
+- Datenbank-Schema
+- Sicherheitsrelevante Änderungen
+
+---
+
+### BACKEND-AGENT
+
+**Rolle:** Node.js / Express / SQLite Entwicklung
+**Wann spawnen:** Neue API-Endpunkte, Datenbankänderungen, Business-Logik, Performance.
+
+**Pflichten:**
+- Prepared Statements — niemals String-Concatenation in SQL
+- Input-Validierung auf allen Endpunkten
+- Keine sensiblen Daten in Logs oder Responses
+- Fehler mit sinnvollem HTTP-Statuscode zurückgeben
+
+---
+
+### FRONTEND-AGENT
+
+**Rolle:** React / Vite / TailwindCSS Entwicklung
+**Wann spawnen:** Neue Komponenten, Pages, Zustand-Store-Änderungen, API-Client.
+
+**Pflichten:**
+- PE Corporate Design einhalten (Tokens, Schrift, Dark Mode)
+- Mobile-first — erst Mobile, dann Desktop
+- `BackButton` Komponente verwenden statt eigener `←` Links
+- Keine sensiblen Daten im LocalStorage außer JWT-Token
+
+---
+
+### SECURITY-AGENT
+
+**Rolle:** Sicherheitsprüfung und -härtung
+**Wann spawnen:** Vor jedem Deployment, bei Auth-Änderungen, bei neuen Eingabefeldern.
+
+**Pflichten:**
+- Kein Commit mit Secrets, Keys oder `.env`-Inhalten
+- JWT-Handling prüfen (Expiry, Signatur, Payload-Inhalt)
+- XSS / Injection Vektoren in neuen Inputs identifizieren
+- Rate Limiting auf neuen Endpunkten sicherstellen
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,47 @@ Ich agiere als **Team Lead**. Ich entscheide selbstständig, wann eine Aufgabe a
 
 ---
 
+## Git-Workflow (PFLICHT)
+
+### Branching-Strategie
+- `main` — Produktion, immer stabil
+- `dev` — Basis für neue Branches
+- Feature/Fix-Branches immer von `dev` abzweigen
+
+### Regel: Ein Branch = Ein PR = Ein Thema
+- Jeder Bug → eigener Branch + eigener PR
+- Jedes Feature → eigener Branch + eigener PR
+- Verwandte kleine Bugs dürfen zusammen → PR-Titel muss es klar beschreiben
+- **Niemals** Bug-Fix und Feature im selben PR mischen
+
+### Branch-Namenskonvention
+```
+fix/kurze-beschreibung       # Bug-Fix
+feat/kurze-beschreibung      # Neues Feature
+docs/kurze-beschreibung      # Nur Dokumentation
+```
+
+### Workflow
+```
+1. git checkout dev && git pull origin dev
+2. git checkout -b fix/mein-bug
+3. Änderungen machen + committen
+4. git push origin fix/mein-bug
+5. gh pr create --base main --head fix/mein-bug
+6. PR mergen
+7. git checkout dev && git pull origin dev  (dev aktuell halten)
+```
+
+### Commit-Messages
+```
+feat: kurze Beschreibung      # neues Feature
+fix: kurze Beschreibung       # Bug-Fix
+docs: kurze Beschreibung      # Dokumentation
+refactor: kurze Beschreibung  # Umstrukturierung ohne Funktionsänderung
+```
+
+---
+
 ## Design — P Entertainment Corporate Design (PFLICHT)
 
 **Schrift:** Verdana, Geneva, sans-serif — keine andere

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -9,7 +9,7 @@ async function request(path, options = {}) {
   const token = getToken();
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const res = await fetch(BASE + path, { ...options, headers });
-  if (res.status === 401) {
+  if (res.status === 401 && path !== '/auth/login') {
     // Token abgelaufen oder ungültig — Session beenden
     localStorage.removeItem('token');
     window.location.reload();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,5 +35,7 @@ body {
 
 @media (min-width: 1024px) {
   .sidebar-desktop { display: flex !important; flex-direction: column; }
-  .mobile-tabs { display: none !important; }
+  .mobile-tiles-grid { display: none !important; }
+  .mobile-back-bar { display: none !important; }
+  .content-area { display: flex !important; }
 }

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -6,17 +6,17 @@ import AdminLogin from '../components/admin/AdminLogin';
 import TournamentManager from '../components/admin/TournamentManager';
 
 const ALL_TABS = [
-  { id: 'overview',    label: 'Übersicht',      roles: ['admin', 'director'] },
-  { id: 'director',    label: 'Turnierleiter',   roles: ['admin', 'director'] },
-  { id: 'tournaments', label: 'Turniere',         roles: ['admin', 'director'] },
-  { id: 'players',     label: 'Spieler',          roles: ['admin', 'director'] },
-  { id: 'boards',      label: 'Boards',           roles: ['admin', 'director'] },
-  { id: 'users',       label: 'User',             roles: ['admin'] },
-  { id: 'gastro',      label: 'Gastro',           roles: ['admin'] },
-  { id: 'mailing',     label: 'Mailing',          roles: ['admin'] },
-  { id: 'settings',    label: 'Einstellungen',    roles: ['admin'] },
-  { id: 'log',         label: 'System-Log',       roles: ['admin', 'director'] },
-  { id: 'help',        label: '? Hilfe',          roles: ['admin', 'director'] },
+  { id: 'overview',    label: 'Übersicht',     abbr: 'ÜB', color: 'var(--pe-cyan-bright)', roles: ['admin', 'director'] },
+  { id: 'director',    label: 'Turnierleiter', abbr: 'TL', color: 'var(--pe-blue-mid)',    roles: ['admin', 'director'] },
+  { id: 'tournaments', label: 'Turniere',      abbr: 'TU', color: 'var(--pe-cyan-light)',  roles: ['admin', 'director'] },
+  { id: 'players',     label: 'Spieler',       abbr: 'SP', color: 'var(--pe-success)',     roles: ['admin', 'director'] },
+  { id: 'boards',      label: 'Boards',        abbr: 'BD', color: 'var(--pe-blue-deep)',   roles: ['admin', 'director'] },
+  { id: 'users',       label: 'User',          abbr: 'US', color: 'var(--pe-warning)',     roles: ['admin'] },
+  { id: 'gastro',      label: 'Gastro',        abbr: 'GT', color: 'var(--pe-success)',     roles: ['admin'] },
+  { id: 'mailing',     label: 'Mailing',       abbr: 'ML', color: 'var(--pe-cyan-bright)', roles: ['admin'] },
+  { id: 'settings',    label: 'Einstellungen', abbr: 'EI', color: 'var(--pe-text-sub)',    roles: ['admin'] },
+  { id: 'log',         label: 'System-Log',    abbr: 'LOG', color: 'var(--pe-text-muted)', roles: ['admin', 'director'] },
+  { id: 'help',        label: 'Hilfe',         abbr: '?',  color: 'var(--pe-text-sub)',    roles: ['admin', 'director'] },
 ];
 
 function parseJwt(token) {
@@ -2093,7 +2093,10 @@ function AdminDashboard({ tab }) {
     : visibleTabs[0]?.id || 'overview';
 
   const [activeTab, setActiveTab] = useState(resolvedDefault);
+  const [showMobileTiles, setShowMobileTiles] = useState(true);
   const [userPopoverOpen, setUserPopoverOpen] = useState(false);
+
+  const selectTab = (id) => { setActiveTab(id); setShowMobileTiles(false); };
 
   const ROLE_LABEL = { admin: 'Admin', director: 'Turnierleitung', referee: 'Schiedsrichter', gastronomy: 'Gastronomie' };
 
@@ -2165,57 +2168,90 @@ function AdminDashboard({ tab }) {
 
       {/* Body: Sidebar + Content */}
       <div style={{ display: 'flex', minHeight: 'calc(100vh - 64px)' }}>
-        {/* Sidebar (Desktop) */}
-        <div style={{ width: '200px', flexShrink: 0, background: 'var(--pe-bg-card)', borderRight: '1px solid var(--pe-border)', padding: '16px 0', display: 'none' }} className="sidebar-desktop">
+        {/* Sidebar (Desktop ≥1024px) */}
+        <div className="sidebar-desktop" style={{ width: '200px', flexShrink: 0, background: 'var(--pe-bg-card)', borderRight: '1px solid var(--pe-border)', padding: '16px 0', display: 'none' }}>
           {visibleTabs.map(t => (
-            <button key={t.id} onClick={() => setActiveTab(t.id)} style={{ width: '100%', padding: '14px 20px', textAlign: 'left', background: activeTab === t.id ? 'var(--pe-bg-elevated)' : 'transparent', color: activeTab === t.id ? 'var(--pe-cyan-bright)' : 'var(--pe-text-sub)', border: 'none', borderLeft: activeTab === t.id ? '3px solid var(--pe-cyan-bright)' : '3px solid transparent', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '14px', cursor: 'pointer' }}>
+            <button key={t.id} onClick={() => selectTab(t.id)} style={{ width: '100%', padding: '14px 20px', textAlign: 'left', background: activeTab === t.id ? 'var(--pe-bg-elevated)' : 'transparent', color: activeTab === t.id ? 'var(--pe-cyan-bright)' : 'var(--pe-text-sub)', border: 'none', borderLeft: activeTab === t.id ? '3px solid var(--pe-cyan-bright)' : '3px solid transparent', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '14px', cursor: 'pointer' }}>
               {t.label}
             </button>
           ))}
         </div>
 
         {/* Main area */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-          {/* Mobile Tab-Leiste */}
-          <div className="mobile-tabs" style={{ display: 'flex', overflowX: 'auto', padding: '8px', gap: '8px', background: 'var(--pe-bg-card)', borderBottom: '1px solid var(--pe-border)', WebkitOverflowScrolling: 'touch' }}>
-            {visibleTabs.map((t) => (
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+
+          {/* Mobile: Kachel-Grid */}
+          <div
+            className="mobile-tiles-grid"
+            style={{ display: showMobileTiles ? 'grid' : 'none', gridTemplateColumns: '1fr 1fr', gap: '12px', padding: '16px', overflowY: 'auto' }}
+          >
+            {visibleTabs.map(t => (
               <button
                 key={t.id}
-                onClick={() => setActiveTab(t.id)}
+                onClick={() => selectTab(t.id)}
                 style={{
-                  padding: '10px 16px',
-                  borderRadius: '8px',
-                  fontWeight: 'bold',
-                  fontSize: '13px',
-                  whiteSpace: 'nowrap',
-                  background: activeTab === t.id ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)',
+                  display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+                  gap: '12px', padding: '20px 12px', minHeight: '110px',
+                  background: 'var(--pe-bg-card)',
                   border: '1px solid var(--pe-border)',
-                  color: activeTab === t.id ? 'var(--pe-text)' : 'var(--pe-text-sub)',
-                  minHeight: '44px',
-                  fontFamily: 'Verdana, Geneva, sans-serif',
-                  flexShrink: 0,
+                  borderRadius: '16px',
                   cursor: 'pointer',
+                  fontFamily: 'Verdana, Geneva, sans-serif',
+                  transition: 'border-color 0.15s, background 0.15s',
                 }}
+                onMouseEnter={e => { e.currentTarget.style.borderColor = t.color; e.currentTarget.style.background = 'var(--pe-bg-elevated)'; }}
+                onMouseLeave={e => { e.currentTarget.style.borderColor = 'var(--pe-border)'; e.currentTarget.style.background = 'var(--pe-bg-card)'; }}
               >
-                {t.label}
+                <div style={{
+                  width: '52px', height: '52px', borderRadius: '50%',
+                  background: t.color + '22',
+                  border: `2px solid ${t.color}`,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  color: t.color, fontWeight: 'bold', fontSize: t.abbr.length > 2 ? '11px' : '15px', flexShrink: 0,
+                }}>
+                  {t.abbr}
+                </div>
+                <span style={{ color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '13px', textAlign: 'center', lineHeight: 1.3 }}>
+                  {t.label}
+                </span>
               </button>
             ))}
           </div>
 
-          {/* Content */}
-          <div style={{ flex: 1, padding: '24px', maxWidth: '1400px', overflowY: 'auto' }}>
-            {activeTab === 'overview'    && <OverviewTab />}
-            {activeTab === 'director'    && <TournamentDirectorTab />}
-            {activeTab === 'tournaments' && <TournamentExtendedTab />}
-            {activeTab === 'players'     && <PlayersTab />}
-            {activeTab === 'boards'      && <BoardsTab />}
-            {activeTab === 'users'       && <UsersTab />}
-            {activeTab === 'gastro'      && <GastroAdminTab />}
-            {activeTab === 'mailing'     && <MailingTab />}
-            {activeTab === 'settings'    && <SettingsTab />}
-            {activeTab === 'log'         && <LogTab />}
-            {activeTab === 'help'        && <HelpTab />}
+          {/* Mobile: Back-Bar + Content */}
+          <div
+            className="content-area"
+            style={{ display: showMobileTiles ? 'none' : 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}
+          >
+            {/* Mobile Back-Button */}
+            <div className="mobile-back-bar" style={{ display: 'flex', alignItems: 'center', gap: '12px', padding: '10px 16px', background: 'var(--pe-bg-card)', borderBottom: '1px solid var(--pe-border)', flexShrink: 0 }}>
+              <button
+                onClick={() => setShowMobileTiles(true)}
+                style={{ display: 'flex', alignItems: 'center', gap: '8px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', borderRadius: '8px', padding: '8px 14px', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '13px', cursor: 'pointer', minHeight: '40px' }}
+              >
+                &#8592; Menü
+              </button>
+              <span style={{ color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '15px' }}>
+                {visibleTabs.find(t => t.id === activeTab)?.label}
+              </span>
+            </div>
+
+            {/* Content */}
+            <div style={{ flex: 1, padding: '24px', maxWidth: '1400px', overflowY: 'auto' }}>
+              {activeTab === 'overview'    && <OverviewTab />}
+              {activeTab === 'director'    && <TournamentDirectorTab />}
+              {activeTab === 'tournaments' && <TournamentExtendedTab />}
+              {activeTab === 'players'     && <PlayersTab />}
+              {activeTab === 'boards'      && <BoardsTab />}
+              {activeTab === 'users'       && <UsersTab />}
+              {activeTab === 'gastro'      && <GastroAdminTab />}
+              {activeTab === 'mailing'     && <MailingTab />}
+              {activeTab === 'settings'    && <SettingsTab />}
+              {activeTab === 'log'         && <LogTab />}
+              {activeTab === 'help'        && <HelpTab />}
+            </div>
           </div>
+
         </div>
       </div>
     </div>

--- a/frontend/src/pages/RefereePage.jsx
+++ b/frontend/src/pages/RefereePage.jsx
@@ -256,7 +256,13 @@ function RoundThrows({ throws, prevThrow, onUndo, disabled, isTablet }) {
                     </button>
                   </>
                 ) : (
-                  <span style={{ color: 'var(--pe-text-muted)', fontSize: '18px' }}>—</span>
+                  <>
+                    <span style={{ color: 'var(--pe-text-muted)', fontSize: '18px' }}>—</span>
+                    <button disabled aria-hidden="true"
+                      style={btn({ padding: '1px 8px', background: 'transparent', color: 'transparent', fontSize: '14px', border: 'none', minHeight: 'unset', visibility: 'hidden', cursor: 'default' })}>
+                      ↩
+                    </button>
+                  </>
                 )}
               </div>
             );
@@ -464,7 +470,7 @@ function TabletLayout({ boardId, token, onLogout, selectedGameId, setSelectedGam
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden', fontFamily: 'Verdana, Geneva, sans-serif', background: 'var(--pe-bg)' }}>
 
       {/* ── LEFT PANEL ── */}
-      <div style={{ width: '340px', flexShrink: 0, display: 'flex', flexDirection: 'column', background: 'var(--pe-bg-card)', borderRight: '1px solid var(--pe-border)', overflow: 'hidden' }}>
+      <div style={{ width: '360px', minWidth: '320px', flexShrink: 0, display: 'flex', flexDirection: 'column', background: 'var(--pe-bg-card)', borderRight: '1px solid var(--pe-border)', overflow: 'hidden', overflowX: 'hidden' }}>
 
         {/* Header */}
         <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--pe-border)', display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>


### PR DESCRIPTION
## Probleme

- **Layout-Shift:** Das Scoring-UI verrutschte je nachdem wer am Zug ist, da das Undo-Icon (↩) nur beim aktiven Spieler gerendert wurde und so die Höhe der Panels veränderte
- **Sidebar zu schmal:** Die linke Spielliste erzeugte unnötige horizontale Scrollbereiche bei langen Spielernamen

## Fixes

- Undo-Icon bekommt einen unsichtbaren Platzhalter (`visibility: hidden`) wenn nicht aktiv → Layout bleibt stabil
- Sidebar: Breite von 340px auf 360px erhöht + `overflowX: hidden` → kein horizontales Scrollen mehr

## Test plan

- [ ] Aktiven Spieler wechseln → kein Layout-Shift
- [ ] Lange Spielernamen in der Sidebar → kein horizontaler Scroll
- [ ] Undo-Button weiterhin funktionsfähig beim aktiven Spieler

🤖 Generated with [Claude Code](https://claude.com/claude-code)