### PR TITLE
fix: resolve referee URL by board number for active tournament

### DIFF
--- a/backend/src/routes/boards.js
+++ b/backend/src/routes/boards.js
@@ -48,6 +48,20 @@ router.post('/', requireAdmin, (req, res) => {
   });
 });
 
+// Resolve a board by its display number for the currently active tournament
+router.get('/by-number/:number', (req, res) => {
+  const number = parseInt(req.params.number, 10);
+  if (isNaN(number)) return res.status(400).json({ error: 'Invalid board number' });
+
+  const activeTournament = db.prepare("SELECT id FROM tournaments WHERE status = 'active' LIMIT 1").get();
+  if (!activeTournament) return res.status(404).json({ error: 'No active tournament' });
+
+  const board = db.prepare('SELECT * FROM boards WHERE number = ? AND tournament_id = ?').get(number, activeTournament.id);
+  if (!board) return res.status(404).json({ error: 'Board not found' });
+
+  res.json(board);
+});
+
 // Aktuelles Spiel auf einer Scheibe — nur laufende Partien (bulloff oder active)
 router.get('/:id/current-game', (req, res) => {
   const board = db.prepare('SELECT * FROM boards WHERE id = ?').get(req.params.id);

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1089,11 +1089,15 @@ function TournamentDirectorTab() {
               }}
             >
               {/* Board header */}
-              <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--pe-border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: activeGame ? 'rgba(30,127,235,0.12)' : 'transparent' }}>
-                <span style={{ fontWeight: 'bold', color: 'var(--pe-text)', fontSize: '15px' }}>
+              <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--pe-border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px', background: activeGame ? 'rgba(30,127,235,0.12)' : 'transparent' }}>
+                <span style={{ fontWeight: 'bold', color: 'var(--pe-text)', fontSize: '15px', flex: 1, minWidth: 0 }}>
                   Board {board.number}{board.name ? ` — ${board.name}` : ''}{board.is_final ? ' ★' : ''}
                 </span>
