### PR TITLE
fix: boards UNIQUE constraint per (number, tournament_id) instead of global

### DIFF
--- a/backend/src/db/db.js
+++ b/backend/src/db/db.js
@@ -100,6 +100,30 @@ function initialize() {
     }
   }
 
+  // Migrate boards table: replace global UNIQUE(number) with UNIQUE(number, tournament_id)
+  try {
+    const hasOldConstraint = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='boards'").get();
+    if (hasOldConstraint && /number INTEGER UNIQUE/i.test(hasOldConstraint.sql)) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS boards_new (
+          id INTEGER PRIMARY KEY,
+          number INTEGER NOT NULL,
+          name TEXT,
+          active BOOLEAN DEFAULT 1,
+          is_final BOOLEAN DEFAULT 0,
+          tournament_id INTEGER REFERENCES tournaments(id),
+          UNIQUE(number, tournament_id)
+        );
+        INSERT OR IGNORE INTO boards_new (id, number, name, active, is_final, tournament_id)
+          SELECT id, number, name, active, COALESCE(is_final, 0), tournament_id FROM boards;
+        DROP TABLE boards;
+        ALTER TABLE boards_new RENAME TO boards;
+      `);
+    }
+  } catch (e) {
+    // Migration already done or not needed
+  }
+
   // Walk-On Jobs Tabelle anlegen
   db.exec(`
     CREATE TABLE IF NOT EXISTS walkon_jobs (

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -105,10 +105,12 @@ CREATE TABLE IF NOT EXISTS users (
 -- NEU: Dartscheiben
 CREATE TABLE IF NOT EXISTS boards (
   id INTEGER PRIMARY KEY,
-  number INTEGER UNIQUE NOT NULL,
+  number INTEGER NOT NULL,
   name TEXT,
   active BOOLEAN DEFAULT 1,
-  tournament_id INTEGER REFERENCES tournaments(id)
+  is_final BOOLEAN DEFAULT 0,
+  tournament_id INTEGER REFERENCES tournaments(id),
+  UNIQUE(number, tournament_id)
 );
 
 -- NEU: Spielplan / Scheduling


### PR DESCRIPTION
## Problem

`boards.number` had a global UNIQUE constraint, so two tournaments could not both have a Board 1, Board 2 etc. → "UNIQUE constraint failed: boards.number" on second tournament creation.

## Fix

- `schema.sql`: Changed `number INTEGER UNIQUE` to `number INTEGER NOT NULL` + `UNIQUE(number, tournament_id)` on the table level
- `db.js`: Added migration that detects the old schema and rebuilds the boards table with the new constraint (SQLite does not support DROP CONSTRAINT, so table rebuild is required)

## Effect

Board numbers are now unique per tournament. Multiple tournaments can each have boards numbered 1, 2, 3... without conflict.