### PR TITLE
feat: UI/UX overhaul — AppShell, TopBar, RoleTabs, role-based navigation (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ coverage/
 
 # Optional: Lockfiles behalten für reproduzierbare Builds
 # package-lock.json und yarn.lock werden NICHT ignoriert
+.superpowers/

--- a/docs/superpowers/plans/2026-03-15-ui-ux-overhaul.md
+++ b/docs/superpowers/plans/2026-03-15-ui-ux-overhaul.md
@@ -1,0 +1,873 @@
+# UI/UX Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a persistent AppShell with role-aware TopBar + tab navigation, unified back button pattern, and polished hover/transition animations across the DartEvent Manager PWA.
+
+**Architecture:** A new `AppShell` layout route wraps all shell pages (HomePage, TournamentPage, PlayerRegistrationPage, RefereePage, GastronomyPage) and renders a persistent `TopBar` + `RoleTabs`. Standalone pages (Admin, CurrentGameView, NFC, Orders, Cancel) remain unwrapped. Role is extracted from JWT on login and persisted in Zustand via localStorage.
+
+**Tech Stack:** React 18, react-router-dom v6, Zustand, TailwindCSS, PE Corporate Design tokens, pure CSS transitions (no animation library)
+
+**Spec:** `docs/superpowers/specs/2026-03-15-ui-ux-overhaul-design.md`
+
+---
+
+## Chunk 1: Foundation — Store & CSS Utilities
+
+Files touched:
+- Modify: `frontend/src/store/index.js`
+- Modify: `frontend/src/App.jsx` (extract `parseJwt` to shared util)
+- Create: `frontend/src/lib/parseJwt.js`
+- Modify: `frontend/src/index.css`
+
+---
+
+### Task 1: Extract `parseJwt` to shared utility
+
+`parseJwt` currently lives in `App.jsx` (line 18–22) but is needed in `store/index.js`. Extract it first so both files can import it.
+
+**Files:**
+- Create: `frontend/src/lib/parseJwt.js`
+- Modify: `frontend/src/App.jsx`
+
+- [ ] **Step 1: Create the lib directory and utility file**
+
+```bash
+mkdir -p /home/moritzwolf/dartsturnier/frontend/src/lib
+```
+
+```js
+// frontend/src/lib/parseJwt.js
+export function parseJwt(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch { return null; }
+}
+```
+
+- [ ] **Step 2: Update App.jsx to import instead of define**
+
+In `frontend/src/App.jsx`, replace lines 17–22:
+```js
+// Remove this block:
+// NEU: JWT Payload dekodieren (ohne Verifikation — Verifikation passiert im Backend)
+function parseJwt(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch { return null; }
+}
+```
+Add import at top of file (after existing imports):
+```js
+import { parseJwt } from './lib/parseJwt';
+```
+
+- [ ] **Step 3: Verify the app still starts**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend && npm run dev
+```
+Open `http://localhost:5173` — homepage must load without console errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/lib/parseJwt.js frontend/src/App.jsx
+git commit -m "refactor: extract parseJwt to shared utility"
+```
+
+---
+
+### Task 2: Add `role` to Zustand store
+
+**Files:**
+- Modify: `frontend/src/store/index.js`
+
+- [ ] **Step 1: Update the store**
+
+Replace the entire contents of `frontend/src/store/index.js`:
+
+```js
+import { create } from 'zustand';
+import { parseJwt } from '../lib/parseJwt';
+
+export const useStore = create((set) => ({
+  token: localStorage.getItem('token'),
+  role:  parseJwt(localStorage.getItem('token'))?.role ?? null,
+  admin: null,
+
+  setToken: (token) => {
+    localStorage.setItem('token', token);
+    set({ token, role: parseJwt(token)?.role ?? null });
+  },
+
+  logout: () => {
+    localStorage.removeItem('token');
+    set({ token: null, role: null, admin: null });
+  },
+
+  currentTournament: null,
+  setCurrentTournament: (t) => set({ currentTournament: t }),
+}));
+```
+
+- [ ] **Step 2: Verify role is populated after login**
+
+Start dev server. Open browser DevTools console. Log in as admin/referee/gastro. Run:
+```js
+window.__zustand = require('./store').useStore.getState()
+```
+Or simply check: after login, hard-refresh the page — the role pill (added in Task 5) should still appear.
+
+For now, verify no console errors on startup:
+```bash
+cd /home/moritzwolf/dartsturnier/frontend && npm run dev
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/store/index.js
+git commit -m "feat: add role field to Zustand store, persist from JWT via localStorage"
+```
+
+---
+
+### Task 3: Add global CSS animation utilities
+
+**Files:**
+- Modify: `frontend/src/index.css`
+
+- [ ] **Step 1: Append utilities to index.css**
+
+Open `frontend/src/index.css` and append at the end of the file:
+
+```css
+/* ─── PE Interactive Utilities ─────────────────────────────── */
+
+/* Hover: interactive cards (tournament, player, board cards) */
+.pe-card-interactive {
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+  cursor: pointer;
+}
+.pe-card-interactive:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 4px 20px rgba(0, 184, 255, 0.12);
+}
+.pe-card-interactive:active {
+  transform: scale(0.98);
+}
+
+/* Hover: buttons */
+.pe-btn {
+  transition: border-color 150ms ease, color 150ms ease,
+              background 150ms ease, transform 150ms ease;
+}
+.pe-btn:hover {
+  border-color: var(--pe-cyan-bright);
+  color: var(--pe-cyan-bright);
+}
+.pe-btn:active {
+  transform: scale(0.97);
+}
+
+/* Page entry animation (applied to shell page root divs) */
+.pe-page-enter {
+  animation: pe-fade-in 200ms ease forwards;
+}
+@keyframes pe-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Hide scrollbar utility (for RoleTabs) */
+.pe-scrollbar-hide {
+  scrollbar-width: none;       /* Firefox */
+  -ms-overflow-style: none;    /* IE/Edge */
+}
+.pe-scrollbar-hide::-webkit-scrollbar {
+  display: none;               /* Chrome/Safari */
+}
+```
+
+- [ ] **Step 2: Verify no CSS errors**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend && npm run dev
+```
+Open browser, check DevTools console — no CSS parse errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/index.css
+git commit -m "feat: add pe-card-interactive, pe-btn, pe-page-enter CSS utilities"
+```
+
+---
+
+## Chunk 2: New Components — TopBar, RoleTabs, AppShell
+
+Files touched:
+- Create: `frontend/src/components/TopBar.jsx`
+- Create: `frontend/src/components/RoleTabs.jsx`
+- Create: `frontend/src/components/AppShell.jsx`
+
+---
+
+### Task 4: Build `TopBar` component
+
+The TopBar has two states controlled by props:
+- **Root state** (`isSubPage=false`): logo left, role pill + avatar right
+- **Sub-page state** (`isSubPage=true`): ← back icon left, page title center, avatar right
+
+**Files:**
+- Create: `frontend/src/components/TopBar.jsx`
+
+- [ ] **Step 1: Create TopBar.jsx**
+
+```jsx
+// frontend/src/components/TopBar.jsx
+import { useNavigate } from 'react-router-dom';
+import { useStore } from '../store';
+
+const ROLE_PILL = {
+  referee:    { bg: 'rgba(255,176,32,0.15)',  color: 'var(--pe-warning)',      border: 'rgba(255,176,32,0.3)',  label: 'Referee' },
+  gastronomy: { bg: 'rgba(0,229,160,0.15)',   color: 'var(--pe-success)',      border: 'rgba(0,229,160,0.3)',   label: 'Gastro' },
+  admin:      { bg: 'rgba(0,184,255,0.15)',   color: 'var(--pe-cyan-bright)',  border: 'rgba(0,184,255,0.3)',   label: 'Admin' },
+  director:   { bg: 'rgba(0,184,255,0.15)',   color: 'var(--pe-cyan-bright)',  border: 'rgba(0,184,255,0.3)',   label: 'Director' },
+};
+
+export default function TopBar({ isSubPage = false, title = '', onBack }) {
+  const navigate = useNavigate();
+  const { role, logout } = useStore();
+
+  const handleBack = () => {
+    if (onBack) onBack();
+    else navigate(-1);
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
+  const pill = role ? ROLE_PILL[role] : null;
+  const initials = role ? role.slice(0, 1).toUpperCase() : '?';
+
+  return (
+    <header style={{
+      height: '64px',
+      background: 'var(--pe-bg-elevated)',
+      borderBottom: '1px solid var(--pe-border)',
+      display: 'flex',
+      alignItems: 'center',
+      padding: '0 12px',
+      gap: '8px',
+      flexShrink: 0,
+      fontFamily: 'Verdana, Geneva, sans-serif',
+      position: 'sticky',
+      top: 0,
+      zIndex: 100,
+    }}>
+      {isSubPage ? (
+        /* Sub-page: ← back icon — 64×64px tap area via padding around 40px visual icon */
+        <button
+          onClick={handleBack}
+          aria-label="Zurück"
+          style={{
+            padding: '12px',           /* 12+40+12 = 64px tap area */
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: 'var(--pe-text-sub)',
+            fontSize: '22px',
+            flexShrink: 0,
+            transition: 'color 150ms ease',
+            borderRadius: '8px',
+            margin: '0 0 0 -12px',    /* align visually with edge */
+          }}
+          onMouseEnter={e => e.currentTarget.style.color = 'var(--pe-cyan-bright)'}
+          onMouseLeave={e => e.currentTarget.style.color = 'var(--pe-text-sub)'}
+        >
+          ←
+        </button>
+      ) : (
+        /* Root: logo */
+        <span style={{
+          fontSize: '14px',
+          fontWeight: 'bold',
+          background: 'var(--pe-gradient)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          flexShrink: 0,
+        }}>
+          DartEvent
+        </span>
+      )}
+
+      {/* Center: page title (sub-page) or spacer (root) */}
+      <div style={{ flex: 1, textAlign: isSubPage ? 'center' : 'left' }}>
+        {isSubPage && (
+          <span style={{ fontSize: '14px', fontWeight: 'bold', color: 'var(--pe-text)' }}>
+            {title}
+          </span>
+        )}
+      </div>
+
+      {/* Right: role pill (root only) + avatar */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
+        {!isSubPage && pill && (
+          <span style={{
+            background: pill.bg,
+            color: pill.color,
+            border: `1px solid ${pill.border}`,
+            borderRadius: '12px',
+            padding: '3px 10px',
+            fontSize: '11px',
+            fontWeight: 'bold',
+          }}>
+            {pill.label}
+          </span>
+        )}
+        {role && (
+          <button
+            onClick={handleLogout}
+            title="Abmelden"
+            style={{
+              width: '32px',
+              height: '32px',
+              borderRadius: '50%',
+              background: 'var(--pe-gradient)',
+              border: 'none',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '11px',
+              fontWeight: 'bold',
+              color: 'white',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              transition: 'opacity 150ms ease',
+            }}
+            onMouseEnter={e => e.currentTarget.style.opacity = '0.8'}
+            onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+          >
+            {initials}
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 2: Verify no import errors**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend && npm run build 2>&1 | head -30
+```
+Expected: no errors mentioning `TopBar.jsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/TopBar.jsx
+git commit -m "feat: add TopBar component with root/sub-page states and role pill"
+```
+
+---
+
+### Task 5: Build `RoleTabs` component
+
+**Files:**
+- Create: `frontend/src/components/RoleTabs.jsx`
+
+- [ ] **Step 1: Create RoleTabs.jsx**
+
+```jsx
+// frontend/src/components/RoleTabs.jsx
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useStore } from '../store';
+
+const TABS = {
+  public:     [
+    { label: 'Home',    path: '/' },
+    { label: 'Turnier', path: '/tournament' },
+  ],
+  referee:    [
+    { label: 'Boards',  path: '/referee' },
+    { label: 'Turnier', path: '/tournament' },
+  ],
+  gastronomy: [
+    { label: 'Bestellungen', path: '/gastronomy' },
+    { label: 'Produkte',     path: '/gastronomy?tab=products' },
+    { label: 'NFC',          path: '/nfc-scan' },
+  ],
+  admin: [
+    { label: 'Home',    path: '/' },
+    { label: 'Turnier', path: '/tournament' },
+    { label: 'Boards',  path: '/admin?tab=boards' },
+    { label: 'Gastro',  path: '/gastronomy' },
+    { label: 'Admin',   path: '/admin' },
+  ],
+  director: [
+    { label: 'Home',    path: '/' },
+    { label: 'Turnier', path: '/tournament' },
+    { label: 'Boards',  path: '/admin?tab=boards' },
+    { label: 'Spieler', path: '/admin?tab=players' },
+  ],
+};
+
+export default function RoleTabs() {
+  const { role } = useStore();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const tabs = TABS[role] ?? TABS.public;
+
+  const isActive = (path) => {
+    const base = path.split('?')[0];
+    if (base === '/') return pathname === '/';
+    return pathname.startsWith(base);
+  };
+
+  return (
+    <nav
+      className="pe-scrollbar-hide"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        padding: '0 12px',
+        background: 'var(--pe-bg-card)',
+        borderBottom: '1px solid var(--pe-border)',
+        overflowX: 'auto',
+        flexShrink: 0,
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}
+    >
+      {tabs.map((tab) => {
+        const active = isActive(tab.path);
+        return (
+          <button
+            key={tab.label}
+            onClick={() => navigate(tab.path)}
+            style={{
+              minHeight: '64px',
+              padding: '0 14px',
+              background: 'none',
+              border: 'none',
+              borderBottom: active ? '2px solid var(--pe-cyan-bright)' : '2px solid transparent',
+              cursor: 'pointer',
+              fontSize: '12px',
+              fontWeight: active ? 'bold' : 'normal',
+              color: active ? 'var(--pe-cyan-bright)' : 'var(--pe-text-muted)',
+              whiteSpace: 'nowrap',
+              transition: 'color 150ms ease, border-color 150ms ease',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+            }}
+            onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-sub)'; }}
+            onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-muted)'; }}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+```
+
+**Note on tab height:** `minHeight: '64px'` per spec (CLAUDE.md mandatory minimum for all interactive elements).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/components/RoleTabs.jsx
+git commit -m "feat: add RoleTabs component with role-aware tab sets"
+```
+
+---
+
+### Task 6: Build `AppShell` component
+
+AppShell is the layout route. It determines from the current URL whether to show the root state (Logo + Tabs) or sub-page state (← + Title).
+
+**Files:**
+- Create: `frontend/src/components/AppShell.jsx`
+
+- [ ] **Step 1: Create AppShell.jsx**
+
+```jsx
+// frontend/src/components/AppShell.jsx
+import { Outlet, useMatch } from 'react-router-dom';
+import TopBar from './TopBar';
+import RoleTabs from './RoleTabs';
+
+function useSubPage() {
+  const registerMatch = useMatch('/tournament/:id/register');
+  const tournamentMatch = useMatch('/tournament/:id');
+
+  if (registerMatch) return { isSubPage: true, title: 'Anmelden' };
+  if (tournamentMatch) return { isSubPage: true, title: 'Turnier-Detail' };
+  return { isSubPage: false, title: '' };
+}
+
+export default function AppShell() {
+  const { isSubPage, title } = useSubPage();
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <TopBar isSubPage={isSubPage} title={title} />
+      {!isSubPage && <RoleTabs />}
+      <main className="pe-page-enter" style={{ flex: 1 }}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/components/AppShell.jsx
+git commit -m "feat: add AppShell layout component with TopBar and RoleTabs"
+```
+
+---
+
+## Chunk 3: Route Restructure — App.jsx
+
+Files touched:
+- Modify: `frontend/src/App.jsx`
+
+---
+
+### Task 7: Restructure App.jsx to nested layout routes
+
+This is the highest-risk task. The entire `<Routes>` tree changes. Do this carefully.
+
+**Files:**
+- Modify: `frontend/src/App.jsx`
+
+- [ ] **Step 1: Add AppShell import**
+
+In `frontend/src/App.jsx`, add to the import block at the top:
+```js
+import AppShell from './components/AppShell';
+```
+
+- [ ] **Step 2: Replace the Routes block**
+
+Replace the `<Routes>...</Routes>` block inside the `App()` function (currently lines 80–100) with:
+
+```jsx
+<Routes>
+  {/* ── Shell routes: persistent TopBar + RoleTabs ── */}
+  <Route element={<AppShell />}>
+    <Route path="/" element={<HomePage />} />
+    <Route path="/tournament/:id" element={<TournamentPage />} />
+    <Route path="/tournament/:id/register" element={<PlayerRegistrationPage />} />
+    <Route path="/referee/:boardId" element={<RefereePage />} />
+    <Route path="/gastronomy" element={<GastronomyPage />} />
+  </Route>
+
+  {/* ── Standalone routes: no shell ── */}
+  <Route path="/admin/users" element={<AdminPage tab="users" />} />
+  <Route path="/admin" element={<AdminPage />} />
+  <Route path="/board/:boardId" element={<CurrentGameView />} />
+  <Route path="/nfc" element={<NFCScanPage />} />
+  <Route path="/nfc-scan" element={<NFCScanPage />} />
+  <Route path="/orders/:uid" element={<OrderPage />} />
+  <Route path="/cancel/:token" element={<CancelRegistrationPage />} />
+</Routes>
+```
+
+- [ ] **Step 3: Verify all routes render correctly**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend && npm run dev
+```
+
+Check each route manually in the browser:
+
+| URL | Expected |
+|-----|---------|
+| `http://localhost:5173/` | HomePage with TopBar + public tabs |
+| `http://localhost:5173/tournament/1` | TournamentPage with ← "Turnier-Detail" in TopBar |
+| `http://localhost:5173/tournament/1/register` | PlayerRegistrationPage with ← "Anmelden" |
+| `http://localhost:5173/admin` | AdminPage WITHOUT TopBar shell |
+| `http://localhost:5173/board/1` | CurrentGameView WITHOUT TopBar shell |
+| `http://localhost:5173/cancel/test` | CancelRegistrationPage WITHOUT TopBar shell |
+
+- [ ] **Step 4: Verify build passes**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend && npm run build 2>&1 | tail -10
+```
+Expected: `✓ built in X.XXs` — no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/App.jsx
+git commit -m "feat: restructure App.jsx to nested layout routes with AppShell"
+```
+
+---
+
+## Chunk 4: Page Cleanup + Color Fixes + Touch Targets
+
+Files touched:
+- Modify: `frontend/src/pages/TournamentPage.jsx`
+- Modify: `frontend/src/pages/PlayerRegistrationPage.jsx`
+- Modify: `frontend/src/pages/HomePage.jsx`
+- Modify: `frontend/src/pages/GastronomyPage.jsx`
+- Modify: `frontend/src/pages/CurrentGameView.jsx`
+
+---
+
+### Task 8: Remove `BackButton` usage from shell pages
+
+`TournamentPage` and `PlayerRegistrationPage` are now inside AppShell — TopBar handles back navigation. Remove the BackButton import and usage from both.
+
+**Files:**
+- Modify: `frontend/src/pages/TournamentPage.jsx`
+- Modify: `frontend/src/pages/PlayerRegistrationPage.jsx`
+
+- [ ] **Step 1: Remove BackButton from TournamentPage**
+
+In `frontend/src/pages/TournamentPage.jsx`:
+1. Remove the `import BackButton from '../components/BackButton';` line
+2. Remove the `<BackButton />` JSX element (line ~37)
+
+- [ ] **Step 2: Remove BackButton from PlayerRegistrationPage**
+
+In `frontend/src/pages/PlayerRegistrationPage.jsx`:
+1. Remove `import BackButton from '../components/BackButton';` if present
+2. Remove inline `←` back link elements (lines ~79 and ~138 — plain text arrows)
+   These look like: `<a onClick={() => navigate(-1)} style={{...}}>← Zurück</a>` or similar
+
+- [ ] **Step 3: Verify pages still render**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend && npm run dev
+```
+Navigate to `/tournament/1` — TournamentPage should have TopBar with ← and no second back button.
+Navigate to `/tournament/1/register` — same, single ← in TopBar.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/TournamentPage.jsx frontend/src/pages/PlayerRegistrationPage.jsx
+git commit -m "refactor: remove BackButton usages from shell pages — TopBar handles back nav"
+```
+
+---
+
+### Task 9: Apply `pe-card-interactive` to cards in HomePage
+
+**Files:**
+- Modify: `frontend/src/pages/HomePage.jsx`
+
+- [ ] **Step 1: Add className to tournament cards**
+
+Find the tournament/player/board card elements in `HomePage.jsx`. These are typically `<div>` elements with `style={{ background: 'var(--pe-bg-card)', border: ... }}`. Add `className="pe-card-interactive"` to each card wrapper.
+
+Look for the pattern and add the class:
+```jsx
+// Before
+<div style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', ... }}>
+
+// After
+<div className="pe-card-interactive" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', ... }}>
+```
+
+Apply to: tournament list items, player list items, board list items.
+
+- [ ] **Step 2: Add `pe-btn` to FAB buttons**
+
+Find the FAB buttons (lines ~691–706) and add `className="pe-btn"` to each.
+
+- [ ] **Step 3: Fix hardcoded gradient (line 391)**
+
+Find line 391 in `HomePage.jsx`:
+```js
+// Before (hardcoded):
+background: 'linear-gradient(135deg, #5DD5FF, #1E7FEB, #1A4FD6)'
+
+// After (PE token):
+background: 'var(--pe-gradient)'
+```
+
+- [ ] **Step 4: Fix search input touch target (line ~180)**
+
+Find the search input and add `minHeight: '64px'`:
+```jsx
+// Before:
+style={{ padding: '12px 14px', ... }}
+
+// After:
+style={{ padding: '12px 14px', minHeight: '64px', ... }}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/HomePage.jsx
+git commit -m "feat: add hover animations to cards and FABs, fix hardcoded gradient"
+```
+
+---
+
+### Task 10: Fix hardcoded colors in GastronomyPage + touch targets
+
+**Files:**
+- Modify: `frontend/src/pages/GastronomyPage.jsx`
+
+- [ ] **Step 1: Fix `'#fff'` hardcodes (lines 46 and 357)**
+
+```js
+// Before:
+color: '#fff'
+
+// After:
+color: 'var(--pe-text)'
+```
+
+Apply to lines 46 and 357 only. **Do not change line 72** — that is `color: '#000'` (black text on a green success button, intentional contrast).
+
+- [ ] **Step 2: Fix category button touch target (line ~496)**
+
+```jsx
+// Before:
+style={{ minHeight: '48px', ... }}
+
+// After:
+style={{ minHeight: '64px', ... }}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/GastronomyPage.jsx
+git commit -m "fix: replace hardcoded colors with PE tokens in GastronomyPage, fix touch targets"
+```
+
+---
+
+### Task 11: Fix hardcoded colors in CurrentGameView + PlayerRegistrationPage
+
+**Files:**
+- Modify: `frontend/src/pages/CurrentGameView.jsx`
+- Modify: `frontend/src/pages/PlayerRegistrationPage.jsx`
+
+- [ ] **Step 1: Fix CurrentGameView (lines 140, 152)**
+
+In `frontend/src/pages/CurrentGameView.jsx`, find lines 140 and 152:
+```js
+// Before:
+background: 'linear-gradient(135deg, #5DD5FF, #1E7FEB, #1A4FD6)'
+
+// After:
+background: 'var(--pe-gradient)'
+```
+
+- [ ] **Step 2: Fix PlayerRegistrationPage (lines 124, 206)**
+
+```js
+// Before:
+color: '#fff'
+
+// After:
+color: 'var(--pe-text)'
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/CurrentGameView.jsx frontend/src/pages/PlayerRegistrationPage.jsx
+git commit -m "fix: replace hardcoded colors with PE tokens in CurrentGameView and PlayerRegistrationPage"
+```
+
+---
+
+### Task 12: Final acceptance check
+
+- [ ] **Step 1: Build check**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend && npm run build 2>&1 | tail -10
+```
+Expected: clean build, no errors.
+
+- [ ] **Step 2: Manual acceptance criteria walkthrough**
+
+Start the full dev stack:
+```bash
+cd /home/moritzwolf/dartsturnier && npm run dev   # or start backend + frontend separately
+```
+
+Walk through each acceptance criterion from the spec:
+
+| Check | How to verify |
+|-------|--------------|
+| AppShell wraps shell routes only | Visit `/`, `/tournament/1`, `/gastronomy` → TopBar visible. Visit `/admin`, `/board/1` → no TopBar |
+| TopBar root state | Visit `/` → Logo + no role pill (public), or role pill after login |
+| TopBar sub-page state | Visit `/tournament/1` → ← icon + "Turnier-Detail" |
+| ← touch target ≥ 64px | DevTools → inspect ← button → computed height must be ≥ 64px |
+| RoleTabs per role | Log in as referee → see Boards + Turnier tabs only |
+| Role persists after hard refresh | Login, F5 → role pill still shown |
+| Hover on cards | Hover tournament cards → subtle lift + glow |
+| Page fade-in | Navigate between routes → 200ms fade-in visible |
+| Touch targets ≥ 64px | DevTools inspect tabs, search input, category buttons |
+| No hardcoded colors | Search codebase: `grep -r "'#fff'" frontend/src/pages/` → only non-critical hits remain |
+| BackButton removed from shell pages | Visit `/tournament/1` → only one ← (in TopBar), no duplicate |
+
+- [ ] **Step 3: Create follow-up GitHub issues**
+
+```bash
+gh issue create --title "refactor: unify back navigation on standalone pages (cancel/orders/nfc)" \
+  --body "Follow-up to #30. CancelRegistrationPage, OrderPage, NFCScanPage still use their own inline back navigation. Unify with a shared pattern." \
+  --label "enhancement"
+
+gh issue create --title "feat: replace alert() with toast notifications in GastronomyPage and RefereePage" \
+  --body "Follow-up to #30. GastronomyPage (lines 144, 191, 225, 244) uses browser alert(). Replace with in-app toast component." \
+  --label "enhancement"
+
+gh issue create --title "security: activate ProtectedRoute for admin/referee/gastro routes" \
+  --body "Follow-up to #30. Frontend route guards are not active. ProtectedRoute component exists in App.jsx but is unused. Harden with proper redirect behavior." \
+  --label "security"
+```
+
+- [ ] **Step 4: Final commit + push**
+
+```bash
+git add -p   # review any remaining unstaged changes
+git push origin fix/board-view-fixes
+```
+
+---
+
+## File Map Summary
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `frontend/src/lib/parseJwt.js` | CREATE | Shared JWT decode utility |
+| `frontend/src/components/TopBar.jsx` | CREATE | Persistent top bar, root + sub-page states |
+| `frontend/src/components/RoleTabs.jsx` | CREATE | Role-aware horizontal tab navigation |
+| `frontend/src/components/AppShell.jsx` | CREATE | Layout route wrapper |
+| `frontend/src/store/index.js` | MODIFY | Add `role` field + localStorage init |
+| `frontend/src/App.jsx` | MODIFY | Nested route structure + parseJwt import |
+| `frontend/src/index.css` | MODIFY | Add pe-card-interactive, pe-btn, pe-page-enter |
+| `frontend/src/pages/TournamentPage.jsx` | MODIFY | Remove BackButton |
+| `frontend/src/pages/PlayerRegistrationPage.jsx` | MODIFY | Remove inline ← links + fix colors |
+| `frontend/src/pages/HomePage.jsx` | MODIFY | Add card hover classes, fix gradient, fix search touch target |
+| `frontend/src/pages/GastronomyPage.jsx` | MODIFY | Fix #fff colors + category button touch target |
+| `frontend/src/pages/CurrentGameView.jsx` | MODIFY | Fix hardcoded gradients |
+| `components/BackButton.jsx` | DEPRECATED | Keep file, no usages in shell pages |

--- a/docs/superpowers/specs/2026-03-15-ui-ux-overhaul-design.md
+++ b/docs/superpowers/specs/2026-03-15-ui-ux-overhaul-design.md
@@ -1,0 +1,328 @@
+# Design Spec: Frontend UI/UX Overhaul (Issue #30)
+
+**Date:** 2026-03-15
+**Status:** Approved
+**Branch target:** `dev`
+
+---
+
+## Overview
+
+Comprehensive UI/UX overhaul of the DartEvent Manager PWA. Introduces a consistent navigation shell, role-based tab navigation, a unified back button pattern, and polished hover/transition animations throughout. All changes must adhere to P Entertainment Corporate Design (Verdana, dark mode, PE CSS tokens).
+
+---
+
+## 1. Route Architecture — In vs. Out of AppShell
+
+Not all routes go inside AppShell. The following classification is required before implementation.
+
+### Routes INSIDE AppShell (persistent TopBar + RoleTabs)
+
+| Route | Type | TopBar state |
+|-------|------|-------------|
+| `/` | Root | Logo + Role Pill + Tabs |
+| `/tournament/:id` | Sub-page | ← + "Turnier-Detail" |
+| `/tournament/:id/register` | Sub-page | ← + "Anmelden" |
+| `/referee/:boardId` | Root (own role) | Logo + Referee Pill + Tabs |
+| `/gastronomy` | Root (own role) | Logo + Gastro Pill + Tabs |
+
+### Routes OUTSIDE AppShell (standalone, no persistent header)
+
+| Route | Reason |
+|-------|--------|
+| `/admin`, `/admin/users` | AdminPage has its own full-screen header + tab navigation. Wrapping with AppShell would collide visually. Admin remains self-contained. |
+| `/board/:boardId` | `CurrentGameView` is a TV/beamer display page — no nav shell appropriate. Public, full-screen, standalone. |
+| `/nfc`, `/nfc-scan` | Public QR/NFC entry point — standalone, no auth context. |
+| `/orders/:uid` | Public QR-code order page — standalone, no auth context. |
+| `/cancel/:token` | Tokenised public cancellation page — standalone. |
+
+### react-router-dom v6 Nested Route Structure
+
+AppShell is implemented as a **layout route** using `<Outlet />`. App.jsx restructuring:
+
+```jsx
+<Routes>
+  {/* Shell routes — TopBar + RoleTabs */}
+  <Route element={<AppShell />}>
+    <Route path="/" element={<HomePage />} />
+    <Route path="/tournament/:id" element={<TournamentPage />} />
+    <Route path="/tournament/:id/register" element={<PlayerRegistrationPage />} />
+    <Route path="/referee/:boardId" element={<RefereePage />} />
+    <Route path="/gastronomy" element={<GastronomyPage />} />
+  </Route>
+
+  {/* Standalone routes — no shell */}
+  <Route path="/admin" element={<AdminPage />} />
+  <Route path="/admin/users" element={<AdminPage tab="users" />} />  {/* retain tab prop */}
+  <Route path="/board/:boardId" element={<CurrentGameView />} />
+  <Route path="/nfc" element={<NFCScanPage />} />
+  <Route path="/nfc-scan" element={<NFCScanPage />} />
+  <Route path="/orders/:uid" element={<OrderPage />} />
+  <Route path="/cancel/:token" element={<CancelRegistrationPage />} />
+</Routes>
+```
+
+---
+
+## 2. Navigation Architecture
+
+### AppShell Component
+
+Wraps shell routes as a react-router-dom v6 layout route. Reads `role` from Zustand. Determines TopBar state (root vs sub-page) based on current route depth.
+
+```
+<AppShell>            ← layout route, renders <Outlet />
+  <TopBar />          ← always visible within shell
+  <RoleTabs />        ← only on root-level shell routes
+  <Outlet />          ← page content
+</AppShell>
+```
+
+Root-level shell routes (no parent path segment): `/`, `/referee/:boardId`, `/gastronomy`
+Sub-page shell routes (have a parent): `/tournament/:id`, `/tournament/:id/register`
+
+### Top Bar — Two States
+
+**Root-level state** (HomePage, RefereePage, GastronomyPage):
+```
+[DartEvent Logo]  ············  [Role Pill]  [Avatar →Logout]
+[Tab 1]  [Tab 2]  [Tab 3]  ...
+```
+
+**Sub-page state** (TournamentPage, PlayerRegistrationPage):
+```
+[← Icon (64×64px tap area)]  ·  [Page Title]  ·  [Avatar]
+(no Tab Row)
+```
+
+- ← Icon: **64×64px minimum tappable area** achieved via padding (`padding: 12px`around a 40px visual icon). Color `var(--pe-text-sub)`, hover `var(--pe-cyan-bright)`, transition 150ms.
+- Page Title: centered, bold 14px, `var(--pe-text)`.
+- Logo hidden on sub-pages.
+
+### Role Pill Colors
+
+| Role | Background | Text | Border |
+|------|-----------|------|--------|
+| public | — | — | not shown |
+| referee | `rgba(255,176,32,0.15)` | `--pe-warning` | `rgba(255,176,32,0.3)` |
+| gastronomy | `rgba(0,229,160,0.15)` | `--pe-success` | `rgba(0,229,160,0.3)` |
+| admin / director | `rgba(0,184,255,0.15)` | `--pe-cyan-bright` | `rgba(0,184,255,0.3)` |
+
+---
+
+## 3. Role-Based Tab Navigation
+
+### RoleTabs Component
+
+Renders a horizontal scrollable tab row. Tabs derived from `role` in Zustand. Hidden on sub-pages. Scrollable on mobile (`overflow-x: auto`, scrollbar hidden).
+
+### Tab Sets per Role
+
+| Role | Tabs (in order) | Default Tab |
+|------|----------------|-------------|
+| public (unauthenticated) | Home · Turnier | Home |
+| referee | Boards · Turnier | Boards |
+| gastronomy | Bestellungen · Produkte · NFC | Bestellungen |
+| admin | Home · Turnier · Boards · Gastro · Admin | Home |
+| director | Home · Turnier · Boards · Spieler | Home |
+
+Note: "Boards" tab for referee/admin links to `/referee/:boardId` (referee's board) or `/` board overview. A dedicated `BoardsPage` is not in scope — the tab for referee routes to their assigned board, for admin to the boards overview within AdminPage.
+
+### Active Tab Indicator
+
+Sliding underline: CSS transition on `left` + `width`, 200ms ease. Active tab `var(--pe-cyan-bright)`.
+
+### Role Detection & Zustand Store
+
+```js
+// store/index.js additions
+{
+  token: localStorage.getItem('token') ?? null,
+  role:  parseJwt(localStorage.getItem('token'))?.role ?? null,  // init from localStorage
+
+  setToken: (token) => {
+    localStorage.setItem('token', token);
+    set({ token, role: parseJwt(token)?.role ?? null });
+  },
+
+  logout: () => {
+    localStorage.removeItem('token');
+    set({ token: null, role: null });
+  }
+}
+```
+
+Role is initialised from localStorage on page load so hard-refresh preserves the authenticated state.
+
+### Auth Handling for Shell Routes
+
+- `RefereePage` and `GastronomyPage` handle their own inline login — no ProtectedRoute applied. If user is unauthenticated, the page renders its login form as today.
+- `ProtectedRoute` is **not activated** as part of this spec. Auth hardening is a separate security task.
+
+---
+
+## 4. Back Button Pattern
+
+### Behavior
+
+Back navigation handled exclusively by `TopBar` on shell sub-pages. No page implements its own back button.
+
+- ← Icon calls `useNavigate(-1)` by default.
+- Explicit `onBack` prop available for pages that need custom back behavior.
+- `BackButton.jsx` deprecated — all usages in `PlayerRegistrationPage`, `TournamentPage`, `NFCScanPage`, `GastronomyPage`, `OrderPage` removed (TopBar handles it via AppShell).
+- `CancelRegistrationPage`, `OrderPage`, `NFCScanPage` are standalone (outside AppShell) and retain their own simple back navigation temporarily — deduplicated in a follow-up.
+
+### Pages in AppShell Requiring Title
+
+| Page | Title |
+|------|-------|
+| TournamentPage | Turnier-Detail |
+| PlayerRegistrationPage | Anmelden |
+
+RefereePage and GastronomyPage are root-level shell routes — they show Logo + Tabs, not ← back.
+
+### Touch Targets
+
+← Icon tappable area: **min 64×64px** via `padding: 12px` around the SVG/icon. All other interactive elements in section 6 audit.
+
+---
+
+## 5. Animations & Hover Effects
+
+### Global Utilities (index.css)
+
+```css
+/* Hover: interactive cards */
+.pe-card-interactive {
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+}
+.pe-card-interactive:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 4px 20px rgba(0, 184, 255, 0.12);
+}
+.pe-card-interactive:active {
+  transform: scale(0.98);
+}
+
+/* Hover: buttons */
+.pe-btn {
+  transition: border-color 150ms ease, color 150ms ease, background 150ms ease, transform 150ms ease;
+}
+.pe-btn:hover {
+  border-color: var(--pe-cyan-bright);
+  color: var(--pe-cyan-bright);
+}
+.pe-btn:active {
+  transform: scale(0.97);
+}
+
+/* Page entry fade */
+.pe-page-enter {
+  animation: pe-fade-in 200ms ease forwards;
+}
+@keyframes pe-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+```
+
+### Applied To
+
+| Element | Effect |
+|---------|--------|
+| Tournament cards | `pe-card-interactive` |
+| Player cards | `pe-card-interactive` |
+| Board cards | `pe-card-interactive` |
+| All `<button>` elements | `pe-btn` |
+| FAB buttons (HomePage) | `pe-btn` + glow on hover |
+| Nav tabs | color + underline transition |
+| Page root `<div>` (in AppShell) | `pe-page-enter` |
+| TopBar ← icon | color transition to cyan |
+
+---
+
+## 6. Touch Target Audit — Required Fixes
+
+All interactive elements must meet **min 64px height**.
+
+| Element | File | Current | Fix |
+|---------|------|---------|-----|
+| TopBar ← icon | TopBar.jsx (new) | — | 64×64px via padding |
+| Tab buttons | RoleTabs.jsx (new) | — | `minHeight: 64px` |
+| Search input | HomePage.jsx:180 | 48px | padding increase → 64px |
+| Category buttons | GastronomyPage.jsx:496 | 48px | `minHeight: 64px` |
+
+---
+
+## 7. Hardcoded Color Fixes
+
+Replace with PE tokens in:
+
+| File | Lines | Issue |
+|------|-------|-------|
+| HomePage.jsx | 391 | Hardcoded gradient → `var(--pe-gradient)` |
+| GastronomyPage.jsx | 46, 72, 357 | `'#fff'` → `var(--pe-text)` |
+| CurrentGameView.jsx | 140, 152 | Hardcoded gradient → `var(--pe-gradient)` |
+| PlayerRegistrationPage.jsx | 124, 206 | `'#fff'` → `var(--pe-text)` |
+
+---
+
+## 8. Component Summary
+
+### New Components
+
+| File | Purpose |
+|------|---------|
+| `components/AppShell.jsx` | Layout route wrapper: TopBar + RoleTabs + Outlet |
+| `components/TopBar.jsx` | Root state (logo+pill) vs sub-page state (←+title) |
+| `components/RoleTabs.jsx` | Role-aware scrollable tab row |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `store/index.js` | Add `role`, init from localStorage, clear on logout |
+| `App.jsx` | Restructure routes into nested layout (AppShell shell + standalone) |
+| `index.css` | Add `pe-card-interactive`, `pe-btn`, `pe-page-enter` utilities |
+| `PlayerRegistrationPage.jsx` | Remove inline ← link; remove `BackButton` usage |
+| `TournamentPage.jsx` | Remove `BackButton` usage |
+| `HomePage.jsx:391` | Fix hardcoded gradient |
+| `GastronomyPage.jsx:46,72,357` | Fix hardcoded `#fff` |
+| `CurrentGameView.jsx:140,152` | Fix hardcoded gradient |
+| `PlayerRegistrationPage.jsx:124,206` | Fix hardcoded `#fff` |
+
+### Deprecated
+
+| File | Status |
+|------|--------|
+| `components/BackButton.jsx` | Deprecated — keep file, remove all usages from shell pages |
+
+---
+
+## 9. Out of Scope
+
+- AdminPage redesign (self-contained, separate issue)
+- GastronomyPage / RefereePage `alert()` → toast (separate issue)
+- ProtectedRoute auth hardening (separate security task)
+- Skeleton loading screens
+- Dedicated BoardsPage component
+- CancelRegistrationPage, OrderPage, NFCScanPage back nav unification
+
+---
+
+## 10. Acceptance Criteria
+
+- [ ] AppShell wraps shell routes; standalone routes render without shell
+- [ ] TopBar shows Logo + Role Pill + Avatar on root shell routes
+- [ ] TopBar shows ← + Page Title + Avatar on sub-page shell routes
+- [ ] ← touch target ≥ 64×64px
+- [ ] RoleTabs renders correct tabs per JWT role
+- [ ] Role persists in Zustand after hard refresh (localStorage init)
+- [ ] Hover effects on all interactive cards and buttons
+- [ ] Page fade-in animation on shell route transitions
+- [ ] All touch targets ≥ 64px (tabs 64px, search 64px, category buttons 64px)
+- [ ] No hardcoded colors — PE tokens used in all fixed files
+- [ ] Verdana font unchanged throughout
+- [ ] Dark mode consistent — no light-mode leaks
+- [ ] BackButton.jsx usages removed from all shell pages
+- [ ] react-router-dom v6 nested routes work correctly (no blank screens)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import OrderPage from './pages/OrderPage';
 import AdminPage from './pages/AdminPage';
 // NEU: Board-Ansicht importieren
 import CurrentGameView from './pages/CurrentGameView';
+import AppShell from './components/AppShell';
 import { parseJwt } from './lib/parseJwt';
 
 // NEU: Lazy imports für Seiten die von frontend-referee-admin erstellt werden
@@ -72,25 +73,23 @@ export default function App() {
     <Suspense fallback={<LazyFallback />}>
       <ThemeLoader />
       <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/tournament/:id" element={<TournamentPage />} />
-        <Route path="/tournament/:id/register" element={<PlayerRegistrationPage />} />
+        {/* ── Shell routes: persistent TopBar + RoleTabs ── */}
+        <Route element={<AppShell />}>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/tournament/:id" element={<TournamentPage />} />
+          <Route path="/tournament/:id/register" element={<PlayerRegistrationPage />} />
+          <Route path="/referee/:boardId" element={<RefereePage />} />
+          <Route path="/gastronomy" element={<GastronomyPage />} />
+        </Route>
+
+        {/* ── Standalone routes: no shell ── */}
+        <Route path="/admin/users" element={<AdminPage tab="users" />} />
+        <Route path="/admin" element={<AdminPage />} />
+        <Route path="/board/:boardId" element={<CurrentGameView />} />
         <Route path="/nfc" element={<NFCScanPage />} />
-        {/* NEU: NFC-Scan alternative Route */}
         <Route path="/nfc-scan" element={<NFCScanPage />} />
         <Route path="/orders/:uid" element={<OrderPage />} />
-        {/* NEU: Board-Ansicht für Beamer/TV (öffentlich) */}
-        <Route path="/board/:boardId" element={<CurrentGameView />} />
-        {/* Admin Users Tab — AdminPage hat eigenen Login */}
-        <Route path="/admin/users" element={<AdminPage tab="users" />} />
-        {/* NEU: Referee-Seite (eigener Login auf der Seite) */}
-        <Route path="/referee/:boardId" element={<RefereePage />} />
-        {/* NEU: Gastronomy Routen (eigener Login auf der Seite) */}
-        <Route path="/gastronomy" element={<GastronomyPage />} />
-        {/* Spieler-Abmeldung via Token-Link */}
         <Route path="/cancel/:token" element={<CancelRegistrationPage />} />
-        {/* Admin — AdminPage hat eigenen Login */}
-        <Route path="/admin" element={<AdminPage />} />
       </Routes>
     </Suspense>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,18 +8,12 @@ import OrderPage from './pages/OrderPage';
 import AdminPage from './pages/AdminPage';
 // NEU: Board-Ansicht importieren
 import CurrentGameView from './pages/CurrentGameView';
+import { parseJwt } from './lib/parseJwt';
 
 // NEU: Lazy imports für Seiten die von frontend-referee-admin erstellt werden
 const RefereePage = lazy(() => import('./pages/RefereePage'));
 const GastronomyPage = lazy(() => import('./pages/GastronomyPage'));
 const CancelRegistrationPage = lazy(() => import('./pages/CancelRegistrationPage'));
-
-// NEU: JWT Payload dekodieren (ohne Verifikation — Verifikation passiert im Backend)
-function parseJwt(token) {
-  try {
-    return JSON.parse(atob(token.split('.')[1]));
-  } catch { return null; }
-}
 
 // NEU: Protected Route mit Rollenprüfung
 function ProtectedRoute({ element, roles }) {

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -1,0 +1,27 @@
+// frontend/src/components/AppShell.jsx
+import { Outlet, useMatch } from 'react-router-dom';
+import TopBar from './TopBar';
+import RoleTabs from './RoleTabs';
+
+function useSubPage() {
+  const registerMatch = useMatch('/tournament/:id/register');
+  const tournamentMatch = useMatch('/tournament/:id');
+
+  if (registerMatch) return { isSubPage: true, title: 'Anmelden' };
+  if (tournamentMatch) return { isSubPage: true, title: 'Turnier-Detail' };
+  return { isSubPage: false, title: '' };
+}
+
+export default function AppShell() {
+  const { isSubPage, title } = useSubPage();
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <TopBar isSubPage={isSubPage} title={title} />
+      {!isSubPage && <RoleTabs />}
+      <main className="pe-page-enter" style={{ flex: 1 }}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/RoleTabs.jsx
+++ b/frontend/src/components/RoleTabs.jsx
@@ -34,14 +34,28 @@ const TABS = {
 export default function RoleTabs() {
   const { role } = useStore();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
 
   const tabs = TABS[role] ?? TABS.public;
 
-  const isActive = (path) => {
-    const base = path.split('?')[0];
-    if (base === '/') return pathname === '/';
-    return pathname.startsWith(base);
+  const isActive = (tabPath) => {
+    const [tabBase, tabQuery] = tabPath.split('?');
+    if (tabBase === '/') return pathname === '/' && !search;
+
+    // If this tab has a query string (e.g. ?tab=boards), also match the query
+    if (tabQuery) {
+      return pathname.startsWith(tabBase) && search === '?' + tabQuery;
+    }
+
+    // For tabs without query string, only mark active if no conflicting tab with
+    // the same base path and a query string would match instead
+    const hasQueryVariant = tabs.some(t => {
+      const [b, q] = t.path.split('?');
+      return q && b === tabBase && search === '?' + q;
+    });
+    if (hasQueryVariant) return false;
+
+    return pathname.startsWith(tabBase);
   };
 
   return (

--- a/frontend/src/components/RoleTabs.jsx
+++ b/frontend/src/components/RoleTabs.jsx
@@ -90,7 +90,7 @@ export default function RoleTabs() {
               fontWeight: active ? 'bold' : 'normal',
               color: active ? 'var(--pe-cyan-bright)' : 'var(--pe-text-muted)',
               whiteSpace: 'nowrap',
-              transition: 'color 150ms ease, border-color 150ms ease',
+              transition: 'color 200ms ease, border-color 200ms ease',
               fontFamily: 'Verdana, Geneva, sans-serif',
             }}
             onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-sub)'; }}

--- a/frontend/src/components/RoleTabs.jsx
+++ b/frontend/src/components/RoleTabs.jsx
@@ -60,6 +60,7 @@ export default function RoleTabs() {
 
   return (
     <nav
+      aria-label="Hauptnavigation"
       className="pe-scrollbar-hide"
       style={{
         display: 'flex',
@@ -77,8 +78,9 @@ export default function RoleTabs() {
         const active = isActive(tab.path);
         return (
           <button
-            key={tab.label}
+            key={tab.path}
             onClick={() => navigate(tab.path)}
+            aria-current={active ? 'page' : undefined}
             style={{
               minHeight: '64px',
               padding: '0 14px',

--- a/frontend/src/components/RoleTabs.jsx
+++ b/frontend/src/components/RoleTabs.jsx
@@ -1,0 +1,91 @@
+// frontend/src/components/RoleTabs.jsx
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useStore } from '../store';
+
+const TABS = {
+  public:     [
+    { label: 'Home',    path: '/' },
+    { label: 'Turnier', path: '/tournament' },
+  ],
+  referee:    [
+    { label: 'Boards',  path: '/referee' },
+    { label: 'Turnier', path: '/tournament' },
+  ],
+  gastronomy: [
+    { label: 'Bestellungen', path: '/gastronomy' },
+    { label: 'Produkte',     path: '/gastronomy?tab=products' },
+    { label: 'NFC',          path: '/nfc-scan' },
+  ],
+  admin: [
+    { label: 'Home',    path: '/' },
+    { label: 'Turnier', path: '/tournament' },
+    { label: 'Boards',  path: '/admin?tab=boards' },
+    { label: 'Gastro',  path: '/gastronomy' },
+    { label: 'Admin',   path: '/admin' },
+  ],
+  director: [
+    { label: 'Home',    path: '/' },
+    { label: 'Turnier', path: '/tournament' },
+    { label: 'Boards',  path: '/admin?tab=boards' },
+    { label: 'Spieler', path: '/admin?tab=players' },
+  ],
+};
+
+export default function RoleTabs() {
+  const { role } = useStore();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const tabs = TABS[role] ?? TABS.public;
+
+  const isActive = (path) => {
+    const base = path.split('?')[0];
+    if (base === '/') return pathname === '/';
+    return pathname.startsWith(base);
+  };
+
+  return (
+    <nav
+      className="pe-scrollbar-hide"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        padding: '0 12px',
+        background: 'var(--pe-bg-card)',
+        borderBottom: '1px solid var(--pe-border)',
+        overflowX: 'auto',
+        flexShrink: 0,
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}
+    >
+      {tabs.map((tab) => {
+        const active = isActive(tab.path);
+        return (
+          <button
+            key={tab.label}
+            onClick={() => navigate(tab.path)}
+            style={{
+              minHeight: '64px',
+              padding: '0 14px',
+              background: 'none',
+              border: 'none',
+              borderBottom: active ? '2px solid var(--pe-cyan-bright)' : '2px solid transparent',
+              cursor: 'pointer',
+              fontSize: '12px',
+              fontWeight: active ? 'bold' : 'normal',
+              color: active ? 'var(--pe-cyan-bright)' : 'var(--pe-text-muted)',
+              whiteSpace: 'nowrap',
+              transition: 'color 150ms ease, border-color 150ms ease',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+            }}
+            onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-sub)'; }}
+            onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-muted)'; }}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -68,16 +68,11 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
         </button>
       ) : (
         /* Root: logo */
-        <span style={{
-          fontSize: '14px',
-          fontWeight: 'bold',
-          background: 'var(--pe-gradient)',
-          WebkitBackgroundClip: 'text',
-          WebkitTextFillColor: 'transparent',
-          flexShrink: 0,
-        }}>
-          DartEvent
-        </span>
+        <img
+          src="/logo.png"
+          alt="DartEvent"
+          style={{ height: '32px', flexShrink: 0, objectFit: 'contain' }}
+        />
       )}
 
       {/* Center: page title (sub-page) or spacer (root) */}
@@ -109,9 +104,10 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
             onClick={handleLogout}
             title="Abmelden"
             style={{
-              width: '32px',
-              height: '32px',
-              borderRadius: '50%',
+              padding: '16px 8px',
+              minWidth: '40px',
+              minHeight: '48px',
+              borderRadius: '50px',
               background: 'var(--pe-gradient)',
               border: 'none',
               cursor: 'pointer',
@@ -120,7 +116,7 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
               justifyContent: 'center',
               fontSize: '11px',
               fontWeight: 'bold',
-              color: 'white',
+              color: 'var(--pe-text)',
               fontFamily: 'Verdana, Geneva, sans-serif',
               transition: 'opacity 150ms ease',
             }}

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -104,6 +104,7 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
         {role && (
           <button
             onClick={handleLogout}
+            aria-label="Abmelden"
             title="Abmelden"
             style={{
               padding: '16px 8px',

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -1,0 +1,136 @@
+// frontend/src/components/TopBar.jsx
+import { useNavigate } from 'react-router-dom';
+import { useStore } from '../store';
+
+const ROLE_PILL = {
+  referee:    { bg: 'rgba(255,176,32,0.15)',  color: 'var(--pe-warning)',      border: 'rgba(255,176,32,0.3)',  label: 'Referee' },
+  gastronomy: { bg: 'rgba(0,229,160,0.15)',   color: 'var(--pe-success)',      border: 'rgba(0,229,160,0.3)',   label: 'Gastro' },
+  admin:      { bg: 'rgba(0,184,255,0.15)',   color: 'var(--pe-cyan-bright)',  border: 'rgba(0,184,255,0.3)',   label: 'Admin' },
+  director:   { bg: 'rgba(0,184,255,0.15)',   color: 'var(--pe-cyan-bright)',  border: 'rgba(0,184,255,0.3)',   label: 'Director' },
+};
+
+export default function TopBar({ isSubPage = false, title = '', onBack }) {
+  const navigate = useNavigate();
+  const { role, logout } = useStore();
+
+  const handleBack = () => {
+    if (onBack) onBack();
+    else navigate(-1);
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
+  const pill = role ? ROLE_PILL[role] : null;
+  const initials = role ? role.slice(0, 1).toUpperCase() : '?';
+
+  return (
+    <header style={{
+      height: '64px',
+      background: 'var(--pe-bg-elevated)',
+      borderBottom: '1px solid var(--pe-border)',
+      display: 'flex',
+      alignItems: 'center',
+      padding: '0 12px',
+      gap: '8px',
+      flexShrink: 0,
+      fontFamily: 'Verdana, Geneva, sans-serif',
+      position: 'sticky',
+      top: 0,
+      zIndex: 100,
+    }}>
+      {isSubPage ? (
+        /* Sub-page: ← back icon — 64×64px tap area via padding around 40px visual icon */
+        <button
+          onClick={handleBack}
+          aria-label="Zurück"
+          style={{
+            padding: '12px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: 'var(--pe-text-sub)',
+            fontSize: '22px',
+            flexShrink: 0,
+            transition: 'color 150ms ease',
+            borderRadius: '8px',
+            margin: '0 0 0 -12px',
+          }}
+          onMouseEnter={e => e.currentTarget.style.color = 'var(--pe-cyan-bright)'}
+          onMouseLeave={e => e.currentTarget.style.color = 'var(--pe-text-sub)'}
+        >
+          ←
+        </button>
+      ) : (
+        /* Root: logo */
+        <span style={{
+          fontSize: '14px',
+          fontWeight: 'bold',
+          background: 'var(--pe-gradient)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          flexShrink: 0,
+        }}>
+          DartEvent
+        </span>
+      )}
+
+      {/* Center: page title (sub-page) or spacer (root) */}
+      <div style={{ flex: 1, textAlign: isSubPage ? 'center' : 'left' }}>
+        {isSubPage && (
+          <span style={{ fontSize: '14px', fontWeight: 'bold', color: 'var(--pe-text)' }}>
+            {title}
+          </span>
+        )}
+      </div>
+
+      {/* Right: role pill (root only) + avatar */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
+        {!isSubPage && pill && (
+          <span style={{
+            background: pill.bg,
+            color: pill.color,
+            border: `1px solid ${pill.border}`,
+            borderRadius: '12px',
+            padding: '3px 10px',
+            fontSize: '11px',
+            fontWeight: 'bold',
+          }}>
+            {pill.label}
+          </span>
+        )}
+        {role && (
+          <button
+            onClick={handleLogout}
+            title="Abmelden"
+            style={{
+              width: '32px',
+              height: '32px',
+              borderRadius: '50%',
+              background: 'var(--pe-gradient)',
+              border: 'none',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '11px',
+              fontWeight: 'bold',
+              color: 'white',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              transition: 'opacity 150ms ease',
+            }}
+            onMouseEnter={e => e.currentTarget.style.opacity = '0.8'}
+            onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+          >
+            {initials}
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -57,6 +57,8 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
             color: 'var(--pe-text-sub)',
             fontSize: '22px',
             flexShrink: 0,
+            alignSelf: 'stretch',
+            width: '64px',
             transition: 'color 150ms ease',
             borderRadius: '8px',
             margin: '0 0 0 -12px',
@@ -105,8 +107,8 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
             title="Abmelden"
             style={{
               padding: '16px 8px',
-              minWidth: '40px',
-              minHeight: '48px',
+              minWidth: '64px',
+              minHeight: '64px',
               borderRadius: '50px',
               background: 'var(--pe-gradient)',
               border: 'none',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,3 +39,49 @@ body {
   .mobile-back-bar { display: none !important; }
   .content-area { display: flex !important; }
 }
+
+/* ─── PE Interactive Utilities ─────────────────────────────── */
+
+/* Hover: interactive cards (tournament, player, board cards) */
+.pe-card-interactive {
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+  cursor: pointer;
+}
+.pe-card-interactive:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 4px 20px rgba(0, 184, 255, 0.12);
+}
+.pe-card-interactive:active {
+  transform: scale(0.98);
+}
+
+/* Hover: buttons */
+.pe-btn {
+  transition: border-color 150ms ease, color 150ms ease,
+              background 150ms ease, transform 150ms ease;
+}
+.pe-btn:hover {
+  border-color: var(--pe-cyan-bright);
+  color: var(--pe-cyan-bright);
+}
+.pe-btn:active {
+  transform: scale(0.97);
+}
+
+/* Page entry animation (applied to shell page root divs) */
+.pe-page-enter {
+  animation: pe-fade-in 200ms ease forwards;
+}
+@keyframes pe-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Hide scrollbar utility (for RoleTabs) */
+.pe-scrollbar-hide {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.pe-scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/frontend/src/lib/parseJwt.js
+++ b/frontend/src/lib/parseJwt.js
@@ -1,0 +1,5 @@
+export function parseJwt(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch { return null; }
+}

--- a/frontend/src/pages/CurrentGameView.jsx
+++ b/frontend/src/pages/CurrentGameView.jsx
@@ -137,7 +137,7 @@ export default function CurrentGameView() {
       {youtubeUrl && <YouTubeModal url={youtubeUrl} onClose={() => setYoutubeUrl(null)} />}
 
       {/* Header */}
-      <div style={{ background: 'linear-gradient(135deg, #5DD5FF, #1E7FEB, #1A4FD6)', padding: hPad, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <div style={{ background: 'var(--pe-gradient)', padding: hPad, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <img src="/logo.jpeg" alt="DartEvent" style={{ height: isMobile ? 32 : 48, borderRadius: 8, flexShrink: 0 }} />
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
           <span style={{ fontSize: isMobile ? 18 : isTablet ? 22 : 28, fontWeight: 'bold', color: '#fff', textShadow: '0 2px 8px rgba(0,0,0,0.3)' }}>

--- a/frontend/src/pages/CurrentGameView.jsx
+++ b/frontend/src/pages/CurrentGameView.jsx
@@ -140,7 +140,7 @@ export default function CurrentGameView() {
       <div style={{ background: 'var(--pe-gradient)', padding: hPad, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <img src="/logo.jpeg" alt="DartEvent" style={{ height: isMobile ? 32 : 48, borderRadius: 8, flexShrink: 0 }} />
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
-          <span style={{ fontSize: isMobile ? 18 : isTablet ? 22 : 28, fontWeight: 'bold', color: '#fff', textShadow: '0 2px 8px rgba(0,0,0,0.3)' }}>
+          <span style={{ fontSize: isMobile ? 18 : isTablet ? 22 : 28, fontWeight: 'bold', color: 'var(--pe-text)', textShadow: '0 2px 8px rgba(0,0,0,0.3)' }}>
             Board {boardNumber}
           </span>
           {gameData && (

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -43,7 +43,7 @@ function GastronomyLogin({ onLogin }) {
           <input type="text" value={form.username} onChange={e => setForm({...form, username: e.target.value})} placeholder="Benutzername" style={inp} />
           <input type="password" value={form.password} onChange={e => setForm({...form, password: e.target.value})} placeholder="Passwort" style={inp} />
           {error && <p style={{ color: 'var(--pe-danger)', fontSize: '14px', textAlign: 'center' }}>{error}</p>}
-          <button type="submit" disabled={loading || !form.username || !form.password} style={{ background: 'var(--pe-gradient)', color: '#fff', border: 'none', borderRadius: '12px', padding: '16px', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '64px', opacity: loading ? 0.6 : 1 }}>
+          <button type="submit" disabled={loading || !form.username || !form.password} style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', borderRadius: '12px', padding: '16px', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '64px', opacity: loading ? 0.6 : 1 }}>
             {loading ? 'Anmelden...' : 'Anmelden'}
           </button>
         </form>
@@ -354,7 +354,7 @@ export default function GastronomyPage() {
                         .then((g) => { setGuest(g); setCart([]); setGuestSearch(''); setAllGuests(prev => [...prev, g]); })
                         .catch((err) => alert(err.message || 'Gast konnte nicht angelegt werden'));
                     }}
-                    style={{ padding: '10px 14px', borderRadius: '8px', background: 'var(--pe-blue-mid)', color: '#fff', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px', whiteSpace: 'nowrap' }}
+                    style={{ padding: '10px 14px', borderRadius: '8px', background: 'var(--pe-blue-mid)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px', whiteSpace: 'nowrap' }}
                   >
                     + Neu
                   </button>
@@ -493,7 +493,7 @@ export default function GastronomyPage() {
                       style={{
                         ...btnStyle,
                         padding: '8px 16px',
-                        minHeight: '48px',
+                        minHeight: '64px',
                         background: productFilter === cat.id ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)',
                         color: productFilter === cat.id ? 'var(--pe-text)' : 'var(--pe-text-sub)',
                       }}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -112,7 +112,7 @@ export default function HomePage() {
         ) : (
           <>
             {/* NEU: Aktuelles Turnier Card */}
-            <div style={styles.tournamentCard}>
+            <div className="pe-card-interactive" style={styles.tournamentCard}>
               <div style={styles.tournamentHeader}>
                 <div>
                   <h2 style={styles.tournamentName}>{activeTournament.name}</h2>
@@ -177,7 +177,7 @@ export default function HomePage() {
                     placeholder="Spieler suchen..."
                     value={playerSearch}
                     onChange={e => setPlayerSearch(e.target.value)}
-                    style={{ width: '100%', boxSizing: 'border-box', marginBottom: 10, padding: '12px 14px', borderRadius: 10, border: '1px solid var(--pe-border)', background: 'var(--pe-bg-card)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: 14, outline: 'none' }}
+                    style={{ width: '100%', boxSizing: 'border-box', marginBottom: 10, padding: '12px 14px', borderRadius: 10, border: '1px solid var(--pe-border)', background: 'var(--pe-bg-card)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: 14, outline: 'none', minHeight: '64px' }}
                   />
                 )}
               <div style={styles.playerGrid}>
@@ -193,7 +193,7 @@ export default function HomePage() {
                   players.filter(p => p.name.toLowerCase().includes(playerSearch.toLowerCase())).map((player) => {
                     const stats = getPlayerStats(player);
                     return (
-                      <div key={player.id} style={styles.playerCard}>
+                      <div key={player.id} className="pe-card-interactive" style={styles.playerCard}>
                         <div style={styles.playerName}>{player.name}</div>
                         <div style={styles.playerStatsRow}>
                           <div style={styles.playerStat}>
@@ -233,6 +233,7 @@ export default function HomePage() {
                       <Link
                         key={board.id}
                         to={`/board/${board.number}`}
+                        className="pe-card-interactive"
                         style={styles.boardCard}
                       >
                         <div style={styles.boardHeader}>
@@ -274,7 +275,7 @@ export default function HomePage() {
             {activeTab === 'groups' && groups && (
               <div style={styles.groupsList}>
                 {(Array.isArray(groups) ? groups : []).map((group, idx) => (
-                  <div key={idx} style={styles.groupCard}>
+                  <div key={idx} className="pe-card-interactive" style={styles.groupCard}>
                     <h3 style={styles.groupName}>{group.name || `Gruppe ${idx + 1}`}</h3>
                     <table style={styles.groupTable}>
                       <colgroup>
@@ -330,6 +331,7 @@ export default function HomePage() {
                     <Link
                       key={t.id}
                       to={`/tournament/${t.id}`}
+                      className="pe-card-interactive"
                       style={styles.otherTournamentCard}
                     >
                       <div>
@@ -357,10 +359,10 @@ export default function HomePage() {
 
       {/* NEU: Floating Action Buttons */}
       <div style={styles.fab}>
-        <Link to="/nfc" style={styles.fabButton} title="NFC Scan">
+        <Link to="/nfc" className="pe-btn" style={styles.fabButton} title="NFC Scan">
           NFC
         </Link>
-        <Link to="/admin" style={styles.fabButton} title="Admin">
+        <Link to="/admin" className="pe-btn" style={styles.fabButton} title="Admin">
           &#9881;
         </Link>
       </div>
@@ -388,7 +390,7 @@ function FetchBracket({ tournamentId }) {
 // NEU: Styles
 const styles = {
   header: {
-    background: 'linear-gradient(135deg, #5DD5FF, #1E7FEB, #1A4FD6)',
+    background: 'var(--pe-gradient)',
     padding: '20px 16px',
     display: 'flex',
     alignItems: 'center',

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -404,7 +404,7 @@ const styles = {
   title: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#fff',
+    color: 'var(--pe-text)',
     margin: 0,
     textShadow: '0 2px 8px rgba(0,0,0,0.3)',
     lineHeight: 1.2,

--- a/frontend/src/pages/PlayerRegistrationPage.jsx
+++ b/frontend/src/pages/PlayerRegistrationPage.jsx
@@ -75,10 +75,6 @@ export default function PlayerRegistrationPage() {
 
     return (
       <div style={{ minHeight: '100vh', padding: '20px', maxWidth: '480px', margin: '0 auto', fontFamily: 'Verdana, Geneva, sans-serif', boxSizing: 'border-box' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '28px' }}>
-          <Link to="/" style={{ color: 'var(--pe-text-muted)', textDecoration: 'none', fontSize: '22px' }}>←</Link>
-          <img src="/logo.jpeg" alt="DartEvent" style={{ height: '38px' }} />
-        </div>
 
         {/* Erfolgs-Card */}
         <div style={{ background: 'var(--pe-bg-card)', border: '2px solid var(--pe-success)', borderRadius: '16px', padding: '24px', marginBottom: '16px', textAlign: 'center' }}>
@@ -133,11 +129,6 @@ export default function PlayerRegistrationPage() {
   return (
     <div style={{ minHeight: '100vh', padding: '20px', maxWidth: '480px', margin: '0 auto', fontFamily: 'Verdana, Geneva, sans-serif', boxSizing: 'border-box' }}>
 
-      {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px' }}>
-        <Link to={`/tournament/${id}`} style={{ color: 'var(--pe-text-muted)', textDecoration: 'none', fontSize: '22px' }}>←</Link>
-        <img src="/logo.jpeg" alt="DartEvent" style={{ height: '38px' }} />
-      </div>
 
       {/* Turnier-Info */}
       {tournament && (

--- a/frontend/src/pages/PlayerRegistrationPage.jsx
+++ b/frontend/src/pages/PlayerRegistrationPage.jsx
@@ -117,7 +117,7 @@ export default function PlayerRegistrationPage() {
 
         <Link
           to="/"
-          style={{ display: 'block', textAlign: 'center', padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: '#fff', textDecoration: 'none', fontWeight: 'bold', fontSize: '16px', minHeight: '56px', lineHeight: '24px' }}
+          style={{ display: 'block', textAlign: 'center', padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', textDecoration: 'none', fontWeight: 'bold', fontSize: '16px', minHeight: '56px', lineHeight: '24px' }}
         >
           Zur Turnier-Übersicht
         </Link>
@@ -194,7 +194,7 @@ export default function PlayerRegistrationPage() {
           disabled={submitting || !canSubmit || (tournament && tournament.status !== 'open')}
           style={{
             background: canSubmit ? 'var(--pe-gradient)' : 'var(--pe-bg-elevated)',
-            color: '#fff',
+            color: 'var(--pe-text)',
             border: 'none',
             borderRadius: '12px',
             fontSize: '16px',

--- a/frontend/src/pages/TournamentPage.jsx
+++ b/frontend/src/pages/TournamentPage.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { api } from '../api/client';
 import Bracket from '../components/tournament/Bracket';
-import BackButton from '../components/BackButton';
 
 export default function TournamentPage() {
   const { id } = useParams();
@@ -33,10 +32,6 @@ export default function TournamentPage() {
 
   return (
     <div className="min-h-screen p-4 max-w-2xl mx-auto">
-      <div className="flex items-center gap-3 mb-4">
-        <BackButton to="/" />
-        <img src="/logo.jpeg" alt="DartEvent" className="h-10" />
-      </div>
 
       <h1
         className="text-xl font-bold mb-1"

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,16 +1,21 @@
 import { create } from 'zustand';
+import { parseJwt } from '../lib/parseJwt';
 
 export const useStore = create((set) => ({
   token: localStorage.getItem('token'),
+  role:  parseJwt(localStorage.getItem('token'))?.role ?? null,
   admin: null,
+
   setToken: (token) => {
     localStorage.setItem('token', token);
-    set({ token });
+    set({ token, role: parseJwt(token)?.role ?? null });
   },
+
   logout: () => {
     localStorage.removeItem('token');
-    set({ token: null, admin: null });
+    set({ token: null, role: null, admin: null });
   },
+
   currentTournament: null,
   setCurrentTournament: (t) => set({ currentTournament: t }),
 }));


### PR DESCRIPTION
## Summary

Closes #30

- **AppShell layout route** — persistent TopBar + RoleTabs wraps shell pages (`/`, `/tournament/:id`, `/tournament/:id/register`, `/referee/:boardId`, `/gastronomy`); standalone pages (admin, board/TV, NFC, orders, cancel) remain unwrapped
- **TopBar** — two states: root (logo + role pill + avatar/logout) and sub-page (← back + page title + avatar); 64×64px touch targets; PE CSS tokens throughout
- **RoleTabs** — role-aware horizontal tab navigation with correct tab sets per role (public/referee/gastronomy/admin/director); active tab indicator; 64px touch targets
- **Zustand store** — `role` field added, initialised from JWT on page load (persists across hard refresh)
- **CSS utilities** — `pe-card-interactive`, `pe-btn`, `pe-page-enter` added to `index.css`
- **Hover animations** — `pe-card-interactive` on tournament/player/board cards in HomePage; `pe-btn` on FABs
- **BackButton removed** from shell pages (TournamentPage, PlayerRegistrationPage) — TopBar handles back nav
- **Hardcoded colors fixed** — `#fff` → `var(--pe-text)`, hardcoded gradients → `var(--pe-gradient)` in HomePage, GastronomyPage, CurrentGameView, PlayerRegistrationPage
- **Touch targets fixed** — search input (64px), category buttons in GastronomyPage (64px)

## Follow-up issues created

- #54 — Unify back navigation on standalone pages (cancel/orders/nfc)
- #55 — Replace `alert()` with toast notifications in GastronomyPage + RefereePage
- #56 — Activate ProtectedRoute for admin/referee/gastro routes

## Test Plan

- [ ] Visit `/` → TopBar with logo, public tabs (Home · Turnier)
- [ ] Visit `/tournament/:id` → TopBar shows ← + "Turnier-Detail", no tabs
- [ ] Visit `/tournament/:id/register` → TopBar shows ← + "Anmelden", no tabs
- [ ] Visit `/admin` → no TopBar shell
- [ ] Visit `/board/:boardId` → no TopBar shell
- [ ] Login as referee → Boards · Turnier tabs only
- [ ] Login as admin → Home · Turnier · Boards · Gastro · Admin tabs
- [ ] Hard refresh after login → role pill still shown (localStorage persistence)
- [ ] Hover over tournament cards → subtle lift animation
- [ ] `npm run build` → clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)