### PR TITLE
fix: remove obsolete schedule section from boards tab

### DIFF
--- a/backend/src/routes/boards.js
+++ b/backend/src/routes/boards.js
@@ -48,6 +48,20 @@ router.post('/', requireAdmin, (req, res) => {
   });
 });
 
+// Resolve a board by its display number for the currently active tournament
+router.get('/by-number/:number', (req, res) => {
+  const number = parseInt(req.params.number, 10);
+  if (isNaN(number)) return res.status(400).json({ error: 'Invalid board number' });
+
+  const activeTournament = db.prepare("SELECT id FROM tournaments WHERE status = 'active' LIMIT 1").get();
+  if (!activeTournament) return res.status(404).json({ error: 'No active tournament' });
+
+  const board = db.prepare('SELECT * FROM boards WHERE number = ? AND tournament_id = ?').get(number, activeTournament.id);
+  if (!board) return res.status(404).json({ error: 'Board not found' });
+
+  res.json(board);
+});
+
 // Aktuelles Spiel auf einer Scheibe — nur laufende Partien (bulloff oder active)
 router.get('/:id/current-game', (req, res) => {
   const board = db.prepare('SELECT * FROM boards WHERE id = ?').get(req.params.id);

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1089,11 +1089,15 @@ function TournamentDirectorTab() {
               }}
             >
               {/* Board header */}
-              <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--pe-border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: activeGame ? 'rgba(30,127,235,0.12)' : 'transparent' }}>
-                <span style={{ fontWeight: 'bold', color: 'var(--pe-text)', fontSize: '15px' }}>
+              <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--pe-border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px', background: activeGame ? 'rgba(30,127,235,0.12)' : 'transparent' }}>
+                <span style={{ fontWeight: 'bold', color: 'var(--pe-text)', fontSize: '15px', flex: 1, minWidth: 0 }}>
                   Board {board.number}{board.name ? ` — ${board.name}` : ''}{board.is_final ? ' ★' : ''}
                 </span>