-                <span style={{ fontSize: '11px', padding: '3px 10px', borderRadius: '10px', fontWeight: 'bold', background: activeGame ? 'var(--pe-success)' : hasGames ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)', color: activeGame ? '#000' : 'var(--pe-text)' }}>
+                <a href={`/referee/${board.number}`} target="_blank" rel="noopener noreferrer"
+                   style={{ fontSize: '11px', color: 'var(--pe-cyan-bright)', textDecoration: 'none', padding: '3px 8px', borderRadius: '6px', background: 'rgba(0,184,255,0.1)', border: '1px solid rgba(0,184,255,0.2)', whiteSpace: 'nowrap', flexShrink: 0 }}>
+                  ↗ Referee
+                </a>
+                <span style={{ fontSize: '11px', padding: '3px 10px', borderRadius: '10px', fontWeight: 'bold', background: activeGame ? 'var(--pe-success)' : hasGames ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)', color: activeGame ? '#000' : 'var(--pe-text)', whiteSpace: 'nowrap', flexShrink: 0 }}>
                   {activeGame ? 'Aktiv' : hasGames ? `${boardGames.length} Spiele` : isDropTarget || (isTapTarget && !activeGame) ? 'Hier zuweisen' : 'Frei'}
                 </span>
               </div>

--- a/frontend/src/pages/RefereePage.jsx
+++ b/frontend/src/pages/RefereePage.jsx
@@ -553,7 +553,7 @@ function getPrevRoundLastThrow(liveData) {
 // ══════════════════════════════════════════════════════════════════════════
 // ── TABLET LAYOUT ─────────────────────────────────────────────────────────
 // ══════════════════════════════════════════════════════════════════════════
-function TabletLayout({ boardId, token, onLogout, selectedGameId, setSelectedGameId, liveData, fetchLive, modifier, setModifier, submitting, throwSegment, undoThrow }) {
+function TabletLayout({ boardId, boardNumber, token, onLogout, selectedGameId, setSelectedGameId, liveData, fetchLive, modifier, setModifier, submitting, throwSegment, undoThrow }) {
   const { game, player1, player2, current_round_throws = [] } = liveData || {};
   const currentThrowerId = game?.current_turn || game?.bull_winner_id;
 
@@ -582,7 +582,7 @@ function TabletLayout({ boardId, token, onLogout, selectedGameId, setSelectedGam
         {/* Header */}
         <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--pe-border)', display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
           <img src="/logo.jpeg" alt="" style={{ height: '32px' }} />
-          <span style={{ fontWeight: 'bold', color: 'var(--pe-cyan-bright)', fontSize: '14px', flex: 1 }}>Board {boardId}</span>
+          <span style={{ fontWeight: 'bold', color: 'var(--pe-cyan-bright)', fontSize: '14px', flex: 1 }}>Board {boardNumber}</span>
           <Link to="/" style={{ color: 'var(--pe-text-muted)', textDecoration: 'none', fontSize: '18px', lineHeight: 1 }}>←</Link>
           <button onClick={onLogout} style={btn({ padding: '4px 10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-danger)', fontSize: '12px', minHeight: '30px' })}>
             Abmelden
@@ -738,7 +738,7 @@ function TabletLayout({ boardId, token, onLogout, selectedGameId, setSelectedGam
 // ══════════════════════════════════════════════════════════════════════════
 // ── PHONE LAYOUT ──────────────────────────────────────────────────────────
 // ══════════════════════════════════════════════════════════════════════════
-function PhoneLayout({ boardId, token, onLogout, selectedGameId, setSelectedGameId, liveData, fetchLive, modifier, setModifier, submitting, throwSegment, undoThrow }) {
+function PhoneLayout({ boardId, boardNumber, token, onLogout, selectedGameId, setSelectedGameId, liveData, fetchLive, modifier, setModifier, submitting, throwSegment, undoThrow }) {
   const { game, player1, player2, current_round_throws = [] } = liveData || {};
   const currentThrowerId = game?.current_turn || game?.bull_winner_id;
 
@@ -751,7 +751,7 @@ function PhoneLayout({ boardId, token, onLogout, selectedGameId, setSelectedGame
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '14px' }}>
         <Link to="/" style={{ color: 'var(--pe-text-muted)', textDecoration: 'none', fontSize: '20px' }}>←</Link>
         <img src="/logo.jpeg" alt="" style={{ height: '32px' }} />
-        <span style={{ color: 'var(--pe-text-muted)', fontSize: '13px', fontWeight: 'bold', marginLeft: 'auto' }}>Board {boardId}</span>
+        <span style={{ color: 'var(--pe-text-muted)', fontSize: '13px', fontWeight: 'bold', marginLeft: 'auto' }}>Board {boardNumber}</span>
         {selectedGameId && game && game.status !== 'active' && (
           <button onClick={goToPicker} style={btn({ padding: '5px 10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-warning)', fontSize: '11px', minHeight: '30px', borderColor: 'var(--pe-warning)' })}>
             Andere Partie
@@ -876,8 +876,10 @@ function PhoneLayout({ boardId, token, onLogout, selectedGameId, setSelectedGame
 // ── MAIN PAGE ─────────────────────────────────────────────────────────────
 // ══════════════════════════════════════════════════════════════════════════
 export default function RefereePage() {
-  const { boardId } = useParams();
+  const { boardId: boardNumber } = useParams();
   const [token, setToken] = useState(localStorage.getItem('token'));
+  const [resolvedBoardId, setResolvedBoardId] = useState(null);
+  const [boardNotFound, setBoardNotFound] = useState(false);
   const [selectedGameId, setSelectedGameId] = useState(null);
   const [liveData, setLiveData] = useState(null);
   const [modifier, setModifier] = useState('Single');
@@ -886,11 +888,21 @@ export default function RefereePage() {
 
   if (!token) return <RefereeLogin onLogin={setToken} />;
 
+  // Resolve board number → internal board ID for the active tournament
   useEffect(() => {
-    api.get(`/boards/${boardId}/current-game`).then(data => {
+    setResolvedBoardId(null);
+    setBoardNotFound(false);
+    api.get(`/boards/by-number/${boardNumber}`)
+      .then(board => setResolvedBoardId(board.id))
+      .catch(() => setBoardNotFound(true));
+  }, [boardNumber]);
+
+  useEffect(() => {
+    if (!resolvedBoardId) return;
+    api.get(`/boards/${resolvedBoardId}/current-game`).then(data => {
       if (data?.game_id) setSelectedGameId(data.game_id);
     }).catch(() => {});
-  }, [boardId]);
+  }, [resolvedBoardId]);
 
   const fetchLive = useCallback(async () => {
     if (!selectedGameId) return;
@@ -947,8 +959,29 @@ export default function RefereePage() {
 
   const onLogout = () => { localStorage.removeItem('token'); setToken(null); };
 
+  if (boardNotFound) {
+    return (
+      <div style={{ minHeight: '100vh', background: 'var(--pe-bg)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+        <div style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-danger)', borderRadius: '12px', padding: '32px', maxWidth: '400px', width: '100%', textAlign: 'center' }}>
+          <div style={{ color: 'var(--pe-danger)', fontWeight: 'bold', fontSize: '18px', marginBottom: '12px' }}>Board {boardNumber} nicht gefunden</div>
+          <div style={{ color: 'var(--pe-text-sub)', fontSize: '14px' }}>
+            Bitte prüfe ob ein Turnier aktiv ist und Board {boardNumber} existiert.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!resolvedBoardId) {
+    return (
+      <div style={{ minHeight: '100vh', background: 'var(--pe-bg)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+        <div style={{ color: 'var(--pe-text-sub)', fontSize: '16px' }}>Board wird geladen…</div>
+      </div>
+    );
+  }
+
   const shared = {
-    boardId, token, onLogout,
+    boardId: resolvedBoardId, boardNumber, token, onLogout,
     selectedGameId, setSelectedGameId,
     liveData, fetchLive,
     modifier, setModifier,


### PR DESCRIPTION
## Summary

- **Backend:** adds `GET /api/boards/by-number/:number` in `boards.js`, registered before any `/:id` route, so it cannot be captured by the ID param. Looks up the board with the given display number scoped to the currently active tournament.
- **Frontend (RefereePage):** the URL param is now treated as a board *number*. On mount it calls the new endpoint to resolve the number to the internal board ID. Shows a loading screen while resolving and a clear error screen (`Board {n} nicht gefunden. Bitte prüfe ob ein Turnier aktiv ist und Board {n} existiert.`) on 404. All API calls use the resolved internal ID; display text continues to show the human-readable number.
- **Frontend (AdminPage / DirectorTab):** each board card header now contains a `↗ Referee` link that opens `/referee/<board.number>` in a new tab, making it easy to hand off a board to a referee.

## Test plan

- [ ] Start a tournament and auto-generate boards (IDs may be 5, 6, 7, … not 1, 2, 3)
- [ ] Navigate to `/referee/1` — should resolve to the correct internal board and show Board 1
- [ ] Navigate to `/referee/99` — should show the "Board 99 nicht gefunden" error screen
- [ ] Navigate to `/referee/1` when no tournament is active — should show the error screen
- [ ] In AdminPage → Turnierleiter tab, confirm each board card shows the `↗ Referee` link and it opens the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)