### PR TITLE
feat: tournament-level seed setting (random vs seeded draw)

### DIFF
--- a/backend/src/db/db.js
+++ b/backend/src/db/db.js
@@ -90,6 +90,7 @@ function initialize() {
     "ALTER TABLE players ADD COLUMN walkon_duration INTEGER DEFAULT 30",
     "ALTER TABLE guests ADD COLUMN active BOOLEAN DEFAULT 1",
     "ALTER TABLE tournaments ADD COLUMN start_time TEXT",
+    "ALTER TABLE tournaments ADD COLUMN use_seed BOOLEAN DEFAULT 0",
   ];
 
   for (const stmt of alterStatements) {

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS tournaments (
   format TEXT NOT NULL,
   checkout TEXT NOT NULL,
   status TEXT DEFAULT 'open',
+  use_seed BOOLEAN DEFAULT 0,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/backend/src/routes/tournaments.js
+++ b/backend/src/routes/tournaments.js
@@ -14,7 +14,7 @@ router.get('/', (req, res) => {
 
 // POST /api/tournaments (Admin)
 router.post('/', verifyToken, requireFields(['name', 'format', 'checkout']), (req, res) => {
-  const { name, date, start_time, format, checkout } = req.body;
+  const { name, date, start_time, format, checkout, use_seed } = req.body;
 
   if (!['501', '301'].includes(format)) {
     return res.status(400).json({ error: 'Format must be 501 or 301' });
@@ -28,9 +28,11 @@ router.post('/', verifyToken, requireFields(['name', 'format', 'checkout']), (re
     return res.status(400).json({ error: 'start_time must be in HH:MM format' });
   }
 
+  const useSeedValue = use_seed ? 1 : 0;
+
   const result = db.prepare(
-    'INSERT INTO tournaments (name, date, start_time, format, checkout) VALUES (?, ?, ?, ?, ?)'
-  ).run(name, date || null, start_time || null, format, checkout);
+    'INSERT INTO tournaments (name, date, start_time, format, checkout, use_seed) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(name, date || null, start_time || null, format, checkout, useSeedValue);
 
   const tournament = db.prepare('SELECT * FROM tournaments WHERE id = ?').get(result.lastInsertRowid);
   auditLog(req, 'tournament', 'CREATE', `Turnier "${name}" angelegt`, tournament.id);
@@ -91,7 +93,7 @@ router.put('/:id', verifyToken, (req, res) => {
   const tournament = db.prepare('SELECT * FROM tournaments WHERE id = ?').get(req.params.id);
   if (!tournament) return res.status(404).json({ error: 'Tournament not found' });
 
-  const allowed = ['prelim_format','prelim_legs','qf_format','qf_legs','sf_format','sf_legs','final_format','final_legs','board_count','name','date','start_time'];
+  const allowed = ['prelim_format','prelim_legs','qf_format','qf_legs','sf_format','sf_legs','final_format','final_legs','board_count','name','date','start_time','use_seed'];
   const updates = {};
   for (const key of allowed) {
     if (req.body[key] !== undefined) updates[key] = req.body[key];
@@ -270,6 +272,25 @@ router.post('/:id/draw-groups', requireAdminOrDirector, (req, res) => {
     // Gruppennamen: A, B, C, ...
     const groupNames = Array.from({ length: numGroups }, (_, i) => String.fromCharCode(65 + i));
 
+    // Determine draw order based on tournament.use_seed setting
+    let orderedPlayers;
+    if (tournament.use_seed) {
+      // Seed-aware draw: sort by seed (nulls last), then snake-draft across groups
+      orderedPlayers = [...players].sort((a, b) => {
+        if (a.seed == null && b.seed == null) return 0;
+        if (a.seed == null) return 1;
+        if (b.seed == null) return -1;
+        return a.seed - b.seed;
+      });
+    } else {
+      // Completely random draw: Fisher-Yates shuffle
+      orderedPlayers = [...players];
+      for (let i = orderedPlayers.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [orderedPlayers[i], orderedPlayers[j]] = [orderedPlayers[j], orderedPlayers[i]];
+      }
+    }
+
     const drawTransaction = db.transaction(() => {
       // Gruppen anlegen
       const groupIds = [];
@@ -280,24 +301,25 @@ router.post('/:id/draw-groups', requireAdminOrDirector, (req, res) => {
         groupIds.push(result.lastInsertRowid);
       }
 
-      // Serpentinen-Verteilung: 1->A, 2->B, ..., N->B, N+1->A (umgekehrt)
-      let direction = 1; // 1 = vorwaerts, -1 = rueckwaerts
+      // Snake-draft distribution: 1->A, 2->B, ..., N->N, N+1->N (reverse), ...
+      // Ensures top seeds (or random players) spread across different groups
+      let direction = 1; // 1 = forward, -1 = backward
       let groupIndex = 0;
-      for (const player of players) {
+      for (const player of orderedPlayers) {
         db.prepare(
           'INSERT INTO group_players (group_id, player_id) VALUES (?, ?)'
         ).run(groupIds[groupIndex], player.id);
 
-        // Naechste Gruppe
+        // Advance to next group (snake direction)
         if (direction === 1) {
           if (groupIndex >= numGroups - 1) {
-            direction = -1; // Umkehren
+            direction = -1;
           } else {
             groupIndex++;
           }
         } else {
           if (groupIndex <= 0) {
-            direction = 1; // Umkehren
+            direction = 1;
           } else {
             groupIndex--;
           }

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1225,7 +1225,7 @@ function TournamentExtendedTab() {
   const [numGroups, setNumGroups] = useState(4);
   const [creating, setCreating] = useState(false);
   const [newTournament, setNewTournament] = useState(null); // after step 1
-  const [createForm, setCreateForm] = useState({ name: '', date: '', start_time: '', format: '501', checkout: 'double_out' });
+  const [createForm, setCreateForm] = useState({ name: '', date: '', start_time: '', format: '501', checkout: 'double_out', use_seed: false });
   const [config, setConfig] = useState({
     prelim_format: '301_single_out', prelim_legs: '1',
     qf_format: '501_double_out',     qf_legs: '3',
@@ -1499,6 +1499,27 @@ function TournamentExtendedTab() {
                 <input type="time" value={createForm.start_time} onChange={e => setCreateForm({...createForm, start_time: e.target.value})} placeholder="Startzeit" title="Startzeit (für Spielplan)" style={{ ...inputStyle, width: '120px', padding: '12px 10px', cursor: 'pointer' }} />
               </div>
             </div>
+            {/* Seeding toggle */}
+            <div style={{ marginTop: '12px', padding: '12px 14px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)' }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: createForm.use_seed ? '8px' : '0' }}>
+                <span style={{ color: 'var(--pe-text-sub)', fontSize: '13px', fontWeight: 'bold', fontFamily: 'Verdana, Geneva, sans-serif' }}>Seeding verwenden?</span>
+                <button
+                  type="button"
+                  onClick={() => setCreateForm({...createForm, use_seed: !createForm.use_seed})}
+                  style={{ padding: '6px 16px', borderRadius: '20px', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '13px', cursor: 'pointer', minHeight: '36px', minWidth: '64px', background: createForm.use_seed ? 'var(--pe-success)' : 'var(--pe-bg-card)', color: createForm.use_seed ? '#000' : 'var(--pe-text-muted)', border: createForm.use_seed ? 'none' : '1px solid var(--pe-border)', transition: 'background 0.2s' }}
+                >
+                  {createForm.use_seed ? 'ON' : 'OFF'}
+                </button>
+              </div>
+              {createForm.use_seed
+                ? <p style={{ color: 'var(--pe-success)', fontSize: '11px', margin: '0', lineHeight: '1.4' }}>Spieler können eine Setzposition erhalten. Top-Gesetzte kommen in verschiedene Gruppen.</p>
+                : null
+              }
+              {!createForm.use_seed
+                ? <p style={{ color: 'var(--pe-text-muted)', fontSize: '11px', margin: '0', lineHeight: '1.4' }}>Auslosung komplett zufällig.</p>
+                : null
+              }
+            </div>
             <button type="submit" disabled={creating || !createForm.name.trim()} style={{ width: '100%', marginTop: '16px', padding: '14px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '52px', opacity: creating ? 0.6 : 1 }}>
               {creating ? 'Wird angelegt...' : 'Turnier anlegen & weiter →'}
             </button>
@@ -1548,11 +1569,13 @@ function TournamentExtendedTab() {
                   <input type="text" value={playerForm.nachname} onChange={e => setPlayerForm({...playerForm, nachname: e.target.value})} placeholder="Nachname *" required style={{ ...inputStyle, padding: '10px 12px' }} />
                 </div>
                 <div style={{ display: 'flex', gap: '6px' }}>
+                  {(newTournament?.use_seed || createForm.use_seed) && (
                   <div style={{ display: 'flex', alignItems: 'center', gap: '4px', background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', borderRadius: '8px', padding: '4px 8px' }}>
                     <button type="button" onClick={() => setPlayerForm({...playerForm, seed: String(Math.max(1, (parseInt(playerForm.seed) || 1) - 1))})} style={{ minHeight: '44px', minWidth: '36px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '6px', fontWeight: 'bold', fontSize: '18px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif' }}>−</button>
                     <span style={{ minWidth: '32px', textAlign: 'center', color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '14px' }}>{playerForm.seed || '—'}</span>
                     <button type="button" onClick={() => setPlayerForm({...playerForm, seed: String((parseInt(playerForm.seed) || 0) + 1)})} style={{ minHeight: '44px', minWidth: '36px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '6px', fontWeight: 'bold', fontSize: '18px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif' }}>+</button>
                   </div>
+                )}
                   <button type="submit" disabled={!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()} style={{ flex: 1, padding: '10px 16px', borderRadius: '8px', background: 'var(--pe-blue-deep)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px', opacity: (!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()) ? 0.5 : 1 }}>+ Spieler hinzufügen</button>
                 </div>
               </form>
@@ -1573,7 +1596,7 @@ function TournamentExtendedTab() {
                 <div key={p.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 12px', borderRadius: '8px', background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
                   <span style={{ color: 'var(--pe-text)', fontWeight: 'bold' }}>{p.name}</span>
                   <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-                    {p.seed && <span style={{ color: 'var(--pe-text-muted)', fontSize: '12px' }}>#{p.seed}</span>}
+                    {(newTournament?.use_seed || createForm.use_seed) && p.seed && <span style={{ color: 'var(--pe-text-muted)', fontSize: '12px' }}>#{p.seed}</span>}
                     <button onClick={() => deletePlayer(p.id)} style={{ ...btnSmall, padding: '4px 10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-danger)', minHeight: '30px' }}>✕</button>
                   </div>
                 </div>
@@ -1761,7 +1784,7 @@ function TournamentExtendedTab() {
       {/* Header */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
         <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px' }}>Turniere</h2>
-        <button onClick={() => { setWizardStep(1); setNewTournament(null); setCreateForm({ name: '', date: '', start_time: '', format: '501', checkout: 'double_out' }); }} style={{ padding: '10px 20px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
+        <button onClick={() => { setWizardStep(1); setNewTournament(null); setCreateForm({ name: '', date: '', start_time: '', format: '501', checkout: 'double_out', use_seed: false }); }} style={{ padding: '10px 20px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
           + Neues Turnier
         </button>
       </div>
@@ -1815,6 +1838,11 @@ function TournamentExtendedTab() {
             <span style={{ padding: '4px 10px', borderRadius: '8px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text-sub)', fontSize: '12px' }}>
               {selectedTournament.checkout === 'double_out' ? 'Double Out' : 'Single Out'}
             </span>
+            {selectedTournament.use_seed ? (
+              <span style={{ padding: '4px 10px', borderRadius: '8px', background: 'rgba(0,229,160,0.12)', border: '1px solid var(--pe-success)', color: 'var(--pe-success)', fontSize: '12px', fontWeight: 'bold' }}>
+                Seeding
+              </span>
+            ) : null}
             <span style={{ padding: '4px 10px', borderRadius: '8px', fontSize: '12px', fontWeight: 'bold', background: selectedTournament.status === 'active' ? 'var(--pe-success)' : selectedTournament.status === 'finished' ? 'var(--pe-border)' : 'var(--pe-blue-deep)', color: selectedTournament.status === 'active' ? '#000' : '#fff' }}>
               {selectedTournament.status === 'open' ? 'Offen' : selectedTournament.status === 'active' ? 'Aktiv' : 'Beendet'}
             </span>


### PR DESCRIPTION
## Summary

- **Database**: adds `use_seed BOOLEAN DEFAULT 0` column to `tournaments` table (schema.sql + migration alter-statement in db.js)
- **Backend**: `POST /api/tournaments` accepts `use_seed`, `PUT /api/tournaments/:id` allows updating it; `draw-groups` endpoint now performs a completely random Fisher-Yates shuffle when `use_seed=0`, or a seed-ranked snake-draft (nulls last) when `use_seed=1`
- **Frontend (wizard step 1)**: ON/OFF toggle labelled "Seeding verwenden?" with contextual hint text; stored in `createForm.use_seed`
- **Frontend (wizard step 3)**: seed stepper (+/− buttons) and seed badge in the player list are hidden when `use_seed` is false
- **Frontend (tournament list)**: "Seeding" badge shown next to format/checkout badges when `use_seed` is enabled

## Test plan

- [ ] Create a tournament with seeding OFF → no seed stepper in step 3 → draw-groups distributes players randomly
- [ ] Create a tournament with seeding ON → seed stepper visible → draw-groups places top seeds in different groups (snake draft)
- [ ] Verify "Seeding" badge appears in tournament detail view for seeded tournament
- [ ] Verify existing tournaments (use_seed=0 default) are unaffected
- [ ] Confirm `PUT /api/tournaments/:id` with `use_seed: 1` updates the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)