### PR TITLE
fix: delete schedule entries before games/boards on tournament delete

### DIFF
--- a/backend/src/routes/tournaments.js
+++ b/backend/src/routes/tournaments.js
@@ -215,6 +215,7 @@ router.delete('/:id', requireAdmin, (req, res) => {
   const deleteTx = db.transaction(() => {
     const games = db.prepare('SELECT id FROM games WHERE tournament_id = ?').all(req.params.id);
     for (const game of games) {
+      db.prepare('DELETE FROM schedule WHERE game_id = ?').run(game.id);
       db.prepare('DELETE FROM throws WHERE game_id = ?').run(game.id);
     }
     db.prepare('DELETE FROM games WHERE tournament_id = ?').run(req.params.id);


### PR DESCRIPTION
## Problem

`DELETE /api/tournaments/:id` returned 500 because `schedule` has FK references to both `games.id` and `boards.id`. Deleting games/boards without first removing schedule entries violated these constraints.

## Fix

Added `DELETE FROM schedule WHERE game_id = ?` for each game before deleting throws and games, so FK constraints are satisfied.

## Delete order (after fix)
1. schedule entries (per game)
2. throws (per game)
3. games
4. group_players (per group)
5. groups
6. tournament_registrations
7. boards
8. tournament