### PR TITLE
feat: tournament wizard UX cleanup

### DIFF
--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1282,6 +1282,7 @@ function TournamentExtendedTab() {
   // --- Wizard Step 4: Auslosung ---
   // Aktueller Turnierstatus (wird nach jeder Aktion aktualisiert)
   const [wizardTour, setWizardTour] = useState(null); // aktuelles Turnier-Objekt mit status/group_draw_done
+  const [drawError, setDrawError] = useState('');
 
   const refreshWizardTour = async () => {
     const tid = newTournament?.id || selectedId;
@@ -1301,10 +1302,15 @@ function TournamentExtendedTab() {
 
   const drawGroups = async () => {
     const tid = newTournament?.id || selectedId;
+    setDrawError('');
+    if (numGroups > players.length) {
+      setDrawError(`Zu wenige Spieler für ${numGroups} Gruppen (${players.length} Spieler angemeldet).`);
+      return;
+    }
     try {
       await api.post(`/tournaments/${tid}/draw-groups`, { numGroups });
       await refreshWizardTour();
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setDrawError(err.message || 'Auslosung fehlgeschlagen – bitte erneut versuchen.'); }
   };
 
   const generateGroupSchedule = async () => {
@@ -1384,7 +1390,7 @@ function TournamentExtendedTab() {
             <p style={{ color: 'var(--pe-text-sub)', fontSize: '13px', marginBottom: '16px' }}>Gib dem Turnier einen Namen und optionales Datum.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
               <input type="text" value={createForm.name} onChange={e => setCreateForm({...createForm, name: e.target.value})} placeholder="Turniername *" required style={{ ...inputStyle, padding: '12px 14px' }} />
-              <input type="date" value={createForm.date} onChange={e => setCreateForm({...createForm, date: e.target.value})} style={{ ...inputStyle, padding: '12px 14px' }} />
+              <input type="date" value={createForm.date} onChange={e => setCreateForm({...createForm, date: e.target.value})} style={{ ...inputStyle, padding: '12px 14px', cursor: 'pointer' }} />
             </div>
             <button type="submit" disabled={creating || !createForm.name.trim()} style={{ width: '100%', marginTop: '16px', padding: '14px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '52px', opacity: creating ? 0.6 : 1 }}>
               {creating ? 'Wird angelegt...' : 'Turnier anlegen & weiter →'}
@@ -1435,7 +1441,11 @@ function TournamentExtendedTab() {
                   <input type="text" value={playerForm.nachname} onChange={e => setPlayerForm({...playerForm, nachname: e.target.value})} placeholder="Nachname *" required style={{ ...inputStyle, padding: '10px 12px' }} />
                 </div>
                 <div style={{ display: 'flex', gap: '6px' }}>
-                  <input type="number" value={playerForm.seed} onChange={e => setPlayerForm({...playerForm, seed: e.target.value})} placeholder="Seed" style={{ ...inputStyle, width: '70px', padding: '10px' }} />
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0', border: '1px solid var(--pe-border)', borderRadius: '8px', background: 'var(--pe-bg-card)', overflow: 'hidden', flexShrink: 0 }}>
+                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: Math.max(0, (parseInt(playerForm.seed)||0) - 1) || ''})} style={{ padding: '0 12px', minHeight: '48px', background: 'transparent', border: 'none', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: '18px', cursor: 'pointer', lineHeight: 1 }}>−</button>
+                    <span style={{ minWidth: '32px', textAlign: 'center', color: playerForm.seed ? 'var(--pe-text)' : 'var(--pe-text-muted)', fontSize: '14px', fontWeight: 'bold', userSelect: 'none' }}>{playerForm.seed || '—'}</span>
+                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: (parseInt(playerForm.seed)||0) + 1})} style={{ padding: '0 12px', minHeight: '48px', background: 'transparent', border: 'none', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: '18px', cursor: 'pointer', lineHeight: 1 }}>+</button>
+                  </div>
                   <button type="submit" disabled={!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()} style={{ flex: 1, padding: '10px 16px', borderRadius: '8px', background: 'var(--pe-blue-deep)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px', opacity: (!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()) ? 0.5 : 1 }}>+ Spieler hinzufügen</button>
                 </div>
               </form>
@@ -1567,12 +1577,18 @@ function TournamentExtendedTab() {
                     </select>
                   </div>
 
+                  {drawError && (
+                    <div style={{ padding: '10px 14px', borderRadius: '8px', background: 'rgba(255,69,96,0.1)', border: '1px solid var(--pe-danger)', color: 'var(--pe-danger)', fontSize: '13px' }}>
+                      {drawError}
+                    </div>
+                  )}
+
                   {/* Option A: Gruppenphase */}
-                  <button onClick={drawGroups} style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-blue-deep)', color: '#fff', border: '2px solid var(--pe-blue-mid)', fontFamily: 'Verdana, Geneva, sans-serif', cursor: 'pointer', minHeight: '64px', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '14px' }}>
+                  <button onClick={drawGroups} style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', cursor: 'pointer', minHeight: '64px', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '14px', boxShadow: '0 4px 16px rgba(0,184,255,0.25)' }}>
                     <span style={{ fontSize: '28px', flexShrink: 0 }}>🏆</span>
                     <div>
                       <div style={{ fontWeight: 'bold', fontSize: '15px' }}>Mit Gruppenphase starten</div>
-                      <div style={{ fontSize: '12px', opacity: 0.8, marginTop: '3px' }}>Automatische Gruppenauslosung → Round-Robin → KO-Runde</div>
+                      <div style={{ fontSize: '12px', opacity: 0.85, marginTop: '3px' }}>Automatische Gruppenauslosung → Round-Robin → KO-Runde</div>
                       <div style={{ fontSize: '11px', color: 'var(--pe-cyan-light)', marginTop: '2px' }}>Empfohlen ab 8 Spielern</div>
                     </div>
                   </button>
@@ -1669,9 +1685,11 @@ function TournamentExtendedTab() {
                   </select>
                 </div>
               ))}
