### PR TITLE
fix: apt-get update missing before bootstrap install

### DIFF
--- a/deploy/setup-ubuntu.sh
+++ b/deploy/setup-ubuntu.sh
@@ -7,7 +7,7 @@ set -e
 #   nginx, Node.js, SSL, systemd service, firewall
 #
 # One-liner on a fresh Ubuntu server (run as root):
-#   apt-get install -y curl git && \
+#   apt-get update && apt-get install -y curl git && \
 #   git clone https://github.com/morwol/dart-tournament.git /tmp/dartsturnier-setup && \
 #   sudo bash /tmp/dartsturnier-setup/deploy/setup-ubuntu.sh
 #


### PR DESCRIPTION
## Problem
On minimal Ubuntu images (e.g. Oracle Cloud), package lists are empty on first boot.
`apt-get install -y curl git` fails with "Unable to locate package git".

## Fix
Added `apt-get update` before the bootstrap install in the one-liner comment.

```bash
apt-get update && apt-get install -y curl git && \
git clone https://github.com/morwol/dart-tournament.git /tmp/dartsturnier-setup && \
sudo bash /tmp/dartsturnier-setup/deploy/setup-ubuntu.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)