### PR TITLE
feat: NFC Option B — credit/Nachkasse model

### DIFF
--- a/backend/src/db/db.js
+++ b/backend/src/db/db.js
@@ -88,6 +88,7 @@ function initialize() {
     "ALTER TABLE players ADD COLUMN walkon_file TEXT",
     "ALTER TABLE players ADD COLUMN walkon_start INTEGER DEFAULT 0",
     "ALTER TABLE players ADD COLUMN walkon_duration INTEGER DEFAULT 30",
+    "ALTER TABLE guests ADD COLUMN active BOOLEAN DEFAULT 1",
   ];
 
   for (const stmt of alterStatements) {

--- a/backend/src/routes/nfc.js
+++ b/backend/src/routes/nfc.js
@@ -19,6 +19,10 @@ router.post('/scan', requireFields(['uid']), (req, res) => {
     return res.status(404).json({ error: 'Dieser NFC-Tag ist nicht registriert' });
   }
 
+  if (guest.active === 0) {
+    return res.status(403).json({ error: 'Armband gesperrt' });
+  }
+
   res.json(guest);
 });
 
@@ -53,6 +57,52 @@ router.post('/create-manual', requireAny(['admin', 'gastronomy']), requireFields
   const result = db.prepare('INSERT INTO guests (nfc_uid, name, tournament_id) VALUES (?, ?, ?)').run(uid, name, tournament_id || null);
   const guest = db.prepare('SELECT * FROM guests WHERE id = ?').get(result.lastInsertRowid);
   res.status(201).json(guest);
+});
+
+// PUT /api/nfc/:uid/deactivate — Armband sperren
+router.put('/:uid/deactivate', requireAny(['admin', 'gastronomy']), (req, res) => {
+  const hashedUid = hashUid(req.params.uid);
+  const guest = db.prepare('SELECT * FROM guests WHERE nfc_uid = ?').get(hashedUid);
+  if (!guest) return res.status(404).json({ error: 'Gast nicht gefunden' });
+
+  db.prepare('UPDATE guests SET active = 0 WHERE id = ?').run(guest.id);
+  res.json({ success: true, guest: { id: guest.id, name: guest.name, active: 0 } });
+});
+
+// PUT /api/nfc/:uid/activate — Armband reaktivieren
+router.put('/:uid/activate', requireAny(['admin', 'gastronomy']), (req, res) => {
+  const hashedUid = hashUid(req.params.uid);
+  const guest = db.prepare('SELECT * FROM guests WHERE nfc_uid = ?').get(hashedUid);
+  if (!guest) return res.status(404).json({ error: 'Gast nicht gefunden' });
+
+  db.prepare('UPDATE guests SET active = 1 WHERE id = ?').run(guest.id);
+  res.json({ success: true, guest: { id: guest.id, name: guest.name, active: 1 } });
+});
+
+// GET /api/nfc/:uid/statement — Kontoauszug (public, für Gast-Self-Service)
+router.get('/:uid/statement', (req, res) => {
+  const hashedUid = hashUid(req.params.uid);
+  const guest = db.prepare('SELECT id, name, active FROM guests WHERE nfc_uid = ?').get(hashedUid);
+  if (!guest) return res.status(404).json({ error: 'Gast nicht gefunden' });
+
+  const orders = db.prepare(`
+    SELECT o.id, p.name as product_name, o.quantity,
+           p.price, ROUND(o.quantity * p.price, 2) as total,
+           o.status, o.ordered_at
+    FROM orders o
+    JOIN products p ON o.product_id = p.id
+    WHERE o.guest_id = ?
+    ORDER BY o.ordered_at DESC
+  `).all(guest.id);
+
+  const total_open = Math.round(orders.filter(o => o.status === 'open').reduce((s, o) => s + o.total, 0) * 100) / 100;
+  const total_paid = Math.round(orders.filter(o => o.status === 'paid').reduce((s, o) => s + o.total, 0) * 100) / 100;
+
+  res.json({
+    guest,
+    orders,
+    summary: { total_open, total_paid, total: Math.round((total_open + total_paid) * 100) / 100 },
+  });
 });
 
 // GET /api/nfc/:uid/orders

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -103,6 +103,8 @@ export default function GastronomyPage() {
   // Bereits bestellte offene Artikel des Gastes
   const [guestOpenOrders, setGuestOpenOrders] = useState(null);
   const [orderSuccess, setOrderSuccess] = useState(false);
+  // NEU: Armband sperren/entsperren
+  const [lockLoading, setLockLoading] = useState(false);
 
   const [allGuests, setAllGuests] = useState([]);
 
@@ -224,6 +226,25 @@ export default function GastronomyPage() {
     }
   };
 
