### PR TITLE
fix: setup script bootstrap for fresh Ubuntu servers

### DIFF
--- a/deploy/setup-ubuntu.sh
+++ b/deploy/setup-ubuntu.sh
@@ -6,8 +6,10 @@ set -e
 # Installs and configures everything from scratch:
 #   nginx, Node.js, SSL, systemd service, firewall
 #
-# Run as root:
-#   sudo bash setup-ubuntu.sh
+# One-liner on a fresh Ubuntu server (run as root):
+#   apt-get install -y curl git && \
+#   git clone https://github.com/morwol/dart-tournament.git /tmp/dartsturnier-setup && \
+#   sudo bash /tmp/dartsturnier-setup/deploy/setup-ubuntu.sh
 #
 # Works for both production (main) and dev (dev) servers.
 # ============================================================
@@ -96,6 +98,7 @@ read -p "Continue? [Enter to confirm / Ctrl+C to abort] " _
 echo ""
 echo -e "${GREEN}[1/10] Installing system packages...${NC}"
 apt update -q
+DEBIAN_FRONTEND=noninteractive apt upgrade -y -q
 apt install -y curl git nginx ufw openssl
 
 # Node.js 20 LTS via NodeSource


### PR DESCRIPTION
## Problem
A fresh Ubuntu server has no `git` installed — so cloning the repo to run the setup script was a chicken-and-egg problem. Also missing: a full system upgrade before installing packages.

## Changes
- Added `DEBIAN_FRONTEND=noninteractive apt upgrade -y` to step 1 (system packages)
- Added a clear one-liner comment at the top of the script showing exactly what to run on a brand-new server

## Usage (fresh server)
```bash
apt-get install -y curl git
git clone https://github.com/morwol/dart-tournament.git /tmp/dartsturnier-setup
sudo bash /tmp/dartsturnier-setup/deploy/setup-ubuntu.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)