### PR TITLE
fix: ProtectedRoute redirects to home instead of blank screen

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import TournamentPage from './pages/TournamentPage';
 import PlayerRegistrationPage from './pages/PlayerRegistrationPage';
@@ -19,9 +19,9 @@ const CancelRegistrationPage = lazy(() => import('./pages/CancelRegistrationPage
 // NEU: Protected Route mit Rollenprüfung
 function ProtectedRoute({ element, roles }) {
   const token = localStorage.getItem('token');
-  if (!token) return null;
+  if (!token) return <Navigate to="/" replace />;
   const payload = parseJwt(token);
-  if (!payload || (roles && !roles.includes(payload.role))) return null;
+  if (!payload || (roles && !roles.includes(payload.role))) return <Navigate to="/" replace />;
   return element;
 }
 
@@ -83,7 +83,7 @@ export default function App() {
         </Route>
 
         {/* ── Standalone routes: no shell ── */}
-        <Route path="/admin/users" element={<AdminPage tab="users" />} />
+        <Route path="/admin/users" element={<ProtectedRoute element={<AdminPage tab="users" />} roles={['admin', 'director']} />} />
         <Route path="/admin" element={<AdminPage />} />
         <Route path="/board/:boardId" element={<CurrentGameView />} />
         <Route path="/nfc" element={<NFCScanPage />} />


### PR DESCRIPTION
## Summary
- Fixed `ProtectedRoute` returning `null` (blank screen) for unauthorized users
- Now redirects to `/` with `<Navigate to="/" replace />` for both missing token and insufficient role
- Applied `ProtectedRoute` with `roles={['admin', 'director']}` to `/admin/users` route

Closes #56

## Test Plan
- [ ] Visit `/admin/users` without being logged in → redirected to `/`
- [ ] Log in as referee/gastronomy role → visiting `/admin/users` redirects to `/`
- [ ] Log in as admin or director → `/admin/users` renders normally