### PR TITLE
fix: scope board display and assignment to active tournament

### DIFF
--- a/backend/src/routes/games.js
+++ b/backend/src/routes/games.js
@@ -783,6 +783,10 @@ router.put('/:id/assign-board', requireAuth, (req, res) => {
   if (board_id) {
     const board = db.prepare('SELECT * FROM boards WHERE id = ?').get(board_id);
     if (!board) return res.status(404).json({ error: 'Scheibe nicht gefunden' });
+    // Ensure board belongs to the same tournament as the game
+    if (board.tournament_id !== null && game.tournament_id !== null && board.tournament_id !== game.tournament_id) {
+      return res.status(400).json({ error: 'Scheibe gehört nicht zum Turnier des Spiels' });
+    }
   }
   db.prepare('UPDATE games SET board_id = ? WHERE id = ?').run(board_id || null, req.params.id);
   res.json({ success: true, game_id: req.params.id, board_id: board_id || null });

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -964,7 +964,8 @@ function TournamentDirectorTab() {
     setActiveTournament(active);
     if (active) {
       // Only show boards belonging to the active tournament
-      const tournamentBoards = allBoards.filter(b => b.tournament_id === active.id);
+      // Use loose equality to handle potential type mismatch between SQLite INTEGER and JS number
+      const tournamentBoards = allBoards.filter(b => b.tournament_id == active.id);
       setBoards(tournamentBoards);
       const detail = await api.get(`/tournaments/${active.id}`).catch(() => null);
       if (detail?.games) setGames(detail.games.filter(g => ['pending','bulloff','active'].includes(g.status) && g.player1_name));

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -40,9 +40,9 @@ export default function HomePage() {
         const tournamentDetail = await api.get(`/tournaments/${active.id}`);
         setPlayers(tournamentDetail.players || []);
 
-        // NEU: Boards laden und aktuelle Spiele pro Board
+        // NEU: Boards laden und aktuelle Spiele pro Board (gefiltert nach aktivem Turnier)
         try {
-          const boardList = await api.get('/boards');
+          const boardList = await api.get(`/boards?tournament_id=${active.id}`);
           setBoards(boardList);
 
           const gameMap = {};


### PR DESCRIPTION
## Summary

- **DirectorTab (AdminPage.jsx):** Changed strict `===` to loose `==` when filtering boards by `tournament_id` to guard against potential type mismatch between SQLite `INTEGER` and JavaScript `number` — prevents the board column list from appearing empty when type coercion is needed.
- **HomePage.jsx:** Board list now fetches `GET /api/boards?tournament_id=<active>` instead of `GET /api/boards` (all boards). This ensures the public Scheiben tab only shows boards that belong to the current active tournament, not leftover boards from previous events.
- **games.js (`PUT /games/:id/assign-board`):** Added tournament ownership validation — rejects attempts to assign a game to a board that belongs to a different tournament, preventing cross-tournament contamination in the director view.

## Test plan
- [ ] Start a tournament, create boards for it, verify DirectorTab shows only those boards
- [ ] Verify HomePage Scheiben tab only shows boards for the active tournament
- [ ] Try to drag/assign a game to a board from a different tournament — expect a 400 error
- [ ] RefereePage (`/referee/:boardId`) still loads current game correctly per board
- [ ] CurrentGameView (`/board/:boardId`) still displays live game data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)