-                <span style={{ fontSize: '11px', padding: '3px 10px', borderRadius: '10px', fontWeight: 'bold', background: activeGame ? 'var(--pe-success)' : hasGames ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)', color: activeGame ? '#000' : 'var(--pe-text)' }}>
+                <a href={`/referee/${board.number}`} target="_blank" rel="noopener noreferrer"
+                   style={{ fontSize: '11px', color: 'var(--pe-cyan-bright)', textDecoration: 'none', padding: '3px 8px', borderRadius: '6px', background: 'rgba(0,184,255,0.1)', border: '1px solid rgba(0,184,255,0.2)', whiteSpace: 'nowrap', flexShrink: 0 }}>
+                  ↗ Referee
+                </a>
+                <span style={{ fontSize: '11px', padding: '3px 10px', borderRadius: '10px', fontWeight: 'bold', background: activeGame ? 'var(--pe-success)' : hasGames ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)', color: activeGame ? '#000' : 'var(--pe-text)', whiteSpace: 'nowrap', flexShrink: 0 }}>
                   {activeGame ? 'Aktiv' : hasGames ? `${boardGames.length} Spiele` : isDropTarget || (isTapTarget && !activeGame) ? 'Hier zuweisen' : 'Frei'}
                 </span>
               </div>

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -106,7 +106,6 @@ function BoardsTab() {
   const [boards, setBoards] = useState([]);
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState({ name: '' });
-  const [schedule, setSchedule] = useState([]);
 
   // Load tournaments on mount, default to active or first
   useEffect(() => {
@@ -121,7 +120,6 @@ function BoardsTab() {
   const loadBoards = () => {
     if (!selectedTournamentId) return;
     api.get(`/boards?tournament_id=${selectedTournamentId}`).then(setBoards).catch(() => {});
-    api.get('/schedule').then(data => setSchedule(Array.isArray(data) ? data : [])).catch(() => setSchedule([]));
   };
 
   useEffect(() => { loadBoards(); }, [selectedTournamentId]);
@@ -134,24 +132,6 @@ function BoardsTab() {
       await api.post('/boards', { number: nextNumber, name: form.name, tournament_id: parseInt(selectedTournamentId, 10) });
       setForm({ name: '' });
       setShowForm(false);
-      loadBoards();
-    } catch (err) {
-      alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen');
-    }
-  };
-
-  const handleSkip = async (scheduleId) => {
-    try {
-      await api.put(`/schedule/${scheduleId}/skip`);
-      loadBoards();
-    } catch (err) {
-      alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen');
-    }
-  };
-
-  const handleActivate = async (scheduleId) => {
-    try {
-      await api.put(`/schedule/${scheduleId}/activate`);
       loadBoards();
     } catch (err) {
       alert(err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen');
@@ -243,26 +223,6 @@ function BoardsTab() {
         ))}
       </div>
 
-      {schedule.length > 0 && (
-        <div className="mt-6">
-          <h3 className="text-sm font-bold mb-3" style={{ color: 'var(--pe-text-sub)' }}>SPIELPLAN</h3>
-          <div className="space-y-2">
-            {schedule.map((s) => (
-              <div key={s.id} className="p-3 rounded-lg flex justify-between items-center" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                  <span className="text-sm" style={{ color: 'var(--pe-text)' }}>
-                    {s.player1_name || 'TBD'} vs {s.player2_name || 'TBD'} — Board {s.board_number || '?'}
-                  </span>
-                </div>
-                <div className="flex gap-2">
-                  <button onClick={() => handleActivate(s.id)} style={{ ...btnSmall, padding: '4px 12px', background: 'var(--pe-success)', color: '#000' }}>Start</button>
-                  <button onClick={() => handleSkip(s.id)} style={{ ...btnSmall, padding: '4px 12px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-warning)' }}>Skip</button>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/pages/RefereePage.jsx
+++ b/frontend/src/pages/RefereePage.jsx
@@ -553,7 +553,7 @@ function getPrevRoundLastThrow(liveData) {
 // ══════════════════════════════════════════════════════════════════════════
 // ── TABLET LAYOUT ─────────────────────────────────────────────────────────
 // ══════════════════════════════════════════════════════════════════════════
-function TabletLayout({ boardId, token, onLogout, selectedGameId, setSelectedGameId, liveData, fetchLive, modifier, setModifier, submitting, throwSegment, undoThrow }) {
+function TabletLayout({ boardId, boardNumber, token, onLogout, selectedGameId, setSelectedGameId, liveData, fetchLive, modifier, setModifier, submitting, throwSegment, undoThrow }) {
   const { game, player1, player2, current_round_throws = [] } = liveData || {};
   const currentThrowerId = game?.current_turn || game?.bull_winner_id;
 
@@ -582,7 +582,7 @@ function TabletLayout({ boardId, token, onLogout, selectedGameId, setSelectedGam
         {/* Header */}
         <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--pe-border)', display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
           <img src="/logo.jpeg" alt="" style={{ height: '32px' }} />
-          <span style={{ fontWeight: 'bold', color: 'var(--pe-cyan-bright)', fontSize: '14px', flex: 1 }}>Board {boardId}</span>
+          <span style={{ fontWeight: 'bold', color: 'var(--pe-cyan-bright)', fontSize: '14px', flex: 1 }}>Board {boardNumber}</span>
           <Link to="/" style={{ color: 'var(--pe-text-muted)', textDecoration: 'none', fontSize: '18px', lineHeight: 1 }}>←</Link>
           <button onClick={onLogout} style={btn({ padding: '4px 10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-danger)', fontSize: '12px', minHeight: '30px' })}>
             Abmelden
@@ -738,7 +738,7 @@ function TabletLayout({ boardId, token, onLogout, selectedGameId, setSelectedGam
 // ══════════════════════════════════════════════════════════════════════════
 // ── PHONE LAYOUT ──────────────────────────────────────────────────────────
 // ══════════════════════════════════════════════════════════════════════════
-function PhoneLayout({ boardId, token, onLogout, selectedGameId, setSelectedGameId, liveData, fetchLive, modifier, setModifier, submitting, throwSegment, undoThrow }) {
+function PhoneLayout({ boardId, boardNumber, token, onLogout, selectedGameId, setSelectedGameId, liveData, fetchLive, modifier, setModifier, submitting, throwSegment, undoThrow }) {
   const { game, player1, player2, current_round_throws = [] } = liveData || {};
   const currentThrowerId = game?.current_turn || game?.bull_winner_id;
 
@@ -751,7 +751,7 @@ function PhoneLayout({ boardId, token, onLogout, selectedGameId, setSelectedGame
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '14px' }}>
         <Link to="/" style={{ color: 'var(--pe-text-muted)', textDecoration: 'none', fontSize: '20px' }}>←</Link>
         <img src="/logo.jpeg" alt="" style={{ height: '32px' }} />
-        <span style={{ color: 'var(--pe-text-muted)', fontSize: '13px', fontWeight: 'bold', marginLeft: 'auto' }}>Board {boardId}</span>
+        <span style={{ color: 'var(--pe-text-muted)', fontSize: '13px', fontWeight: 'bold', marginLeft: 'auto' }}>Board {boardNumber}</span>
         {selectedGameId && game && game.status !== 'active' && (
           <button onClick={goToPicker} style={btn({ padding: '5px 10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-warning)', fontSize: '11px', minHeight: '30px', borderColor: 'var(--pe-warning)' })}>
             Andere Partie
@@ -876,8 +876,10 @@ function PhoneLayout({ boardId, token, onLogout, selectedGameId, setSelectedGame
 // ── MAIN PAGE ─────────────────────────────────────────────────────────────
 // ══════════════════════════════════════════════════════════════════════════
 export default function RefereePage() {
-  const { boardId } = useParams();
+  const { boardId: boardNumber } = useParams();
   const [token, setToken] = useState(localStorage.getItem('token'));
+  const [resolvedBoardId, setResolvedBoardId] = useState(null);
+  const [boardNotFound, setBoardNotFound] = useState(false);
   const [selectedGameId, setSelectedGameId] = useState(null);
   const [liveData, setLiveData] = useState(null);
   const [modifier, setModifier] = useState('Single');
@@ -886,11 +888,21 @@ export default function RefereePage() {
 
   if (!token) return <RefereeLogin onLogin={setToken} />;
 
+  // Resolve board number → internal board ID for the active tournament
   useEffect(() => {
-    api.get(`/boards/${boardId}/current-game`).then(data => {
+    setResolvedBoardId(null);
+    setBoardNotFound(false);
+    api.get(`/boards/by-number/${boardNumber}`)
+      .then(board => setResolvedBoardId(board.id))
+      .catch(() => setBoardNotFound(true));
+  }, [boardNumber]);
+
+  useEffect(() => {
+    if (!resolvedBoardId) return;
+    api.get(`/boards/${resolvedBoardId}/current-game`).then(data => {
       if (data?.game_id) setSelectedGameId(data.game_id);
     }).catch(() => {});
-  }, [boardId]);
+  }, [resolvedBoardId]);
 
   const fetchLive = useCallback(async () => {
     if (!selectedGameId) return;
@@ -947,8 +959,29 @@ export default function RefereePage() {
 
   const onLogout = () => { localStorage.removeItem('token'); setToken(null); };
 
+  if (boardNotFound) {
+    return (
+      <div style={{ minHeight: '100vh', background: 'var(--pe-bg)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+        <div style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-danger)', borderRadius: '12px', padding: '32px', maxWidth: '400px', width: '100%', textAlign: 'center' }}>
+          <div style={{ color: 'var(--pe-danger)', fontWeight: 'bold', fontSize: '18px', marginBottom: '12px' }}>Board {boardNumber} nicht gefunden</div>
+          <div style={{ color: 'var(--pe-text-sub)', fontSize: '14px' }}>
+            Bitte prüfe ob ein Turnier aktiv ist und Board {boardNumber} existiert.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!resolvedBoardId) {
+    return (
+      <div style={{ minHeight: '100vh', background: 'var(--pe-bg)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+        <div style={{ color: 'var(--pe-text-sub)', fontSize: '16px' }}>Board wird geladen…</div>
+      </div>
+    );
+  }
+
   const shared = {
-    boardId, token, onLogout,
+    boardId: resolvedBoardId, boardNumber, token, onLogout,
     selectedGameId, setSelectedGameId,
     liveData, fetchLive,
     modifier, setModifier,


### PR DESCRIPTION
Schedule management belongs in the Turnierleiter view, not the Boards admin tab. Removed the Spielplan section including schedule state, API call, and Skip/Start buttons.