### PR TITLE
fix: TopBar/HomePage regressions after UI overhaul (#58 #59 #60 #61)

### DIFF
--- a/frontend/src/components/RoleTabs.jsx
+++ b/frontend/src/components/RoleTabs.jsx
@@ -5,11 +5,11 @@ import { useStore } from '../store';
 const TABS = {
   public:     [
     { label: 'Home',    path: '/' },
-    { label: 'Turnier', path: '/tournament' },
+    { label: 'Turnier', path: '/' },
   ],
   referee:    [
     { label: 'Boards',  path: '/referee' },
-    { label: 'Turnier', path: '/tournament' },
+    { label: 'Turnier', path: '/' },
   ],
   gastronomy: [
     { label: 'Bestellungen', path: '/gastronomy' },
@@ -17,15 +17,13 @@ const TABS = {
     { label: 'NFC',          path: '/nfc-scan' },
   ],
   admin: [
-    { label: 'Home',    path: '/' },
-    { label: 'Turnier', path: '/tournament' },
-    { label: 'Boards',  path: '/admin?tab=boards' },
-    { label: 'Gastro',  path: '/gastronomy' },
-    { label: 'Admin',   path: '/admin' },
+    { label: 'Home',   path: '/' },
+    { label: 'Boards', path: '/admin?tab=boards' },
+    { label: 'Gastro', path: '/gastronomy' },
+    { label: 'Admin',  path: '/admin' },
   ],
   director: [
     { label: 'Home',    path: '/' },
-    { label: 'Turnier', path: '/tournament' },
     { label: 'Boards',  path: '/admin?tab=boards' },
     { label: 'Spieler', path: '/admin?tab=players' },
   ],

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -1,4 +1,5 @@
 // frontend/src/components/TopBar.jsx
+import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useStore } from '../store';
 
@@ -12,6 +13,8 @@ const ROLE_PILL = {
 export default function TopBar({ isSubPage = false, title = '', onBack }) {
   const navigate = useNavigate();
   const { role, logout } = useStore();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
 
   const handleBack = () => {
     if (onBack) onBack();
@@ -19,9 +22,26 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
   };
 
   const handleLogout = () => {
+    setMenuOpen(false);
     logout();
     navigate('/');
   };
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    document.addEventListener('touchstart', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('touchstart', handler);
+    };
+  }, [menuOpen]);
 
   const pill = role ? ROLE_PILL[role] : null;
   const initials = role ? role.slice(0, 1).toUpperCase() : '?';
@@ -42,7 +62,7 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
       zIndex: 100,
     }}>
       {isSubPage ? (
-        /* Sub-page: ← back icon — 64×64px tap area via padding around 40px visual icon */
+        /* Sub-page: ← back icon — 64×64px tap area */
         <button
           onClick={handleBack}
           aria-label="Zurück"
@@ -71,7 +91,7 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
       ) : (
         /* Root: logo */
         <img
-          src="/logo.png"
+          src="/logo.jpeg"
           alt="DartEvent"
           style={{ height: '32px', flexShrink: 0, objectFit: 'contain' }}
         />
@@ -86,7 +106,7 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
         )}
       </div>
 
