### PR TITLE
fix: wire start time input to tournament schedule generation

### DIFF
--- a/backend/src/db/db.js
+++ b/backend/src/db/db.js
@@ -89,6 +89,7 @@ function initialize() {
     "ALTER TABLE players ADD COLUMN walkon_start INTEGER DEFAULT 0",
     "ALTER TABLE players ADD COLUMN walkon_duration INTEGER DEFAULT 30",
     "ALTER TABLE guests ADD COLUMN active BOOLEAN DEFAULT 1",
+    "ALTER TABLE tournaments ADD COLUMN start_time TEXT",
   ];
 
   for (const stmt of alterStatements) {

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS tournaments (
   id INTEGER PRIMARY KEY,
   name TEXT NOT NULL,
   date DATE,
+  start_time TEXT,
   format TEXT NOT NULL,
   checkout TEXT NOT NULL,
   status TEXT DEFAULT 'open',

--- a/backend/src/routes/tournaments.js
+++ b/backend/src/routes/tournaments.js
@@ -14,7 +14,7 @@ router.get('/', (req, res) => {
 
 // POST /api/tournaments (Admin)
 router.post('/', verifyToken, requireFields(['name', 'format', 'checkout']), (req, res) => {
-  const { name, date, format, checkout } = req.body;
+  const { name, date, start_time, format, checkout } = req.body;
 
   if (!['501', '301'].includes(format)) {
     return res.status(400).json({ error: 'Format must be 501 or 301' });
@@ -23,9 +23,14 @@ router.post('/', verifyToken, requireFields(['name', 'format', 'checkout']), (re
     return res.status(400).json({ error: 'Checkout must be single_out or double_out' });
   }
 
+  // Validate start_time format HH:MM if provided
+  if (start_time && !/^\d{2}:\d{2}$/.test(start_time)) {
+    return res.status(400).json({ error: 'start_time must be in HH:MM format' });
+  }
+
   const result = db.prepare(
-    'INSERT INTO tournaments (name, date, format, checkout) VALUES (?, ?, ?, ?)'
-  ).run(name, date || null, format, checkout);
+    'INSERT INTO tournaments (name, date, start_time, format, checkout) VALUES (?, ?, ?, ?, ?)'
+  ).run(name, date || null, start_time || null, format, checkout);
 
   const tournament = db.prepare('SELECT * FROM tournaments WHERE id = ?').get(result.lastInsertRowid);
   auditLog(req, 'tournament', 'CREATE', `Turnier "${name}" angelegt`, tournament.id);
@@ -439,6 +444,7 @@ router.post('/:id/generate-group-schedule', requireAdminOrDirector, (req, res) =
     // Delete any existing group-phase games (round = 0) for this tournament
     const existingGroupGames = db.prepare('SELECT id FROM games WHERE tournament_id = ? AND round = 0').all(req.params.id);
     for (const g of existingGroupGames) {
+      db.prepare('DELETE FROM schedule WHERE game_id = ?').run(g.id);
       db.prepare('DELETE FROM throws WHERE game_id = ?').run(g.id);
       db.prepare('DELETE FROM games WHERE id = ?').run(g.id);
     }
@@ -446,12 +452,37 @@ router.post('/:id/generate-group-schedule', requireAdminOrDirector, (req, res) =
     const startScore = parseInt(tournament.format) || 501;
     let totalCreated = 0;
 
+    // Calculate base datetime from tournament date + start_time
+    const gameDurationMinutes = parseInt(req.body.game_duration_minutes) || 20;
+    let baseDateTime = null;
+    if (tournament.date || tournament.start_time) {
+      const datePart = tournament.date || new Date().toISOString().substring(0, 10);
+      const timePart = tournament.start_time || '10:00';
+      const parsed = new Date(`${datePart}T${timePart}:00`);
+      if (!isNaN(parsed.getTime())) baseDateTime = parsed;
+    }
+
     const insertGames = db.transaction(() => {
+      const boardGameIndex = {};
       for (const [boardId, pairs] of Object.entries(boardGameList)) {
+        boardGameIndex[boardId] = 0;
         for (const [p1, p2] of pairs) {
-          db.prepare(
+          const gameResult = db.prepare(
             'INSERT INTO games (tournament_id, round, player1_id, player2_id, start_score, board_id, status) VALUES (?, 0, ?, ?, ?, ?, ?)'
           ).run(req.params.id, p1.id, p2.id, startScore, parseInt(boardId), 'pending');
+
+          const gameIdx = boardGameIndex[boardId]++;
+          let scheduledAt = null;
+          if (baseDateTime) {
+            const ms = gameIdx * gameDurationMinutes * 60 * 1000;
+            const gameTime = new Date(baseDateTime.getTime() + ms);
+            scheduledAt = gameTime.toISOString().replace('T', ' ').substring(0, 16);
+          }
+
+          db.prepare(
+            'INSERT INTO schedule (tournament_id, game_id, board_id, scheduled_at, status) VALUES (?, ?, ?, ?, ?)'
+          ).run(req.params.id, gameResult.lastInsertRowid, parseInt(boardId), scheduledAt, 'scheduled');
+
           totalCreated++;
         }
       }

--- a/backend/src/routes/tournaments.js
+++ b/backend/src/routes/tournaments.js
@@ -91,13 +91,20 @@ router.put('/:id', verifyToken, (req, res) => {
   const tournament = db.prepare('SELECT * FROM tournaments WHERE id = ?').get(req.params.id);
   if (!tournament) return res.status(404).json({ error: 'Tournament not found' });
 
-  const allowed = ['prelim_format','prelim_legs','qf_format','qf_legs','sf_format','sf_legs','final_format','final_legs','board_count','name','date'];
+  const allowed = ['prelim_format','prelim_legs','qf_format','qf_legs','sf_format','sf_legs','final_format','final_legs','board_count','name','date','start_time'];
   const updates = {};
   for (const key of allowed) {
     if (req.body[key] !== undefined) updates[key] = req.body[key];
   }
 
   if (Object.keys(updates).length === 0) return res.status(400).json({ error: 'No valid fields to update' });
+
+  // Validate start_time format HH:MM if provided as non-empty string
+  if (updates.start_time && !/^\d{2}:\d{2}$/.test(updates.start_time)) {
+    return res.status(400).json({ error: 'start_time must be in HH:MM format' });
+  }
+  // Allow clearing start_time by passing empty string → store as null
+  if (updates.start_time === '') updates.start_time = null;
 
   const setClauses = Object.keys(updates).map((k) => `${k} = ?`).join(', ');
   const values = [...Object.values(updates), req.params.id];

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -211,9 +211,16 @@ function BoardsTab() {
           <div className="space-y-2">
             {schedule.map((s) => (
               <div key={s.id} className="p-3 rounded-lg flex justify-between items-center" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
-                <span className="text-sm" style={{ color: 'var(--pe-text)' }}>
-                  {s.player1_name || 'TBD'} vs {s.player2_name || 'TBD'} — Board {s.board_number || '?'}
-                </span>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                  <span className="text-sm" style={{ color: 'var(--pe-text)' }}>
+                    {s.player1_name || 'TBD'} vs {s.player2_name || 'TBD'} — Board {s.board_number || '?'}
+                  </span>
+                  {s.scheduled_at && (
+                    <span style={{ fontSize: '11px', color: 'var(--pe-cyan-bright)' }}>
+                      {s.scheduled_at.substring(11, 16)} Uhr
+                    </span>
+                  )}
+                </div>
                 <div className="flex gap-2">
                   <button onClick={() => handleActivate(s.id)} style={{ ...btnSmall, padding: '4px 12px', background: 'var(--pe-success)', color: '#000' }}>Start</button>
                   <button onClick={() => handleSkip(s.id)} style={{ ...btnSmall, padding: '4px 12px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-warning)' }}>Skip</button>
@@ -1626,7 +1633,7 @@ function TournamentExtendedTab() {
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
               <div>
                 <div style={{ color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '16px' }}>{t.name}</div>
-                {t.date && <div style={{ color: 'var(--pe-text-muted)', fontSize: '13px', marginTop: '2px' }}>{t.date}</div>}
+                {(t.date || t.start_time) && <div style={{ color: 'var(--pe-text-muted)', fontSize: '13px', marginTop: '2px' }}>{t.date || ''}{t.date && t.start_time ? ' ' : ''}{t.start_time ? `${t.start_time} Uhr` : ''}</div>}
               </div>
               <span style={{ padding: '3px 10px', borderRadius: '12px', fontSize: '12px', fontWeight: 'bold', background: t.status === 'active' ? 'var(--pe-success)' : t.status === 'finished' ? 'var(--pe-border)' : 'var(--pe-blue-deep)', color: t.status === 'active' ? '#000' : '#fff' }}>
                 {t.status === 'open' ? 'Offen' : t.status === 'active' ? 'Aktiv' : 'Beendet'}
@@ -1655,6 +1662,27 @@ function TournamentExtendedTab() {
               {selectedTournament.status === 'open' ? 'Offen' : selectedTournament.status === 'active' ? 'Aktiv' : 'Beendet'}
             </span>
           </div>
+
+          {/* Start time editor — shown for open/active tournaments */}
+          {selectedTournament.status !== 'finished' && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
+              <label style={{ color: 'var(--pe-text-sub)', fontSize: '12px', whiteSpace: 'nowrap' }}>Startzeit:</label>
+              <input
+                type="time"
+                defaultValue={selectedTournament.start_time || ''}
+                key={selectedTournament.id}
+                onBlur={async (e) => {
+                  const val = e.target.value;
+                  try {
+                    await api.put(`/tournaments/${selectedId}`, { start_time: val });
+                    await loadTournaments();
+                  } catch (err) { alert(err.message || 'Startzeit konnte nicht gespeichert werden'); }
+                }}
+                style={{ background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '8px', padding: '6px 10px', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: '13px', cursor: 'pointer', width: '120px' }}
+              />
+              <span style={{ color: 'var(--pe-text-muted)', fontSize: '11px' }}>(für Spielplan-Zeitslots)</span>
+            </div>
+          )}
 
           {/* Groups section — shown if group draw done or groups exist */}
           {(selectedTournament.group_draw_done || groups.length > 0) && groups.length > 0 && (

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1165,7 +1165,7 @@ function TournamentExtendedTab() {
   const [numGroups, setNumGroups] = useState(4);
   const [creating, setCreating] = useState(false);
   const [newTournament, setNewTournament] = useState(null); // after step 1
-  const [createForm, setCreateForm] = useState({ name: '', date: '', format: '501', checkout: 'double_out' });
+  const [createForm, setCreateForm] = useState({ name: '', date: '', start_time: '', format: '501', checkout: 'double_out' });
   const [config, setConfig] = useState({
     prelim_format: '301_single_out', prelim_legs: '1',
     qf_format: '501_double_out',     qf_legs: '3',
@@ -1384,7 +1384,10 @@ function TournamentExtendedTab() {
             <p style={{ color: 'var(--pe-text-sub)', fontSize: '13px', marginBottom: '16px' }}>Gib dem Turnier einen Namen und optionales Datum.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
               <input type="text" value={createForm.name} onChange={e => setCreateForm({...createForm, name: e.target.value})} placeholder="Turniername *" required style={{ ...inputStyle, padding: '12px 14px' }} />
-              <input type="date" value={createForm.date} onChange={e => setCreateForm({...createForm, date: e.target.value})} style={{ ...inputStyle, padding: '12px 14px' }} />
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <input type="date" value={createForm.date} onChange={e => setCreateForm({...createForm, date: e.target.value})} style={{ ...inputStyle, flex: 1, padding: '12px 14px', cursor: 'pointer' }} />
+                <input type="time" value={createForm.start_time} onChange={e => setCreateForm({...createForm, start_time: e.target.value})} placeholder="Startzeit" title="Startzeit (für Spielplan)" style={{ ...inputStyle, width: '120px', padding: '12px 10px', cursor: 'pointer' }} />
+              </div>
             </div>
             <button type="submit" disabled={creating || !createForm.name.trim()} style={{ width: '100%', marginTop: '16px', padding: '14px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '52px', opacity: creating ? 0.6 : 1 }}>
               {creating ? 'Wird angelegt...' : 'Turnier anlegen & weiter →'}
@@ -1602,7 +1605,7 @@ function TournamentExtendedTab() {
       {/* Header */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
         <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px' }}>Turniere</h2>
-        <button onClick={() => { setWizardStep(1); setNewTournament(null); setCreateForm({ name: '', date: '', format: '501', checkout: 'double_out' }); }} style={{ padding: '10px 20px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
+        <button onClick={() => { setWizardStep(1); setNewTournament(null); setCreateForm({ name: '', date: '', start_time: '', format: '501', checkout: 'double_out' }); }} style={{ padding: '10px 20px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
           + Neues Turnier
         </button>
       </div>


### PR DESCRIPTION
## Summary

Fixes #32

The `start_time` field existed in the UI but had no backend effect. This PR fully wires it through.

## Changes

**Backend:**
- Added `start_time TEXT` column to `tournaments` table (schema + migration)
- `POST /api/tournaments` now accepts and stores `start_time` (validated HH:MM format)
- `PUT /api/tournaments/:id` now includes `start_time` in allowed update fields with format validation and empty-string-to-null normalization
- Schedule generation (`generate-group-schedule`) calculates `scheduled_at` per game based on `tournament.start_time` + configurable `game_duration_minutes` (default 20 min)
- Existing group games are cleared from `schedule` table before regeneration

**Frontend:**
- Wizard step 1: added time input next to date input, both with `cursor: pointer`
- Tournament list cards: show `start_time` next to date when set
- Tournament detail: inline time editor (saves on blur) for open/active tournaments
- Boards tab schedule list: displays `scheduled_at` time in cyan per game entry

## Test plan
- [ ] Create tournament with start time → schedule shows correct time slots
- [ ] Edit start time on existing tournament → updates correctly
- [ ] Generate schedule → `scheduled_at` values calculated per board/game index
- [ ] Empty start time → stored as null, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)