### PR TITLE
fix: FOREIGN KEY constraint failed on gastro settle for admin users

### DIFF
--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -115,7 +115,9 @@ router.post('/settle/:guestId', requireAuth, (req, res) => {
       db.prepare("UPDATE orders SET status = 'paid' WHERE guest_id = ? AND status = 'open'").run(guestId);
 
       // Settlement anlegen
-      const settledBy = req.user ? req.user.id : null;
+      // settled_by references users(id) — admins live in a separate table,
+      // so only set it for role-based users (not legacy admins).
+      const settledBy = (req.user && req.user.role) ? req.user.id : null;
       const note = req.body.note || null;
       db.prepare(
         'INSERT INTO settlements (guest_id, total_amount, settled_by, note) VALUES (?, ?, ?, ?)'


### PR DESCRIPTION
## Problem
`POST /api/orders/settle/:guestId` failed with `FOREIGN KEY constraint failed` when called by an admin user.

`settlements.settled_by` is a FK referencing `users(id)`, but admin accounts live in the separate `admins` table — their ID is not valid in `users`.

## Fix
Only populate `settled_by` when the actor has a `role` field (i.e. is a regular user from the `users` table). Admin actors get `NULL` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)