-      {/* Right: role pill (root only) + avatar */}
+      {/* Right: role pill (root only) + avatar with dropdown */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
         {!isSubPage && pill && (
           <span style={{
@@ -102,32 +122,90 @@ export default function TopBar({ isSubPage = false, title = '', onBack }) {
           </span>
         )}
         {role && (
-          <button
-            onClick={handleLogout}
-            aria-label="Abmelden"
-            title="Abmelden"
-            style={{
-              padding: '16px 8px',
-              minWidth: '64px',
-              minHeight: '64px',
-              borderRadius: '50px',
-              background: 'var(--pe-gradient)',
-              border: 'none',
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '11px',
-              fontWeight: 'bold',
-              color: 'var(--pe-text)',
-              fontFamily: 'Verdana, Geneva, sans-serif',
-              transition: 'opacity 150ms ease',
-            }}
-            onMouseEnter={e => e.currentTarget.style.opacity = '0.8'}
-            onMouseLeave={e => e.currentTarget.style.opacity = '1'}
-          >
-            {initials}
-          </button>
+          <div ref={menuRef} style={{ position: 'relative' }}>
+            {/* Avatar button — opens dropdown, does NOT log out directly */}
+            <button
+              onClick={() => setMenuOpen(o => !o)}
+              aria-label="Benutzermenü öffnen"
+              aria-expanded={menuOpen}
+              style={{
+                width: '36px',
+                height: '36px',
+                padding: '14px',
+                minWidth: '64px',
+                minHeight: '64px',
+                boxSizing: 'content-box',
+                borderRadius: '50%',
+                background: 'var(--pe-gradient)',
+                border: 'none',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '13px',
+                fontWeight: 'bold',
+                color: 'var(--pe-text)',
+                fontFamily: 'Verdana, Geneva, sans-serif',
+                transition: 'opacity 150ms ease',
+              }}
+              onMouseEnter={e => e.currentTarget.style.opacity = '0.85'}
+              onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+            >
+              {initials}
+            </button>
+
+            {/* Dropdown */}
+            {menuOpen && (
+              <div style={{
+                position: 'absolute',
+                top: 'calc(100% + 8px)',
+                right: 0,
+                background: 'var(--pe-bg-elevated)',
+                border: '1px solid var(--pe-border)',
+                borderRadius: '12px',
+                minWidth: '160px',
+                padding: '8px',
+                boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+                zIndex: 200,
+                fontFamily: 'Verdana, Geneva, sans-serif',
+              }}>
+                {pill && (
+                  <div style={{
+                    padding: '8px 12px',
+                    fontSize: '11px',
+                    color: pill.color,
+                    fontWeight: 'bold',
+                    borderBottom: '1px solid var(--pe-border)',
+                    marginBottom: '6px',
+                  }}>
+                    {pill.label}
+                  </div>
+                )}
+                <button
+                  onClick={handleLogout}
+                  style={{
+                    width: '100%',
+                    minHeight: '44px',
+                    padding: '10px 12px',
+                    background: 'none',
+                    border: '1px solid var(--pe-border)',
+                    borderRadius: '8px',
+                    color: 'var(--pe-danger)',
+                    cursor: 'pointer',
+                    fontSize: '13px',
+                    fontWeight: 'bold',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                    textAlign: 'left',
+                    transition: 'background 150ms ease',
+                  }}
+                  onMouseEnter={e => e.currentTarget.style.background = 'rgba(255,69,96,0.1)'}
+                  onMouseLeave={e => e.currentTarget.style.background = 'none'}
+                >
+                  Abmelden
+                </button>
+              </div>
+            )}
+          </div>
         )}
       </div>
     </header>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -98,11 +98,6 @@ export default function HomePage() {
 
   return (
     <div style={{ minHeight: '100vh', fontFamily: 'Verdana, Geneva, sans-serif' }}>
-      {/* NEU: Header */}
-      <div style={styles.header}>
-        <img src="/logo.jpeg" alt="DartEvent" style={styles.logo} />
-        <h1 style={styles.title}>DartEvent Manager</h1>
-      </div>
 
       <div style={styles.content}>
         {loading ? (
@@ -357,15 +352,6 @@ export default function HomePage() {
         )}
       </div>
 
-      {/* NEU: Floating Action Buttons */}
-      <div style={styles.fab}>
-        <Link to="/nfc" className="pe-btn" style={styles.fabButton} title="NFC Scan">
-          NFC
-        </Link>
-        <Link to="/admin" className="pe-btn" style={styles.fabButton} title="Admin">
-          &#9881;
-        </Link>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes four regressions introduced by PR #57 (UI/UX Overhaul):

- **#58** — Remove duplicate gradient hero header (`DartEvent Manager` + logo) and redundant NFC/Admin FAB buttons from `HomePage` — navigation is now handled by TopBar + RoleTabs
- **#59** — Fix broken TopBar logo: `src="/logo.png"` → `src="/logo.jpeg"` (only `logo.jpeg` exists in `public/`)
- **#60** — Avatar button regression: was directly logging out on single tap. Now opens a compact dropdown with role label + "Abmelden" button. Tap outside closes without logging out.
- **#61** — "Turnier" tab routed to non-existent `/tournament` (404). Changed to `/`. Admin/director tab sets now have `Turnier` removed (they have "Home" at `/` which serves the same content — avoids duplicate active tab).

## Test Plan

- [ ] TopBar shows logo (not broken image)
- [ ] Tapping avatar opens dropdown; "Abmelden" logs out; tap outside closes
- [ ] HomePage shows no gradient hero / no NFC+⚙ FABs
- [ ] "Turnier" tab (referee/public) navigates to `/` without 404
- [ ] Admin tabs: `Home · Boards · Gastro · Admin` (no duplicate Turnier)
- [ ] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)