### PR TITLE
fix: stable status badge width in gastro product toggle

### DIFF
--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -740,7 +740,7 @@ function GastroAdminTab() {
                     </span>
                   </td>
                   <td style={{ ...tdStyle, textAlign: 'center' }}>
-                    <button onClick={() => toggleAvailable(p)} style={{ ...btnSmall, background: p.available ? 'var(--pe-success)' : 'var(--pe-bg-card)', color: p.available ? '#000' : 'var(--pe-text-muted)', padding: '3px 10px', border: `1px solid ${p.available ? 'var(--pe-success)' : 'var(--pe-border)'}` }}>
+                    <button onClick={() => toggleAvailable(p)} style={{ ...btnSmall, background: p.available ? 'var(--pe-success)' : 'var(--pe-bg-card)', color: p.available ? '#000' : 'var(--pe-text-muted)', padding: '3px 10px', border: `1px solid ${p.available ? 'var(--pe-success)' : 'var(--pe-border)'}`, minWidth: '68px' }}>
                       {p.available ? 'Aktiv' : 'Inaktiv'}
                     </button>
                   </td>


### PR DESCRIPTION
## Summary

- Adds `minWidth: 68px` to the Aktiv/Inaktiv toggle button in the Gastro product list
- Prevents layout shift when switching between the shorter "Aktiv" and longer "Inaktiv" labels

Closes #31