### PR TITLE
fix: remove start_time feature

### DIFF
--- a/backend/src/db/db.js
+++ b/backend/src/db/db.js
@@ -89,7 +89,6 @@ function initialize() {
     "ALTER TABLE players ADD COLUMN walkon_start INTEGER DEFAULT 0",
     "ALTER TABLE players ADD COLUMN walkon_duration INTEGER DEFAULT 30",
     "ALTER TABLE guests ADD COLUMN active BOOLEAN DEFAULT 1",
-    "ALTER TABLE tournaments ADD COLUMN start_time TEXT",
     "ALTER TABLE tournaments ADD COLUMN use_seed BOOLEAN DEFAULT 0",
   ];
 

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -11,7 +11,6 @@ CREATE TABLE IF NOT EXISTS tournaments (
   id INTEGER PRIMARY KEY,
   name TEXT NOT NULL,
   date DATE,
-  start_time TEXT,
   format TEXT NOT NULL,
   checkout TEXT NOT NULL,
   status TEXT DEFAULT 'open',

--- a/backend/src/routes/tournaments.js
+++ b/backend/src/routes/tournaments.js
@@ -14,7 +14,7 @@ router.get('/', (req, res) => {
 
 // POST /api/tournaments (Admin)
 router.post('/', verifyToken, requireFields(['name', 'format', 'checkout']), (req, res) => {
-  const { name, date, start_time, format, checkout, use_seed } = req.body;
+  const { name, date, format, checkout, use_seed } = req.body;
 
   if (!['501', '301'].includes(format)) {
     return res.status(400).json({ error: 'Format must be 501 or 301' });
@@ -23,16 +23,11 @@ router.post('/', verifyToken, requireFields(['name', 'format', 'checkout']), (re
     return res.status(400).json({ error: 'Checkout must be single_out or double_out' });
   }
 
-  // Validate start_time format HH:MM if provided
-  if (start_time && !/^\d{2}:\d{2}$/.test(start_time)) {
-    return res.status(400).json({ error: 'start_time must be in HH:MM format' });
-  }
-
   const useSeedValue = use_seed ? 1 : 0;
 
   const result = db.prepare(
-    'INSERT INTO tournaments (name, date, start_time, format, checkout, use_seed) VALUES (?, ?, ?, ?, ?, ?)'
-  ).run(name, date || null, start_time || null, format, checkout, useSeedValue);
+    'INSERT INTO tournaments (name, date, format, checkout, use_seed) VALUES (?, ?, ?, ?, ?)'
+  ).run(name, date || null, format, checkout, useSeedValue);
 
   const tournament = db.prepare('SELECT * FROM tournaments WHERE id = ?').get(result.lastInsertRowid);
   auditLog(req, 'tournament', 'CREATE', `Turnier "${name}" angelegt`, tournament.id);
@@ -93,20 +88,13 @@ router.put('/:id', verifyToken, (req, res) => {
   const tournament = db.prepare('SELECT * FROM tournaments WHERE id = ?').get(req.params.id);
   if (!tournament) return res.status(404).json({ error: 'Tournament not found' });
 
-  const allowed = ['prelim_format','prelim_legs','qf_format','qf_legs','sf_format','sf_legs','final_format','final_legs','board_count','name','date','start_time','use_seed'];
+  const allowed = ['prelim_format','prelim_legs','qf_format','qf_legs','sf_format','sf_legs','final_format','final_legs','board_count','name','date','use_seed'];
   const updates = {};
   for (const key of allowed) {
     if (req.body[key] !== undefined) updates[key] = req.body[key];
   }
 
   if (Object.keys(updates).length === 0) return res.status(400).json({ error: 'No valid fields to update' });
-
-  // Validate start_time format HH:MM if provided as non-empty string
-  if (updates.start_time && !/^\d{2}:\d{2}$/.test(updates.start_time)) {
-    return res.status(400).json({ error: 'start_time must be in HH:MM format' });
-  }
-  // Allow clearing start_time by passing empty string → store as null
-  if (updates.start_time === '') updates.start_time = null;
 
   const setClauses = Object.keys(updates).map((k) => `${k} = ?`).join(', ');
   const values = [...Object.values(updates), req.params.id];
@@ -489,36 +477,16 @@ router.post('/:id/generate-group-schedule', requireAdminOrDirector, (req, res) =
     const startScore = parseInt(tournament.format) || 501;
     let totalCreated = 0;
 
-    // Calculate base datetime from tournament date + start_time
-    const gameDurationMinutes = parseInt(req.body.game_duration_minutes) || 20;
-    let baseDateTime = null;
-    if (tournament.date || tournament.start_time) {
-      const datePart = tournament.date || new Date().toISOString().substring(0, 10);
-      const timePart = tournament.start_time || '10:00';
-      const parsed = new Date(`${datePart}T${timePart}:00`);
-      if (!isNaN(parsed.getTime())) baseDateTime = parsed;
-    }
-
     const insertGames = db.transaction(() => {
-      const boardGameIndex = {};
       for (const [boardId, pairs] of Object.entries(boardGameList)) {
-        boardGameIndex[boardId] = 0;
         for (const [p1, p2] of pairs) {
           const gameResult = db.prepare(
             'INSERT INTO games (tournament_id, round, player1_id, player2_id, start_score, board_id, status) VALUES (?, 0, ?, ?, ?, ?, ?)'
           ).run(req.params.id, p1.id, p2.id, startScore, parseInt(boardId), 'pending');
 
-          const gameIdx = boardGameIndex[boardId]++;
-          let scheduledAt = null;
-          if (baseDateTime) {
-            const ms = gameIdx * gameDurationMinutes * 60 * 1000;
-            const gameTime = new Date(baseDateTime.getTime() + ms);
-            scheduledAt = gameTime.toISOString().replace('T', ' ').substring(0, 16);
-          }
-
           db.prepare(
             'INSERT INTO schedule (tournament_id, game_id, board_id, scheduled_at, status) VALUES (?, ?, ?, ?, ?)'
-          ).run(req.params.id, gameResult.lastInsertRowid, parseInt(boardId), scheduledAt, 'scheduled');
+          ).run(req.params.id, gameResult.lastInsertRowid, parseInt(boardId), null, 'scheduled');
 
           totalCreated++;
         }

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -253,11 +253,6 @@ function BoardsTab() {
                   <span className="text-sm" style={{ color: 'var(--pe-text)' }}>
                     {s.player1_name || 'TBD'} vs {s.player2_name || 'TBD'} — Board {s.board_number || '?'}
                   </span>
-                  {s.scheduled_at && (
-                    <span style={{ fontSize: '11px', color: 'var(--pe-cyan-bright)' }}>
-                      {s.scheduled_at.substring(11, 16)} Uhr
-                    </span>
-                  )}
                 </div>
                 <div className="flex gap-2">
                   <button onClick={() => handleActivate(s.id)} style={{ ...btnSmall, padding: '4px 12px', background: 'var(--pe-success)', color: '#000' }}>Start</button>
@@ -1225,7 +1220,7 @@ function TournamentExtendedTab() {
   const [numGroups, setNumGroups] = useState(4);
   const [creating, setCreating] = useState(false);
   const [newTournament, setNewTournament] = useState(null); // after step 1
-  const [createForm, setCreateForm] = useState({ name: '', date: '', start_time: '', format: '501', checkout: 'double_out', use_seed: false });
+  const [createForm, setCreateForm] = useState({ name: '', date: '', format: '501', checkout: 'double_out', use_seed: false });
   const [config, setConfig] = useState({
     prelim_format: '301_single_out', prelim_legs: '1',
     qf_format: '501_double_out',     qf_legs: '3',
@@ -1494,10 +1489,7 @@ function TournamentExtendedTab() {
             <p style={{ color: 'var(--pe-text-sub)', fontSize: '13px', marginBottom: '16px' }}>Gib dem Turnier einen Namen und optionales Datum.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
               <input type="text" value={createForm.name} onChange={e => setCreateForm({...createForm, name: e.target.value})} placeholder="Turniername *" required style={{ ...inputStyle, padding: '12px 14px' }} />
-              <div style={{ display: 'flex', gap: '8px' }}>
-                <input type="date" value={createForm.date} onChange={e => setCreateForm({...createForm, date: e.target.value})} style={{ ...inputStyle, flex: 1, padding: '12px 14px', cursor: 'pointer' }} />
-                <input type="time" value={createForm.start_time} onChange={e => setCreateForm({...createForm, start_time: e.target.value})} placeholder="Startzeit" title="Startzeit (für Spielplan)" style={{ ...inputStyle, width: '120px', padding: '12px 10px', cursor: 'pointer' }} />
-              </div>
+              <input type="date" value={createForm.date} onChange={e => setCreateForm({...createForm, date: e.target.value})} style={{ ...inputStyle, padding: '12px 14px', cursor: 'pointer' }} />
             </div>
             {/* Seeding toggle */}
             <div style={{ marginTop: '12px', padding: '12px 14px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)' }}>
@@ -1784,7 +1776,7 @@ function TournamentExtendedTab() {
       {/* Header */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
         <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px' }}>Turniere</h2>
-        <button onClick={() => { setWizardStep(1); setNewTournament(null); setCreateForm({ name: '', date: '', start_time: '', format: '501', checkout: 'double_out', use_seed: false }); }} style={{ padding: '10px 20px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
+        <button onClick={() => { setWizardStep(1); setNewTournament(null); setCreateForm({ name: '', date: '', format: '501', checkout: 'double_out', use_seed: false }); }} style={{ padding: '10px 20px', borderRadius: '10px', background: 'var(--pe-gradient)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
           + Neues Turnier
         </button>
       </div>
@@ -1813,7 +1805,7 @@ function TournamentExtendedTab() {
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
               <div>
                 <div style={{ color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '16px' }}>{t.name}</div>
-                {(t.date || t.start_time) && <div style={{ color: 'var(--pe-text-muted)', fontSize: '13px', marginTop: '2px' }}>{t.date || ''}{t.date && t.start_time ? ' ' : ''}{t.start_time ? `${t.start_time} Uhr` : ''}</div>}
+                {t.date && <div style={{ color: 'var(--pe-text-muted)', fontSize: '13px', marginTop: '2px' }}>{t.date}</div>}
               </div>
               <span style={{ padding: '3px 10px', borderRadius: '12px', fontSize: '12px', fontWeight: 'bold', background: t.status === 'active' ? 'var(--pe-success)' : t.status === 'finished' ? 'var(--pe-border)' : 'var(--pe-blue-deep)', color: t.status === 'active' ? '#000' : '#fff' }}>
                 {t.status === 'open' ? 'Offen' : t.status === 'active' ? 'Aktiv' : 'Beendet'}
@@ -1848,26 +1840,6 @@ function TournamentExtendedTab() {
             </span>
           </div>
 
-          {/* Start time editor — shown for open/active tournaments */}
-          {selectedTournament.status !== 'finished' && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
-              <label style={{ color: 'var(--pe-text-sub)', fontSize: '12px', whiteSpace: 'nowrap' }}>Startzeit:</label>
-              <input
-                type="time"
-                defaultValue={selectedTournament.start_time || ''}
-                key={selectedTournament.id}
-                onBlur={async (e) => {
-                  const val = e.target.value;
-                  try {
-                    await api.put(`/tournaments/${selectedId}`, { start_time: val });
-                    await loadTournaments();
-                  } catch (err) { alert(err.message || 'Startzeit konnte nicht gespeichert werden'); }
-                }}
-                style={{ background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '8px', padding: '6px 10px', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: '13px', cursor: 'pointer', width: '120px' }}
-              />
-              <span style={{ color: 'var(--pe-text-muted)', fontSize: '11px' }}>(für Spielplan-Zeitslots)</span>
-            </div>
-          )}
 
           {/* Groups section — shown if group draw done or groups exist */}
           {(selectedTournament.group_draw_done || groups.length > 0) && groups.length > 0 && (


### PR DESCRIPTION
## Summary

- Remove `start_time TEXT` column from `tournaments` table definition in `schema.sql`
- Remove `ALTER TABLE tournaments ADD COLUMN start_time TEXT` from the migration alter statements in `db.js`
- Remove `start_time` from POST and PUT tournament route handlers, including HH:MM validation and empty-string-to-null normalization
- Remove all `start_time`/`baseDatetime`/`gameDurationMinutes`/`scheduledAt` time-slot calculation from the `generate-group-schedule` endpoint — schedule entries are still inserted but with `scheduled_at = null`
- Remove `start_time` from `createForm` state, wizard step 1 time input, tournament list card display, inline "Startzeit" editor, and boards tab `scheduled_at` time display in `AdminPage.jsx`

## Test plan

- [ ] Create a new tournament — no time input visible, creation succeeds
- [ ] Tournament list cards show only the date (no time suffix)
- [ ] Tournament detail view no longer shows "Startzeit:" inline editor
- [ ] Generate group schedule — succeeds without errors, `scheduled_at` is `null` in DB
- [ ] Boards tab schedule list shows game entries without cyan time labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)