+  // NEU: Armband sperren / entsperren
+  const toggleGuestLock = async () => {
+    if (!guest) return;
+    const isBlocked = guest.active === 0 || guest.active === false;
+    const endpoint = isBlocked ? `/nfc/${guest.nfc_uid}/activate` : `/nfc/${guest.nfc_uid}/deactivate`;
+    setLockLoading(true);
+    try {
+      const updated = await api.put(endpoint);
+      // Merge updated fields back into guest state
+      setGuest((prev) => ({ ...prev, ...updated }));
+      // Also update allGuests list
+      setAllGuests((prev) => prev.map((g) => g.id === guest.id ? { ...g, ...updated } : g));
+    } catch (err) {
+      alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen');
+    } finally {
+      setLockLoading(false);
+    }
+  };
+
   // NEU: Kassen-Daten laden
   const loadRegister = useCallback(async () => {
     setRegisterLoading(true);
@@ -340,14 +361,24 @@ export default function GastronomyPage() {
                   {allGuests
                     .filter((g) => !guestSearch || g.name?.toLowerCase().includes(guestSearch.toLowerCase()))
                     .map((g) => (
-                      <button
-                        key={g.id}
-                        onClick={() => { setGuest(g); setCart([]); setOrderSuccess(false); }}
-                        style={{ padding: '12px 16px', borderRadius: '8px', background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', textAlign: 'left', fontFamily: 'Verdana, Geneva, sans-serif', cursor: 'pointer', minHeight: '52px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-                      >
-                        <span style={{ fontWeight: 'bold' }}>{g.name || 'Gast'}</span>
-                        <span style={{ color: 'var(--pe-text-muted)', fontSize: '12px' }}>#{g.id}</span>
-                      </button>
+                      {(() => {
+                        const gBlocked = g.active === 0 || g.active === false;
+                        return (
+                          <button
+                            key={g.id}
+                            onClick={() => { setGuest(g); setCart([]); setOrderSuccess(false); }}
+                            style={{ padding: '12px 16px', borderRadius: '8px', background: 'var(--pe-bg-card)', border: `1px solid ${gBlocked ? 'var(--pe-danger)' : 'var(--pe-border)'}`, color: 'var(--pe-text)', textAlign: 'left', fontFamily: 'Verdana, Geneva, sans-serif', cursor: 'pointer', minHeight: '52px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+                          >
+                            <span style={{ fontWeight: 'bold' }}>{g.name || 'Gast'}</span>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                              {gBlocked && (
+                                <span style={{ fontSize: '11px', fontWeight: 'bold', color: 'var(--pe-danger)', border: '1px solid var(--pe-danger)', borderRadius: '20px', padding: '2px 8px' }}>Gesperrt</span>
+                              )}
+                              <span style={{ color: 'var(--pe-text-muted)', fontSize: '12px' }}>#{g.id}</span>
+                            </div>
+                          </button>
+                        );
+                      })()}
                     ))
                   }
                   {allGuests.length === 0 && (
@@ -363,18 +394,68 @@ export default function GastronomyPage() {
               {/* NEU: Linke Seite — Gast-Info + offene Bestellungen + Produkte */}
               <div className="flex-1">
                 {/* Gast-Header */}
-                <div className="flex items-center justify-between mb-4 p-3 rounded-xl" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
-                  <div>
-                    <p className="font-bold" style={{ color: 'var(--pe-text)' }}>{guest.name || 'Gast'}</p>
-                    <p className="text-xs" style={{ color: 'var(--pe-text-muted)' }}>#{guest.id}</p>
-                  </div>
-                  <button
-                    onClick={() => { setGuest(null); setCart([]); setGuestOpenOrders(null); }}
-                    style={{ ...btnStyle, minHeight: '56px', padding: '0 20px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', border: '1px solid var(--pe-border)' }}
-                  >
-                    ✕ Schließen
-                  </button>
-                </div>
+                {(() => {
+                  const isBlocked = guest.active === 0 || guest.active === false;
+                  return (
+                    <div className="mb-4 p-3 rounded-xl" style={{ background: 'var(--pe-bg-card)', border: `1px solid ${isBlocked ? 'var(--pe-danger)' : 'var(--pe-border)'}` }}>
+                      {/* Zeile 1: Name + Badge + Schließen */}
+                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px', marginBottom: '10px' }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flex: 1, minWidth: 0 }}>
+                          <div>
+                            <p style={{ fontWeight: 'bold', color: 'var(--pe-text)', margin: 0, fontSize: '15px' }}>{guest.name || 'Gast'}</p>
+                            <p style={{ fontSize: '11px', color: 'var(--pe-text-muted)', margin: '2px 0 0' }}>#{guest.id}</p>
+                          </div>
+                          {/* Status-Badge */}
+                          <span
+                            style={{
+                              flexShrink: 0,
+                              padding: '4px 12px',
+                              borderRadius: '20px',
+                              fontSize: '12px',
+                              fontWeight: 'bold',
+                              color: isBlocked ? 'var(--pe-danger)' : 'var(--pe-success)',
+                              border: `1px solid ${isBlocked ? 'var(--pe-danger)' : 'var(--pe-success)'}`,
+                              background: isBlocked ? 'rgba(255,69,96,0.12)' : 'rgba(0,229,160,0.10)',
+                            }}
+                          >
+                            {isBlocked ? 'Gesperrt' : 'Aktiv'}
+                          </span>
+                        </div>
+                        <button
+                          onClick={() => { setGuest(null); setCart([]); setGuestOpenOrders(null); }}
+                          style={{ ...btnStyle, minHeight: '44px', padding: '0 16px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', border: '1px solid var(--pe-border)', flexShrink: 0 }}
+                        >
+                          ✕ Schließen
+                        </button>
+                      </div>
+                      {/* Zeile 2: Sperren/Entsperren */}
+                      <button
+                        onClick={toggleGuestLock}
+                        disabled={lockLoading}
+                        style={{
+                          ...btnStyle,
+                          width: '100%',
+                          minHeight: '48px',
+                          background: isBlocked ? 'rgba(0,229,160,0.12)' : 'rgba(255,69,96,0.12)',
+                          color: isBlocked ? 'var(--pe-success)' : 'var(--pe-danger)',
+                          border: `1px solid ${isBlocked ? 'var(--pe-success)' : 'var(--pe-danger)'}`,
+                          fontSize: '13px',
+                          opacity: lockLoading ? 0.6 : 1,
+                        }}
+                      >
+                        {lockLoading
+                          ? (isBlocked ? 'Wird entsperrt...' : 'Wird gesperrt...')
+                          : (isBlocked ? 'Armband entsperren' : 'Armband sperren')}
+                      </button>
+                      {/* Hinweis wenn gesperrt */}
+                      {isBlocked && (
+                        <p style={{ margin: '8px 0 0', fontSize: '13px', color: 'var(--pe-danger)', fontWeight: 'bold', textAlign: 'center' }}>
+                          Armband gesperrt — keine Bestellungen möglich
+                        </p>
+                      )}
+                    </div>
+                  );
+                })()}
 
                 {/* Bereits offene Bestellungen dieses Gastes */}
                 {guestOpenOrders && guestOpenOrders.items?.length > 0 && (
@@ -427,24 +508,30 @@ export default function GastronomyPage() {
                 </div>
 
                 {/* Produkt-Buttons */}
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-                  {filteredProducts.map((product) => (
-                    <button
-                      key={product.id}
-                      onClick={() => addToCart(product)}
-                      className="flex flex-col items-center justify-center p-3"
-                      style={{
-                        ...btnStyle,
-                        minHeight: '80px',
-                        background: 'var(--pe-bg-card)',
-                        color: 'var(--pe-text)',
-                      }}
-                    >
-                      <span className="text-sm font-bold mb-1">{product.name}</span>
-                      <span className="text-xs" style={{ color: 'var(--pe-cyan-bright)' }}>{parseFloat(product.price).toFixed(2)} €</span>
-                    </button>
-                  ))}
-                </div>
+                {(() => {
+                  const isBlocked = guest.active === 0 || guest.active === false;
+                  return (
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-3" style={{ opacity: isBlocked ? 0.4 : 1, pointerEvents: isBlocked ? 'none' : undefined }}>
+                      {filteredProducts.map((product) => (
+                        <button
+                          key={product.id}
+                          onClick={() => addToCart(product)}
+                          disabled={isBlocked}
+                          className="flex flex-col items-center justify-center p-3"
+                          style={{
+                            ...btnStyle,
+                            minHeight: '80px',
+                            background: 'var(--pe-bg-card)',
+                            color: 'var(--pe-text)',
+                          }}
+                        >
+                          <span className="text-sm font-bold mb-1">{product.name}</span>
+                          <span className="text-xs" style={{ color: 'var(--pe-cyan-bright)' }}>{parseFloat(product.price).toFixed(2)} €</span>
+                        </button>
+                      ))}
+                    </div>
+                  );
+                })()}
               </div>
 
               {/* NEU: Rechte Seite — Warenkorb (nur Bestellen, kein Abrechnen) */}
@@ -485,14 +572,19 @@ export default function GastronomyPage() {
                     </div>
                   )}
 
-                  <button
-                    onClick={submitOrder}
-                    disabled={cart.length === 0 || submitting}
-                    className="w-full py-4 rounded-xl font-bold text-lg disabled:opacity-50"
-                    style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '64px', fontFamily: 'Verdana, Geneva, sans-serif', border: 'none', cursor: 'pointer' }}
-                  >
-                    {submitting ? 'Wird gespeichert...' : 'Bestellen'}
-                  </button>
+                  {(() => {
+                    const isBlocked = guest && (guest.active === 0 || guest.active === false);
+                    return (
+                      <button
+                        onClick={submitOrder}
+                        disabled={cart.length === 0 || submitting || isBlocked}
+                        className="w-full py-4 rounded-xl font-bold text-lg disabled:opacity-50"
+                        style={{ background: isBlocked ? 'var(--pe-bg-elevated)' : 'var(--pe-gradient)', color: isBlocked ? 'var(--pe-danger)' : 'var(--pe-text)', minHeight: '64px', fontFamily: 'Verdana, Geneva, sans-serif', border: isBlocked ? '1px solid var(--pe-danger)' : 'none', cursor: isBlocked ? 'not-allowed' : 'pointer' }}
+                      >
+                        {isBlocked ? 'Armband gesperrt' : submitting ? 'Wird gespeichert...' : 'Bestellen'}
+                      </button>
+                    );
+                  })()}
 
                   {orderSuccess && cart.length === 0 && (
                     <p className="text-center mt-3 text-sm font-bold" style={{ color: 'var(--pe-success)' }}>✓ Bestellung gespeichert!</p>

--- a/frontend/src/pages/OrderPage.jsx
+++ b/frontend/src/pages/OrderPage.jsx
@@ -1,110 +1,207 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { api } from '../api/client';
-import ProductList from '../components/order/ProductList';
-import Cart from '../components/order/Cart';
 import BackButton from '../components/BackButton';
 
 export default function OrderPage() {
   const { uid } = useParams();
-  const [products, setProducts] = useState([]);
-  const [orders, setOrders] = useState([]);
-  const [cart, setCart] = useState([]);
+  const [statement, setStatement] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    Promise.all([
-      api.get('/products'),
-      api.get(`/nfc/${uid}/orders`),
-    ])
-      .then(([p, o]) => { setProducts(p); setOrders(o); })
-      .catch(() => {})
+    api.get(`/nfc/${uid}/statement`)
+      .then(setStatement)
+      .catch((err) => setError(err.message || 'Kontoauszug konnte nicht geladen werden.'))
       .finally(() => setLoading(false));
   }, [uid]);
 
-  const addToCart = (product) => {
-    setCart((prev) => {
-      const existing = prev.find((item) => item.product_id === product.id);
-      if (existing) {
-        return prev.map((item) =>
-          item.product_id === product.id ? { ...item, quantity: item.quantity + 1 } : item
-        );
-      }
-      return [...prev, { product_id: product.id, name: product.name, price: product.price, quantity: 1 }];
-    });
+  const cardStyle = {
+    background: 'var(--pe-bg-card)',
+    border: '1px solid var(--pe-border)',
+    borderRadius: '12px',
+    padding: '16px',
+    fontFamily: 'Verdana, Geneva, sans-serif',
   };
 
-  const removeFromCart = (productId) => {
-    setCart((prev) =>
-      prev
-        .map((item) => item.product_id === productId ? { ...item, quantity: item.quantity - 1 } : item)
-        .filter((item) => item.quantity > 0)
+  if (loading) {
+    return (
+      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+        <p style={{ color: 'var(--pe-text-sub)' }}>Lade...</p>
+      </div>
     );
-  };
+  }
 
-  const submitOrder = async () => {
-    try {
-      for (const item of cart) {
-        await api.post('/orders', {
-          guest_uid: uid,
-          product_id: item.product_id,
-          quantity: item.quantity,
-        });
-      }
-      setCart([]);
-      const updatedOrders = await api.get(`/nfc/${uid}/orders`);
-      setOrders(updatedOrders);
-    } catch (err) {
-      alert(err.message || 'Fehler beim Bestellen');
-    }
-  };
+  if (error) {
+    return (
+      <div style={{ minHeight: '100vh', padding: '16px', maxWidth: '480px', margin: '0 auto', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px' }}>
+          <BackButton to="/" />
+          <img src="/logo.jpeg" alt="DartEvent" style={{ height: '40px' }} />
+        </div>
+        <div style={{ ...cardStyle, border: '1px solid var(--pe-danger)', textAlign: 'center', padding: '32px 16px' }}>
+          <p style={{ color: 'var(--pe-danger)', fontWeight: 'bold', marginBottom: '8px' }}>Fehler</p>
+          <p style={{ color: 'var(--pe-text-sub)', fontSize: '14px' }}>{error}</p>
+        </div>
+      </div>
+    );
+  }
 
-  if (loading) return <div className="p-4 text-center" style={{ color: 'var(--pe-text-sub)' }}>Lade...</div>;
+  const { guest, orders = [], total_open = 0, total_paid = 0 } = statement || {};
+  const isBlocked = guest?.active === 0 || guest?.active === false;
 
   return (
-    <div className="min-h-screen p-4 max-w-lg mx-auto pb-48">
-      <div className="flex items-center gap-3 mb-6">
+    <div style={{ minHeight: '100vh', padding: '16px', maxWidth: '480px', margin: '0 auto', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px' }}>
         <BackButton to="/" />
-        <img src="/logo.jpeg" alt="DartEvent" className="h-10" />
+        <img src="/logo.jpeg" alt="DartEvent" style={{ height: '40px' }} />
       </div>
 
       <h1
-        className="text-xl font-bold mb-6"
-        style={{ background: 'var(--pe-gradient)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}
+        style={{
+          background: 'var(--pe-gradient)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          fontWeight: 'bold',
+          fontSize: '20px',
+          marginBottom: '20px',
+        }}
       >
-        Bestellungen
+        Kontoauszug
       </h1>
 
-      {orders.length > 0 && (
-        <section className="mb-6">
-          <h2 className="text-lg font-bold mb-3" style={{ color: 'var(--pe-cyan-bright)' }}>Deine Bestellungen</h2>
-          <div className="space-y-2">
-            {orders.map((o) => (
+      {/* Gast-Info */}
+      {guest && (
+        <div style={{ ...cardStyle, marginBottom: '20px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div>
+            <p style={{ fontWeight: 'bold', fontSize: '16px', color: 'var(--pe-text)', margin: 0 }}>{guest.name || 'Gast'}</p>
+            <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)', margin: '4px 0 0' }}>#{guest.id}</p>
+          </div>
+          {isBlocked ? (
+            <span
+              style={{
+                background: 'rgba(255,69,96,0.15)',
+                color: 'var(--pe-danger)',
+                border: '1px solid var(--pe-danger)',
+                borderRadius: '20px',
+                padding: '6px 14px',
+                fontSize: '13px',
+                fontWeight: 'bold',
+              }}
+            >
+              Gesperrt
+            </span>
+          ) : (
+            <span
+              style={{
+                background: 'rgba(0,229,160,0.12)',
+                color: 'var(--pe-success)',
+                border: '1px solid var(--pe-success)',
+                borderRadius: '20px',
+                padding: '6px 14px',
+                fontSize: '13px',
+                fontWeight: 'bold',
+              }}
+            >
+              Aktiv
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Bestellungen */}
+      {orders.length === 0 ? (
+        <div style={{ ...cardStyle, textAlign: 'center', padding: '48px 16px' }}>
+          <p style={{ color: 'var(--pe-text-muted)', fontSize: '15px' }}>Noch keine Bestellungen</p>
+        </div>
+      ) : (
+        <div style={{ marginBottom: '20px' }}>
+          <p
+            style={{
+              fontSize: '11px',
+              fontWeight: 'bold',
+              color: 'var(--pe-text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              marginBottom: '10px',
+            }}
+          >
+            Bestellungen
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            {orders.map((order) => (
               <div
-                key={o.id}
-                className="flex justify-between items-center p-3 rounded-lg"
-                style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}
+                key={order.id}
+                style={{
+                  ...cardStyle,
+                  padding: '12px 16px',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  gap: '12px',
+                }}
               >
-                <span>{o.product_name} x{o.quantity}</span>
-                <span
-                  className="text-xs px-2 py-1 rounded-full font-bold"
-                  style={{
-                    color: o.status === 'paid' ? 'var(--pe-success)' : 'var(--pe-warning)',
-                    border: `1px solid ${o.status === 'paid' ? 'var(--pe-success)' : 'var(--pe-warning)'}`,
-                  }}
-                >
-                  {o.status === 'paid' ? 'Bezahlt' : 'Offen'}
-                </span>
+                <div style={{ flex: 1 }}>
+                  <p style={{ margin: 0, fontWeight: 'bold', fontSize: '14px', color: 'var(--pe-text)' }}>
+                    {order.product_name}
+                  </p>
+                  <p style={{ margin: '3px 0 0', fontSize: '12px', color: 'var(--pe-text-muted)' }}>
+                    {order.quantity} &times; {parseFloat(order.price ?? (order.total / order.quantity)).toFixed(2)} EUR
+                  </p>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '6px' }}>
+                  <span style={{ fontWeight: 'bold', fontSize: '14px', color: 'var(--pe-text-sub)' }}>
+                    {parseFloat(order.total ?? (order.price * order.quantity)).toFixed(2)} EUR
+                  </span>
+                  <span
+                    style={{
+                      fontSize: '11px',
+                      fontWeight: 'bold',
+                      padding: '3px 10px',
+                      borderRadius: '20px',
+                      color: order.status === 'paid' ? 'var(--pe-success)' : 'var(--pe-warning)',
+                      border: `1px solid ${order.status === 'paid' ? 'var(--pe-success)' : 'var(--pe-warning)'}`,
+                      background: order.status === 'paid' ? 'rgba(0,229,160,0.08)' : 'rgba(255,176,32,0.08)',
+                    }}
+                  >
+                    {order.status === 'paid' ? 'Bezahlt' : 'Offen'}
+                  </span>
+                </div>
               </div>
             ))}
           </div>
-        </section>
+        </div>
       )}
 
-      <ProductList products={products} onAdd={addToCart} />
-
-      {cart.length > 0 && (
-        <Cart items={cart} onRemove={removeFromCart} onSubmit={submitOrder} />
+      {/* Zusammenfassung */}
+      {orders.length > 0 && (
+        <div style={{ ...cardStyle, display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <p
+            style={{
+              fontSize: '11px',
+              fontWeight: 'bold',
+              color: 'var(--pe-text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              margin: 0,
+            }}
+          >
+            Zusammenfassung
+          </p>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ fontSize: '14px', color: 'var(--pe-text-sub)' }}>Offen</span>
+            <span style={{ fontWeight: 'bold', fontSize: '16px', color: 'var(--pe-warning)' }}>
+              {parseFloat(total_open).toFixed(2)} EUR
+            </span>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px solid var(--pe-border)', paddingTop: '10px' }}>
+            <span style={{ fontSize: '14px', color: 'var(--pe-text-sub)' }}>Bereits bezahlt</span>
+            <span style={{ fontWeight: 'bold', fontSize: '16px', color: 'var(--pe-success)' }}>
+              {parseFloat(total_paid).toFixed(2)} EUR
+            </span>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Implements the credit/Nachkasse model for NFC wristbands (festival-style).

## Backend
- `guests.active` migration (DEFAULT 1) — auto-runs on next start
- `POST /scan` returns 403 if wristband is deactivated
- `PUT /api/nfc/:uid/deactivate` and `/activate` (admin + gastronomy)
- `GET /api/nfc/:uid/statement` — public endpoint with order list and totals

## Frontend
**OrderPage** — rebuilt as read-only guest statement:
- Fetches `/api/nfc/:uid/statement`
- Shows active/blocked badge, full order list with open/paid status, summary totals
- No cart, no order button

**GastronomyPage** — armband management:
- Guest list shows red "Gesperrt" badge + red border for blocked guests
- Guest header shows active/blocked badge + lock/unlock button
- Product grid disabled when guest is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)