### PR TITLE
fix: scope is_final uniqueness check to same tournament

### DIFF
--- a/backend/src/routes/boards.js
+++ b/backend/src/routes/boards.js
@@ -160,7 +160,12 @@ router.put('/:id/final', requireAdminOrDirector, (req, res) => {
   if (!board) return res.status(404).json({ error: 'Scheibe nicht gefunden' });
 
   if (is_final) {
-    const existingFinal = db.prepare('SELECT id FROM boards WHERE is_final = 1 AND id != ?').get(req.params.id);
+    let existingFinal;
+    if (board.tournament_id != null) {
+      existingFinal = db.prepare('SELECT id FROM boards WHERE is_final = 1 AND id != ? AND tournament_id = ?').get(req.params.id, board.tournament_id);
+    } else {
+      existingFinal = db.prepare('SELECT id FROM boards WHERE is_final = 1 AND id != ? AND tournament_id IS NULL').get(req.params.id);
+    }
     if (existingFinal) {
       return res.status(400).json({ error: 'Es kann nur ein Final-Board geben. Bitte zuerst das andere Board als Final deaktivieren.' });
     }


### PR DESCRIPTION
## Summary
- **Bug:** `PUT /boards/:id/final` checked `is_final` globally across all boards, blocking the update if *any* board (even from another tournament or orphaned) was already marked as final
- **Fix:** Scoped the uniqueness check to `tournament_id`, matching the existing pattern used for board number uniqueness in the POST route
- Handles `NULL` tournament_id (orphaned boards) correctly with `IS NULL` check

Closes #79

## Test plan
- [ ] Create two tournaments, each with boards
- [ ] Mark a board as final in tournament A
- [ ] Verify marking a different board as final in tournament B succeeds (previously failed)
- [ ] Verify marking a second board as final in the *same* tournament still fails correctly
- [ ] Verify orphaned boards (no tournament_id) can be marked as final independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)