-              <button onClick={generateGroupSchedule} style={{ width: '100%', marginTop: '8px', padding: '12px', borderRadius: '10px', background: 'linear-gradient(135deg, #00E5A0, #1E7FEB)', color: '#000', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '44px', fontSize: '13px' }}>
-                Spielplan generieren
-              </button>
+              {selectedTournament.status !== 'active' && (
+                <button onClick={generateGroupSchedule} style={{ width: '100%', marginTop: '8px', padding: '12px', borderRadius: '10px', background: 'linear-gradient(135deg, #00E5A0, #1E7FEB)', color: '#000', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '44px', fontSize: '13px' }}>
+                  Spielplan generieren
+                </button>
+              )}
             </div>
           )}
 
@@ -1698,14 +1716,6 @@ function TournamentExtendedTab() {
         </div>
       )}
 
-      {/* Danger Zone */}
-      <div style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-bg-card)', border: '1px solid var(--pe-danger)', marginTop: '24px' }}>
-        <h3 style={{ color: 'var(--pe-danger)', fontWeight: 'bold', fontSize: '13px', marginBottom: '8px' }}>DANGER ZONE</h3>
-        <p style={{ color: 'var(--pe-text-muted)', fontSize: '12px', marginBottom: '12px' }}>Löscht ALLE Turniere, Spieler, Spiele, Bestellungen. Boards, User und Produkte bleiben.</p>
-        <button onClick={handleWipe} style={{ width: '100%', padding: '12px', borderRadius: '8px', background: 'var(--pe-danger)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
-          Datenbank zurücksetzen (WIPE)
-        </button>
-      </div>
     </div>
   );
 }

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -740,7 +740,7 @@ function GastroAdminTab() {
                     </span>
                   </td>
                   <td style={{ ...tdStyle, textAlign: 'center' }}>
-                    <button onClick={() => toggleAvailable(p)} style={{ ...btnSmall, background: p.available ? 'var(--pe-success)' : 'var(--pe-bg-card)', color: p.available ? '#000' : 'var(--pe-text-muted)', padding: '3px 10px', border: `1px solid ${p.available ? 'var(--pe-success)' : 'var(--pe-border)'}` }}>
+                    <button onClick={() => toggleAvailable(p)} style={{ ...btnSmall, background: p.available ? 'var(--pe-success)' : 'var(--pe-bg-card)', color: p.available ? '#000' : 'var(--pe-text-muted)', padding: '3px 10px', border: `1px solid ${p.available ? 'var(--pe-success)' : 'var(--pe-border)'}`, minWidth: '68px' }}>
                       {p.available ? 'Aktiv' : 'Inaktiv'}
                     </button>
                   </td>
@@ -911,16 +911,20 @@ function TournamentDirectorTab() {
   const [tapGameId, setTapGameId] = useState(null); // Mobile tap-to-assign selection
 
   const load = async () => {
-    const [b, t] = await Promise.all([
+    const [allBoards, t] = await Promise.all([
       api.get('/boards').catch(() => []),
       api.get('/tournaments').catch(() => []),
     ]);
-    setBoards(b);
-    const active = t.find(x => x.status === 'active') || t[0];
+    const active = t.find(x => x.status === 'active') || null;
     setActiveTournament(active);
     if (active) {
+      // Item 9: Only show boards belonging to the active tournament
+      const tournamentBoards = allBoards.filter(b => b.tournament_id === active.id || !b.tournament_id);
+      setBoards(tournamentBoards);
       const detail = await api.get(`/tournaments/${active.id}`).catch(() => null);
       if (detail?.games) setGames(detail.games.filter(g => ['pending','bulloff','active'].includes(g.status) && g.player1_name));
+    } else {
+      setBoards([]);
     }
   };
 
@@ -1011,7 +1015,15 @@ function TournamentDirectorTab() {
         )}
       </div>
 
+      {/* Item 9: No active tournament message */}
+      {!activeTournament && (
+        <div style={{ padding: '32px 16px', textAlign: 'center', color: 'var(--pe-text-muted)', fontSize: '15px', borderRadius: '12px', background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', marginBottom: '20px' }}>
+          Kein aktives Turnier
+        </div>
+      )}
+
       {/* Board grid — responsive: auto-fill wraps on mobile */}
+      {activeTournament && (
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: '12px', marginBottom: '20px' }}>
         {boards.map(board => {
           const boardGames = gamesByBoard[board.id] || [];
@@ -1101,8 +1113,10 @@ function TournamentDirectorTab() {
           );
         })}
       </div>
+      )}
 
       {/* Unassigned games — drag source + drop zone + tap-to-select */}
+      {activeTournament && (
       <div
         onDragOver={e => { e.preventDefault(); setDragOverBoard('unassigned'); }}
         onDragLeave={onDragLeave}
@@ -1144,6 +1158,7 @@ function TournamentDirectorTab() {
           )}
         </div>
       </div>
+      )}
 
     </div>
   );
@@ -1177,6 +1192,7 @@ function TournamentExtendedTab() {
   const [playerForm, setPlayerForm] = useState({ vorname: '', nickname: '', nachname: '', seed: '' });
   const [players, setPlayers] = useState([]);
   const [mockCount, setMockCount] = useState('8');
+  const [wizardError, setWizardError] = useState(''); // inline error for wizard steps
 
   const loadTournaments = () => {
     api.get('/tournaments').then((t) => {
@@ -1215,30 +1231,45 @@ function TournamentExtendedTab() {
     e.preventDefault();
     if (!createForm.name.trim()) return;
     setCreating(true);
+    setWizardError('');
     try {
       const t = await api.post('/tournaments', createForm);
       setNewTournament(t);
       setSelectedId(String(t.id));
       await loadTournaments();
       setWizardStep(2); // direkt zu Format
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setWizardError(err.message || 'Turnier konnte nicht angelegt werden – bitte erneut versuchen.'); }
     finally { setCreating(false); }
   };
 
-  // --- Wizard Step 2: Format speichern ---
+  // --- Wizard Step 2: Format speichern + Boards auto-erstellen ---
   const handleSaveConfig = async () => {
     setSavingConfig(true);
+    setWizardError('');
     const tid = newTournament?.id || selectedId;
+    const boardCount = parseInt(config.board_count) || 1;
     try {
       await api.put(`/tournaments/${tid}`, {
         prelim_format: config.prelim_format, prelim_legs: parseInt(config.prelim_legs) || 1,
         qf_format:     config.qf_format,     qf_legs:    parseInt(config.qf_legs)    || 3,
         sf_format:     config.sf_format,     sf_legs:    parseInt(config.sf_legs)    || 3,
         final_format:  config.final_format,  final_legs: parseInt(config.final_legs) || 5,
-        board_count:   parseInt(config.board_count) || 1,
+        board_count:   boardCount,
       });
+      // Auto-create boards for this tournament if they don't exist yet
+      const existingBoards = await api.get('/boards').catch(() => []);
+      const tournamentBoards = existingBoards.filter(b => b.tournament_id === tid);
+      if (tournamentBoards.length < boardCount) {
+        const toCreate = boardCount - tournamentBoards.length;
+        const startNumber = existingBoards.length + 1;
+        const createPromises = Array.from({ length: toCreate }, (_, i) =>
+          api.post('/boards', { number: startNumber + i, tournament_id: tid }).catch(() => null)
+        );
+        await Promise.all(createPromises);
+        await loadTournaments();
+      }
       setWizardStep(3);
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setWizardError(err.message || 'Konfiguration konnte nicht gespeichert werden – bitte erneut versuchen.'); }
     finally { setSavingConfig(false); }
   };
 
@@ -1247,6 +1278,7 @@ function TournamentExtendedTab() {
     e.preventDefault();
     if (!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()) return;
     const tid = newTournament?.id || selectedId;
+    setWizardError('');
     try {
       await api.post(`/tournaments/${tid}/players`, {
         vorname: playerForm.vorname.trim(),
@@ -1257,7 +1289,7 @@ function TournamentExtendedTab() {
       setPlayerForm({ vorname: '', nickname: '', nachname: '', seed: '' });
       const updated = await api.get(`/tournaments/${tid}/players`);
       setPlayers(updated);
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setWizardError(err.message || 'Spieler konnte nicht hinzugefügt werden – bitte erneut versuchen.'); }
   };
 
   const deletePlayer = async (playerId) => {
@@ -1266,23 +1298,23 @@ function TournamentExtendedTab() {
     try {
       await api.del(`/tournaments/${tid}/players/${playerId}`);
       setPlayers(prev => prev.filter(p => p.id !== playerId));
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setWizardError(err.message || 'Spieler konnte nicht gelöscht werden – bitte erneut versuchen.'); }
   };
 
   const handleMock = async () => {
     const tid = newTournament?.id || selectedId;
     if (!confirm(`${mockCount} Fake-Spieler erstellen?`)) return;
+    setWizardError('');
     try {
       await api.post(`/tournaments/${tid}/mock`, { player_count: parseInt(mockCount) });
       const updated = await api.get(`/tournaments/${tid}/players`);
       setPlayers(updated);
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setWizardError(err.message || 'Simulation fehlgeschlagen – bitte erneut versuchen.'); }
   };
 
   // --- Wizard Step 4: Auslosung ---
   // Aktueller Turnierstatus (wird nach jeder Aktion aktualisiert)
   const [wizardTour, setWizardTour] = useState(null); // aktuelles Turnier-Objekt mit status/group_draw_done
-  const [drawError, setDrawError] = useState('');
 
   const refreshWizardTour = async () => {
     const tid = newTournament?.id || selectedId;
@@ -1302,56 +1334,72 @@ function TournamentExtendedTab() {
 
   const drawGroups = async () => {
     const tid = newTournament?.id || selectedId;
-    setDrawError('');
-    if (numGroups > players.length) {
-      setDrawError(`Zu wenige Spieler für ${numGroups} Gruppen (${players.length} Spieler angemeldet).`);
+    const groupCount = parseInt(numGroups) || 2;
+    // Item 4: Inline validation — minimum 2 groups, at least 2 players per group
+    if (groupCount < 2) {
+      setWizardError('Mindestens 2 Gruppen erforderlich.');
       return;
     }
+    if (players.length < groupCount * 2) {
+      setWizardError(`Zu wenige Spieler: Für ${groupCount} Gruppen werden mindestens ${groupCount * 2} Spieler benötigt.`);
+      return;
+    }
+    setWizardError('');
     try {
       await api.post(`/tournaments/${tid}/draw-groups`, { numGroups });
-      await refreshWizardTour();
-    } catch (err) { setDrawError(err.message || 'Auslosung fehlgeschlagen – bitte erneut versuchen.'); }
+      const t = await refreshWizardTour();
+      // Item 6: Auto-assign boards to groups in sequence after draw
+      if (t?.group_draw_done) {
+        const groupData = await api.get(`/tournaments/${tid}/groups`).catch(() => null);
+        const drawnGroups = groupData?.groups || [];
+        const availableBoards = await api.get('/boards').catch(() => []);
+        const tournamentBoards = availableBoards.filter(b => b.tournament_id === tid || !b.tournament_id).sort((a, b) => a.number - b.number);
+        await Promise.all(
+          drawnGroups.map((g, i) => {
+            const board = tournamentBoards[i];
+            if (board) return api.put(`/tournaments/${tid}/groups/${g.id}/board`, { board_id: board.id }).catch(() => null);
+            return Promise.resolve();
+          })
+        );
+        const refreshed = await api.get(`/tournaments/${tid}/groups`).catch(() => null);
+        if (refreshed) setGroups(refreshed.groups || []);
+      }
+    } catch (err) { setWizardError(err.message || 'Auslosung fehlgeschlagen – bitte erneut versuchen.'); }
   };
 
   const generateGroupSchedule = async () => {
     const tid = newTournament?.id || selectedId;
     if (!tid) return;
+    setWizardError('');
     try {
-      const r = await api.post(`/tournaments/${tid}/generate-group-schedule`);
-      alert(`Spielplan erstellt! ${r.games_created} Partien auf Boards verteilt.`);
+      await api.post(`/tournaments/${tid}/generate-group-schedule`);
       await refreshWizardTour();
       await loadTournaments();
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setWizardError(err.message || 'Spielplan konnte nicht generiert werden – bitte erneut versuchen.'); }
   };
 
   const startTournament = async () => {
     const tid = newTournament?.id || selectedId;
+    setWizardError('');
     try {
       await api.put(`/tournaments/${tid}/start`);
       await loadTournaments();
       setWizardStep(0);
       setNewTournament(null);
       setWizardTour(null);
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setWizardError(err.message || 'Turnier konnte nicht gestartet werden – bitte erneut versuchen.'); }
   };
 
   const lockTournament = async () => {
     if (!confirm('Turnier wirklich abschließen?')) return;
     try { await api.put(`/tournaments/${selectedId}/lock`); loadTournaments(); }
-    catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    catch (err) { setWizardError(err.message || 'Turnier konnte nicht abgeschlossen werden – bitte erneut versuchen.'); }
   };
 
   const deleteTournament = async (id) => {
     if (!confirm('Turnier und alle Daten löschen?')) return;
     try { await api.del(`/tournaments/${id}`); setSelectedId(''); loadTournaments(); }
-    catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
-  };
-
-  const handleWipe = async () => {
-    const confirmed = prompt('Zum Bestätigen "WIPE" eingeben:');
-    if (confirmed !== 'WIPE') return;
-    try { await api.post('/admin/wipe', {}); alert('Alle Turnierdaten gelöscht!'); setSelectedId(''); loadTournaments(); }
-    catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    catch (err) { setWizardError(err.message || 'Turnier konnte nicht gelöscht werden – bitte erneut versuchen.'); }
   };
 
   const assignGroupToBoard = async (groupId, boardId) => {
@@ -1360,7 +1408,7 @@ function TournamentExtendedTab() {
       await api.put(`/tournaments/${tid}/groups/${groupId}/board`, { board_id: boardId || null });
       const data = await api.get(`/tournaments/${tid}/groups`);
       setGroups(data.groups || []);
-    } catch (err) { alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen'); }
+    } catch (err) { setWizardError(err.message || 'Board-Zuordnung fehlgeschlagen – bitte erneut versuchen.'); }
   };
 
   const card = { background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', borderRadius: '12px', padding: '16px', marginBottom: '12px' };
@@ -1383,6 +1431,14 @@ function TournamentExtendedTab() {
             <div key={s} style={{ flex: 1, height: '4px', borderRadius: '2px', background: s <= wizardStep ? 'var(--pe-cyan-bright)' : 'var(--pe-border)' }} />
           ))}
         </div>
+
+        {/* Inline error display */}
+        {wizardError && (
+          <div style={{ marginBottom: '16px', padding: '12px 14px', borderRadius: '10px', background: 'rgba(255,69,96,0.1)', border: '1px solid var(--pe-danger)', color: 'var(--pe-danger)', fontSize: '13px', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span>{wizardError}</span>
+            <button onClick={() => setWizardError('')} style={{ background: 'none', border: 'none', color: 'var(--pe-danger)', cursor: 'pointer', fontSize: '16px', lineHeight: 1, padding: '0 4px' }}>✕</button>
+          </div>
+        )}
 
         {/* Step 1: Grunddaten */}
         {wizardStep === 1 && (
@@ -1441,10 +1497,10 @@ function TournamentExtendedTab() {
                   <input type="text" value={playerForm.nachname} onChange={e => setPlayerForm({...playerForm, nachname: e.target.value})} placeholder="Nachname *" required style={{ ...inputStyle, padding: '10px 12px' }} />
                 </div>
                 <div style={{ display: 'flex', gap: '6px' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0', border: '1px solid var(--pe-border)', borderRadius: '8px', background: 'var(--pe-bg-card)', overflow: 'hidden', flexShrink: 0 }}>
-                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: Math.max(0, (parseInt(playerForm.seed)||0) - 1) || ''})} style={{ padding: '0 12px', minHeight: '48px', background: 'transparent', border: 'none', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: '18px', cursor: 'pointer', lineHeight: 1 }}>−</button>
-                    <span style={{ minWidth: '32px', textAlign: 'center', color: playerForm.seed ? 'var(--pe-text)' : 'var(--pe-text-muted)', fontSize: '14px', fontWeight: 'bold', userSelect: 'none' }}>{playerForm.seed || '—'}</span>
-                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: (parseInt(playerForm.seed)||0) + 1})} style={{ padding: '0 12px', minHeight: '48px', background: 'transparent', border: 'none', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: '18px', cursor: 'pointer', lineHeight: 1 }}>+</button>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '4px', background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', borderRadius: '8px', padding: '4px 8px' }}>
+                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: String(Math.max(1, (parseInt(playerForm.seed) || 1) - 1))})} style={{ minHeight: '44px', minWidth: '36px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '6px', fontWeight: 'bold', fontSize: '18px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif' }}>−</button>
+                    <span style={{ minWidth: '32px', textAlign: 'center', color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '14px' }}>{playerForm.seed || '—'}</span>
+                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: String((parseInt(playerForm.seed) || 0) + 1)})} style={{ minHeight: '44px', minWidth: '36px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '6px', fontWeight: 'bold', fontSize: '18px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif' }}>+</button>
                   </div>
                   <button type="submit" disabled={!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()} style={{ flex: 1, padding: '10px 16px', borderRadius: '8px', background: 'var(--pe-blue-deep)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px', opacity: (!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()) ? 0.5 : 1 }}>+ Spieler hinzufügen</button>
                 </div>
@@ -1577,18 +1633,12 @@ function TournamentExtendedTab() {
                     </select>
                   </div>
 
-                  {drawError && (
-                    <div style={{ padding: '10px 14px', borderRadius: '8px', background: 'rgba(255,69,96,0.1)', border: '1px solid var(--pe-danger)', color: 'var(--pe-danger)', fontSize: '13px' }}>
-                      {drawError}
-                    </div>
-                  )}
-
                   {/* Option A: Gruppenphase */}
-                  <button onClick={drawGroups} style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', cursor: 'pointer', minHeight: '64px', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '14px', boxShadow: '0 4px 16px rgba(0,184,255,0.25)' }}>
+                  <button onClick={drawGroups} style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', boxShadow: '0 4px 14px rgba(0,184,255,0.3)', fontFamily: 'Verdana, Geneva, sans-serif', cursor: 'pointer', minHeight: '64px', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '14px' }}>
                     <span style={{ fontSize: '28px', flexShrink: 0 }}>🏆</span>
                     <div>
                       <div style={{ fontWeight: 'bold', fontSize: '15px' }}>Mit Gruppenphase starten</div>
-                      <div style={{ fontSize: '12px', opacity: 0.85, marginTop: '3px' }}>Automatische Gruppenauslosung → Round-Robin → KO-Runde</div>
+                      <div style={{ fontSize: '12px', opacity: 0.8, marginTop: '3px' }}>Automatische Gruppenauslosung → Round-Robin → KO-Runde</div>
                       <div style={{ fontSize: '11px', color: 'var(--pe-cyan-light)', marginTop: '2px' }}>Empfohlen ab 8 Spielern</div>
                     </div>
                   </button>
@@ -1622,6 +1672,14 @@ function TournamentExtendedTab() {
           + Neues Turnier
         </button>
       </div>
+
+      {/* Inline error display for list view */}
+      {wizardError && (
+        <div style={{ marginBottom: '16px', padding: '12px 14px', borderRadius: '10px', background: 'rgba(255,69,96,0.1)', border: '1px solid var(--pe-danger)', color: 'var(--pe-danger)', fontSize: '13px', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span>{wizardError}</span>
+          <button onClick={() => setWizardError('')} style={{ background: 'none', border: 'none', color: 'var(--pe-danger)', cursor: 'pointer', fontSize: '16px', lineHeight: 1, padding: '0 4px' }}>✕</button>
+        </div>
+      )}
 
       {/* Turnier-Liste */}
       {tournaments.length === 0 && (
@@ -1685,8 +1743,8 @@ function TournamentExtendedTab() {
                   </select>
                 </div>
               ))}
-              {selectedTournament.status !== 'active' && (
-                <button onClick={generateGroupSchedule} style={{ width: '100%', marginTop: '8px', padding: '12px', borderRadius: '10px', background: 'linear-gradient(135deg, #00E5A0, #1E7FEB)', color: '#000', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '44px', fontSize: '13px' }}>
+              {selectedTournament.status === 'open' && !selectedTournament.group_draw_done && (
+                <button onClick={generateGroupSchedule} style={{ width: '100%', marginTop: '8px', padding: '12px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '44px', fontSize: '13px' }}>
                   Spielplan generieren
                 </button>
               )}


### PR DESCRIPTION
Closes #33 — implements all 9 UX improvements to the tournament wizard and admin views.

## Summary

- **Item 1** — Date picker now shows pointer cursor for clearer affordance
- **Item 2** — Boards are auto-created and linked to the tournament when saving the format step (board_count boards → POST /api/boards with tournament_id)
- **Item 3** — Seed input replaced with touch-friendly `−` / `+` stepper buttons (minHeight 44px)
- **Item 4** — All `alert()` calls in `TournamentExtendedTab` removed; replaced with inline German error state rendered near the wizard header. Group validation: min 2 groups, min 2 players per group
- **Item 5** — "Mit Gruppenphase starten" button now uses `pe-gradient` background + `box-shadow: 0 4px 14px rgba(0,184,255,0.3)` as clear primary CTA
- **Item 6** — After group draw, boards are automatically assigned to groups in sequence (Group A → Board 1, Group B → Board 2, …)
- **Item 7** — "Spielplan generieren" button in list view is hidden when `group_draw_done === true` or tournament is not `open`
- **Item 8** — Entire DANGER ZONE / WIPE section removed; individual tournament deletion remains
- **Item 9** — DirectorTab filters boards to only those belonging to the active tournament; shows "Kein aktives Turnier" when no tournament is active

## Test plan

- [ ] Create tournament → date picker shows hand cursor
- [ ] Complete format step → boards auto-created matching board_count
- [ ] Step 3: seed stepper shows `−` / `+` buttons, no free-text input
- [ ] Trigger errors (no name, too few players for group count) → inline error in German, no alert()
- [ ] Draw groups → "Gruppenphase starten" is visually distinct gradient button
- [ ] After draw → groups have boards auto-assigned in sequence
- [ ] In list view → "Spielplan generieren" only shown for open tournaments without draw
- [ ] No DANGER ZONE section visible in Tournaments tab
- [ ] Turnierleiter tab with no active tournament shows "Kein aktives Turnier"
- [ ] Turnierleiter tab with active tournament only shows that tournament's boards

🤖 Generated with [Claude Code](https://claude.com/claude-code)