### PR TITLE
feat: GitHub webhook auto-deploy for dev branch

### DIFF
--- a/backend/webhook.js
+++ b/backend/webhook.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// ============================================================
+// DartEvent — GitHub Webhook Receiver
+//
+// Listens on 127.0.0.1:9001 (proxied by nginx at /webhook).
+// On push to 'dev' branch: runs deploy/update-dev.sh
+//
+// Requires env vars (loaded from /var/www/dartsturnier/backend/.env):
+//   WEBHOOK_SECRET  — must match the secret set in GitHub
+//   WEBHOOK_PORT    — optional, default 9001
+// ============================================================
+
+require('dotenv').config({ path: require('path').join(__dirname, '.env') });
+
+const http   = require('http');
+const crypto = require('crypto');
+const { exec } = require('child_process');
+
+const PORT   = process.env.WEBHOOK_PORT || 9001;
+const SECRET = process.env.WEBHOOK_SECRET || '';
+const SCRIPT = '/var/www/dartsturnier/deploy/update-dev.sh';
+
+// ── HMAC-SHA256 signature verification ─────────────────────
+function verifySignature(secret, payload, signature) {
+  if (!secret) return true; // no secret configured → skip (dev only)
+  const hmac     = crypto.createHmac('sha256', secret);
+  const expected = 'sha256=' + hmac.update(payload).digest('hex');
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+// ── HTTP server ─────────────────────────────────────────────
+const server = http.createServer((req, res) => {
+  if (req.method !== 'POST' || req.url !== '/webhook') {
+    res.writeHead(404); res.end(); return;
+  }
+
+  const chunks = [];
+  req.on('data', c => chunks.push(c));
+  req.on('end', () => {
+    const payload   = Buffer.concat(chunks);
+    const signature = req.headers['x-hub-signature-256'] || '';
+
+    if (!verifySignature(SECRET, payload, signature)) {
+      console.warn('[webhook] Invalid signature — rejected');
+      res.writeHead(401); res.end('Unauthorized'); return;
+    }
+
+    let event;
+    try { event = JSON.parse(payload.toString()); }
+    catch { res.writeHead(400); res.end('Bad JSON'); return; }
+
+    const githubEvent = req.headers['x-github-event'];
+    const ref         = event.ref || '';
+
+    // Only react to pushes on the dev branch
+    if (githubEvent !== 'push' || ref !== 'refs/heads/dev') {
+      res.writeHead(200); res.end('ignored'); return;
+    }
+
+    const pusher  = event.pusher?.name || 'unknown';
+    const commits = event.commits?.length || 0;
+    console.log(`[webhook] Push to dev by ${pusher} (${commits} commit(s)) — deploying...`);
+
+    res.writeHead(200); res.end('deploying');
+
+    exec(`bash ${SCRIPT}`, { timeout: 300000 }, (err, stdout, stderr) => {
+      if (err) {
+        console.error('[webhook] Deploy FAILED:', err.message);
+        if (stderr) console.error(stderr.slice(-500));
+      } else {
+        console.log('[webhook] Deploy successful');
+        if (stdout) console.log(stdout.slice(-300));
+      }
+    });
+  });
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[webhook] Listening on 127.0.0.1:${PORT}`);
+});

--- a/deploy/dartevent-webhook.service
+++ b/deploy/dartevent-webhook.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=DartEvent GitHub Webhook Receiver
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/var/www/dartsturnier/backend
+ExecStart=/usr/bin/node /var/www/dartsturnier/backend/webhook.js
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=dartevent-webhook
+EnvironmentFile=/var/www/dartsturnier/backend/.env
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/setup-ubuntu.sh
+++ b/deploy/setup-ubuntu.sh
@@ -1,0 +1,363 @@
+#!/bin/bash
+set -e
+# ============================================================
+# DartEvent Manager — Full Setup Script for Ubuntu Server
+#
+# Installs and configures everything from scratch:
+#   nginx, Node.js, SSL, systemd service, firewall
+#
+# One-liner on a fresh Ubuntu server (run as root):
+#   apt-get update && apt-get install -y curl git && \
+#   git clone https://github.com/morwol/dart-tournament.git /tmp/dartsturnier-setup && \
+#   sudo bash /tmp/dartsturnier-setup/deploy/setup-ubuntu.sh
+#
+# Works for both production (main) and dev (dev) servers.
+# ============================================================
+
+# --- Colors ---
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+MUTED='\033[0;90m'
+NC='\033[0m'
+
+# --- Root check ---
+if [ "$EUID" -ne 0 ]; then
+  echo -e "${RED}Please run as root: sudo bash setup-ubuntu.sh${NC}"
+  exit 1
+fi
+
+clear
+echo -e "${BOLD}${CYAN}"
+echo "╔══════════════════════════════════════════════╗"
+echo "║       DartEvent Manager — Ubuntu Setup       ║"
+echo "╚══════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+# ── Interactive configuration ──────────────────────────────
+
+echo -e "${YELLOW}Please answer the following questions:${NC}"
+echo ""
+
+# Domain
+read -p "  Domain (e.g. darts.example.com): " DOMAIN
+if [ -z "$DOMAIN" ]; then
+  echo -e "${RED}Domain cannot be empty.${NC}"; exit 1
+fi
+
+# Branch
+echo ""
+echo "  Which branch should be deployed?"
+echo "    [1] main  — production"
+echo "    [2] dev   — development"
+read -p "  Choice [1/2]: " BRANCH_CHOICE
+if [ "$BRANCH_CHOICE" = "2" ]; then
+  BRANCH="dev"
+else
+  BRANCH="main"
+fi
+
+# Repo URL
+echo ""
+read -p "  Git repository URL: " REPO_URL
+if [ -z "$REPO_URL" ]; then
+  echo -e "${RED}Repository URL cannot be empty.${NC}"; exit 1
+fi
+
+# Admin credentials
+echo ""
+echo -e "${YELLOW}Admin account (first login):${NC}"
+read -p "  Admin username [admin]: " ADMIN_USER
+ADMIN_USER="${ADMIN_USER:-admin}"
+read -s -p "  Admin password: " ADMIN_PASS
+echo ""
+if [ -z "$ADMIN_PASS" ]; then
+  echo -e "${RED}Admin password cannot be empty.${NC}"; exit 1
+fi
+
+# JWT Secret + Webhook Secret (auto-generate)
+JWT_SECRET=$(openssl rand -hex 48)
+WEBHOOK_SECRET=$(openssl rand -hex 32)
+
+# Summary
+APP_DIR="/var/www/dartsturnier"
+SERVICE_NAME="dartevent"
+
+echo ""
+echo -e "${CYAN}──────────────────────────────────────────────${NC}"
+echo -e "  Domain:     ${BOLD}$DOMAIN${NC}"
+echo -e "  Branch:     ${BOLD}$BRANCH${NC}"
+echo -e "  App path:   ${BOLD}$APP_DIR${NC}"
+echo -e "  Service:    ${BOLD}$SERVICE_NAME${NC}"
+if [ "$BRANCH" = "dev" ]; then
+echo -e "  Webhook:    ${BOLD}https://$DOMAIN/webhook${NC}"
+fi
+echo -e "${CYAN}──────────────────────────────────────────────${NC}"
+echo ""
+read -p "Continue? [Enter to confirm / Ctrl+C to abort] " _
+
+# ── 1. System packages ──────────────────────────────────────
+
+echo ""
+STEPS=10
+[ "$BRANCH" = "dev" ] && STEPS=11
+
+echo -e "${GREEN}[1/$STEPS] Installing system packages...${NC}"
+apt update -q
+DEBIAN_FRONTEND=noninteractive apt upgrade -y -q
+apt install -y curl git nginx ufw openssl
+
+# Node.js 20 LTS via NodeSource
+if ! command -v node &>/dev/null || [ "$(node -e 'process.exit(parseInt(process.version.slice(1)) < 18 ? 1 : 0)'; echo $?)" != "0" ]; then
+  curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+  apt install -y nodejs
+fi
+
+# ffmpeg + yt-dlp (for walk-on songs)
+apt install -y ffmpeg
+if ! command -v yt-dlp &>/dev/null; then
+  curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp
+  chmod a+rx /usr/local/bin/yt-dlp
+fi
+
+# certbot
+apt install -y certbot python3-certbot-nginx
+
+echo -e "${GREEN}    ✓ Packages installed${NC}"
+
+# ── 2. Firewall ─────────────────────────────────────────────
+
+echo -e "${GREEN}[2/$STEPS] Configuring firewall (ufw + iptables)...${NC}"
+
+# Oracle Cloud (and some other providers) inject a REJECT rule into iptables
+# that runs BEFORE ufw chains — blocking all traffic except SSH.
+# Detect and remove it so nginx can serve HTTP/HTTPS.
+if iptables -L INPUT -n | grep -q "reject-with icmp-host-prohibited"; then
+  # Find and delete the reject rule
+  REJECT_LINE=$(iptables -L INPUT -n --line-numbers | awk '/reject-with icmp-host-prohibited/{print $1; exit}')
+  if [ -n "$REJECT_LINE" ]; then
+    iptables -D INPUT "$REJECT_LINE"
+    echo "    Removed Oracle Cloud iptables REJECT rule (line $REJECT_LINE)"
+  fi
+fi
+
+# Ensure ports 80 + 443 are explicitly allowed at iptables level
+iptables -C INPUT -p tcp --dport 80 -j ACCEPT 2>/dev/null  || iptables -I INPUT 1 -p tcp --dport 80  -j ACCEPT
+iptables -C INPUT -p tcp --dport 443 -j ACCEPT 2>/dev/null || iptables -I INPUT 1 -p tcp --dport 443 -j ACCEPT
+
+# Persist iptables rules across reboots
+apt-get install -y -q iptables-persistent
+netfilter-persistent save
+
+# ufw on top
+ufw --force reset
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow OpenSSH
+ufw allow 'Nginx Full'
+ufw --force enable
+echo -e "${GREEN}    ✓ Firewall configured (SSH + HTTP/HTTPS open)${NC}"
+
+# ── 3. Service user ─────────────────────────────────────────
+
+echo -e "${GREEN}[3/$STEPS] Creating service user...${NC}"
+if ! id "$SERVICE_NAME" &>/dev/null; then
+  useradd -r -s /bin/false -d "$APP_DIR" "$SERVICE_NAME"
+fi
+echo -e "${GREEN}    ✓ User '$SERVICE_NAME' ready${NC}"
+
+# ── 4. Clone repository ─────────────────────────────────────
+
+echo -e "${GREEN}[4/$STEPS] Cloning repository (branch: $BRANCH)...${NC}"
+if [ -d "$APP_DIR/.git" ]; then
+  echo "    Repository already exists — pulling latest..."
+  cd "$APP_DIR"
+  git fetch origin
+  git checkout "$BRANCH"
+  git pull origin "$BRANCH"
+else
+  git clone "$REPO_URL" "$APP_DIR"
+  cd "$APP_DIR"
+  git checkout "$BRANCH"
+fi
+echo -e "${GREEN}    ✓ Code ready at $APP_DIR${NC}"
+
+# ── 5. Environment file ─────────────────────────────────────
+
+echo -e "${GREEN}[5/$STEPS] Creating .env...${NC}"
+ENV_FILE="$APP_DIR/backend/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  cat > "$ENV_FILE" <<EOF
+PORT=3001
+JWT_SECRET=$JWT_SECRET
+DB_PATH=./data/dartevent.db
+ADMIN_USERNAME=$ADMIN_USER
+ADMIN_PASSWORD=$ADMIN_PASS
+WEBHOOK_SECRET=$WEBHOOK_SECRET
+WEBHOOK_PORT=9001
+EOF
+  chmod 600 "$ENV_FILE"
+  chown "$SERVICE_NAME":"$SERVICE_NAME" "$ENV_FILE"
+fi
+echo -e "${GREEN}    ✓ .env created${NC}"
+
+# ── 6. Backend setup ────────────────────────────────────────
+
+echo -e "${GREEN}[6/$STEPS] Installing backend dependencies...${NC}"
+cd "$APP_DIR/backend"
+npm install --omit=dev
+mkdir -p "$APP_DIR/backend/data/walkon"
+chown -R "$SERVICE_NAME":"$SERVICE_NAME" "$APP_DIR/backend/data"
+echo -e "${GREEN}    ✓ Backend ready${NC}"
+
+# ── 7. Frontend build ───────────────────────────────────────
+
+echo -e "${GREEN}[7/$STEPS] Building frontend...${NC}"
+cd "$APP_DIR/frontend"
+npm install
+npm run build
+echo -e "${GREEN}    ✓ Frontend built${NC}"
+
+# ── 8. nginx configuration ──────────────────────────────────
+
+echo -e "${GREEN}[8/$STEPS] Configuring nginx...${NC}"
+NGINX_CONF="/etc/nginx/sites-available/dartevent"
+
+cat > "$NGINX_CONF" <<EOF
+limit_req_zone \$binary_remote_addr zone=api:10m rate=20r/s;
+
+server {
+    listen 80;
+    server_name $DOMAIN;
+
+    location /api {
+        limit_req zone=api burst=50 nodelay;
+        proxy_pass http://127.0.0.1:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_cache_bypass \$http_upgrade;
+    }
+
+    location / {
+        root $APP_DIR/frontend/dist;
+        try_files \$uri \$uri/ /index.html;
+
+        location ~* \.(js|css|png|jpg|ico|svg|woff2)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+    }
+$([ "$BRANCH" = "dev" ] && cat <<'WEBHOOK'
+    location /webhook {
+        proxy_pass http://127.0.0.1:9001/webhook;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+WEBHOOK
+)
+}
+EOF
+
+# Enable site
+ln -sf "$NGINX_CONF" /etc/nginx/sites-enabled/dartevent
+rm -f /etc/nginx/sites-enabled/default
+nginx -t
+systemctl enable --now nginx
+echo -e "${GREEN}    ✓ nginx configured for $DOMAIN${NC}"
+
+# ── 9. SSL certificate ──────────────────────────────────────
+
+echo -e "${GREEN}[9/$STEPS] Obtaining SSL certificate...${NC}"
+certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos --register-unsafely-without-email --redirect
+echo -e "${GREEN}    ✓ SSL certificate installed${NC}"
+
+# ── 10. systemd service ─────────────────────────────────────
+
+echo -e "${GREEN}[10/$STEPS] Installing systemd service...${NC}"
+cat > /etc/systemd/system/dartevent.service <<EOF
+[Unit]
+Description=DartEvent Manager Backend
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$SERVICE_NAME
+Group=$SERVICE_NAME
+WorkingDirectory=$APP_DIR/backend
+ExecStart=/usr/bin/node src/app.js
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=dartevent
+EnvironmentFile=$APP_DIR/backend/.env
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=$APP_DIR/backend/data
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now dartevent
+sleep 2
+
+# ── 11. Webhook service (dev only) ──────────────────────────
+
+if [ "$BRANCH" = "dev" ]; then
+  echo -e "${GREEN}[11/$STEPS] Installing webhook service...${NC}"
+  cp "$APP_DIR/deploy/dartevent-webhook.service" /etc/systemd/system/dartevent-webhook.service
+  systemctl daemon-reload
+  systemctl enable --now dartevent-webhook
+  sleep 1
+  if systemctl is-active --quiet dartevent-webhook; then
+    echo -e "${GREEN}    ✓ Webhook receiver running on port 9001${NC}"
+  else
+    echo -e "${YELLOW}    ⚠ Webhook service failed to start (non-fatal)${NC}"
+    echo "      journalctl -u dartevent-webhook -n 20"
+  fi
+fi
+
+# ── Final status ────────────────────────────────────────────
+
+echo ""
+echo -e "${CYAN}══════════════════════════════════════════════${NC}"
+if systemctl is-active --quiet dartevent; then
+  echo -e "${GREEN}${BOLD}✓ Setup complete! DartEvent is running.${NC}"
+else
+  echo -e "${RED}✗ Service failed to start. Check logs:${NC}"
+  echo "  journalctl -u dartevent -n 50"
+  exit 1
+fi
+echo ""
+echo -e "  ${BOLD}URL:${NC}     https://$DOMAIN"
+echo -e "  ${BOLD}Branch:${NC}  $BRANCH"
+echo -e "  ${BOLD}Admin:${NC}   $ADMIN_USER"
+if [ "$BRANCH" = "dev" ]; then
+echo ""
+echo -e "  ${BOLD}GitHub Webhook setup:${NC}"
+echo -e "    URL:     ${CYAN}https://$DOMAIN/webhook${NC}"
+echo -e "    Secret:  ${YELLOW}$WEBHOOK_SECRET${NC}"
+echo -e "    Events:  Just the push event"
+echo -e "    ${MUTED}(Settings → Webhooks → Add webhook)${NC}"
+fi
+echo ""
+echo -e "  Update: ${CYAN}sudo bash $APP_DIR/deploy/update-dev.sh${NC}   (dev)"
+echo -e "         ${CYAN}sudo bash $APP_DIR/deploy/update.sh${NC}        (prod)"
+echo ""
+echo -e "  Logs:   ${CYAN}journalctl -u dartevent -f${NC}"
+[ "$BRANCH" = "dev" ] && echo -e "          ${CYAN}journalctl -u dartevent-webhook -f${NC}"
+echo -e "${CYAN}══════════════════════════════════════════════${NC}"
+echo ""


### PR DESCRIPTION
## Summary
- Push to `dev` branch → dev server automatically pulls and redeploys
- Webhook receiver runs as a separate systemd service (survives app restarts during deploy)
- HMAC-SHA256 signature verification to ensure requests come from GitHub
- Only activates when setup script is run with branch = dev

## New files
- `backend/webhook.js` — lightweight HTTP server (native Node, no extra deps), listens on `127.0.0.1:9001`
- `deploy/dartevent-webhook.service` — systemd unit for the webhook receiver

## Changes to `setup-ubuntu.sh` (dev branch only)
- Auto-generates `WEBHOOK_SECRET` and adds it to `.env`
- Adds `/webhook` nginx proxy location
- Installs and starts `dartevent-webhook.service`
- Prints the webhook URL + secret at the end of setup for easy GitHub configuration

## GitHub setup (after running setup script)
1. Go to repo → Settings → Webhooks → Add webhook
2. Payload URL: `https://your-dev-domain/webhook`
3. Secret: shown at end of setup script
4. Events: "Just the push event"

## Test plan
- [ ] Push commit to `dev` branch
- [ ] Verify `journalctl -u dartevent-webhook -f` shows deploy triggered
- [ ] Verify app reflects changes within ~60 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)