### PR TITLE
feat: persistent player lookup and walk-on metadata

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -25,6 +25,7 @@ const productRoutes = require('./routes/products');
 const registrationRoutes = require('./routes/registration');
 const configRoutes = require('./routes/config');
 const walkonRoutes = require('./routes/walkon');
+const historyRoutes = require('./routes/history');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -79,6 +80,7 @@ app.use('/api/products', productRoutes);
 app.use('/api/registration', registrationRoutes);
 app.use('/api/config', configRoutes);
 app.use('/api/walkon', walkonRoutes);
+app.use('/api/history', historyRoutes);
 
 // Health check
 app.get('/api/health', (req, res) => {

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -2,7 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const { db } = require('../db/db');
-const { requireAdmin, requireAdminOrDirector } = require('../middleware/auth');
+const { requireAdmin, requireAdminOrDirector, requireAny } = require('../middleware/auth');
 const { auditLog } = require('../lib/auditLog');
 
 // POST /api/admin/wipe — Alle Turnierdaten löschen (Boards + Users + Produkte bleiben)
@@ -78,6 +78,76 @@ router.get('/logs/export', requireAdmin, (req, res) => {
   res.setHeader('Content-Type', 'text/csv');
   res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
   res.send(csv);
+});
+
+// GET /api/admin/reports/gastro — Gastro report (admin/gastro only)
+router.get('/reports/gastro', requireAny(['admin', 'gastro']), (req, res) => {
+  try {
+    const revenue = db.prepare(`
+      SELECT
+        COALESCE(SUM(o.quantity * p.price), 0) AS total_revenue,
+        COALESCE(SUM(CASE WHEN o.status = 'paid' THEN o.quantity * p.price ELSE 0 END), 0) AS paid_revenue,
+        COALESCE(SUM(CASE WHEN o.status = 'open' THEN o.quantity * p.price ELSE 0 END), 0) AS open_revenue,
+        COUNT(DISTINCT o.id) AS total_orders,
+        COUNT(DISTINCT o.guest_id) AS total_guests
+      FROM orders o
+      JOIN products p ON o.product_id = p.id
+    `).get();
+
+    const topProducts = db.prepare(`
+      SELECT
+        p.id, p.name, p.category, p.price,
+        COALESCE(SUM(o.quantity), 0) AS total_quantity,
+        COALESCE(SUM(o.quantity * p.price), 0) AS total_revenue
+      FROM products p
+      LEFT JOIN orders o ON o.product_id = p.id
+      GROUP BY p.id
+      HAVING total_quantity > 0
+      ORDER BY total_revenue DESC
+    `).all();
+
+    const ordersPerGuest = db.prepare(`
+      SELECT
+        g.id AS guest_id, g.name AS guest_name,
+        COUNT(o.id) AS order_count,
+        COALESCE(SUM(o.quantity), 0) AS total_items,
+        COALESCE(SUM(o.quantity * p.price), 0) AS total_spent,
+        COALESCE(SUM(CASE WHEN o.status = 'open' THEN o.quantity * p.price ELSE 0 END), 0) AS open_amount,
+        COALESCE(SUM(CASE WHEN o.status = 'paid' THEN o.quantity * p.price ELSE 0 END), 0) AS paid_amount
+      FROM guests g
+      JOIN orders o ON o.guest_id = g.id
+      JOIN products p ON o.product_id = p.id
+      GROUP BY g.id
+      ORDER BY total_spent DESC
+    `).all();
+
+    const byCategory = db.prepare(`
+      SELECT
+        p.category,
+        COALESCE(SUM(o.quantity), 0) AS total_quantity,
+        COALESCE(SUM(o.quantity * p.price), 0) AS total_revenue
+      FROM orders o
+      JOIN products p ON o.product_id = p.id
+      GROUP BY p.category
+      ORDER BY total_revenue DESC
+    `).all();
+
+    const settlements = db.prepare(`
+      SELECT COUNT(*) AS count, COALESCE(SUM(total_amount), 0) AS total
+      FROM settlements
+    `).get();
+
+    res.json({
+      revenue,
+      top_products: topProducts,
+      orders_per_guest: ordersPerGuest,
+      by_category: byCategory,
+      settlements,
+    });
+  } catch (err) {
+    console.error('[admin/reports/gastro]', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 
 module.exports = router;

--- a/backend/src/routes/history.js
+++ b/backend/src/routes/history.js
@@ -1,0 +1,192 @@
+const express = require('express');
+const { db } = require('../db/db');
+
+const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// GET /api/history — List all finished tournaments
+// ---------------------------------------------------------------------------
+router.get('/', (req, res) => {
+  try {
+    const tournaments = db.prepare(`
+      SELECT
+        t.id, t.name, t.date, t.format, t.checkout, t.status, t.created_at,
+        COUNT(DISTINCT tr.player_id) AS player_count,
+        COUNT(DISTINCT CASE WHEN g.status = 'finished' THEN g.id END) AS games_played,
+        w.name AS winner_name, w.id AS winner_id
+      FROM tournaments t
+      LEFT JOIN tournament_registrations tr ON tr.tournament_id = t.id
+      LEFT JOIN games g ON g.tournament_id = t.id
+      LEFT JOIN (
+        SELECT g2.tournament_id, g2.winner_id
+        FROM games g2
+        WHERE g2.status = 'finished'
+          AND g2.round = (
+            SELECT MAX(g3.round) FROM games g3
+            WHERE g3.tournament_id = g2.tournament_id AND g3.status = 'finished'
+          )
+      ) final_game ON final_game.tournament_id = t.id
+      LEFT JOIN players w ON w.id = final_game.winner_id
+      WHERE t.status = 'finished'
+      GROUP BY t.id
+      ORDER BY t.date DESC, t.created_at DESC
+    `).all();
+
+    res.json(tournaments);
+  } catch (err) {
+    console.error('[history]', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/history/:id — Tournament detail + per-player stats
+// Stats: 3-dart average, W/L, 180s, checkout%, best leg, highest checkout
+// ---------------------------------------------------------------------------
+router.get('/:id', (req, res) => {
+  try {
+    const tournamentId = parseInt(req.params.id, 10);
+    if (!tournamentId || tournamentId <= 0) {
+      return res.status(400).json({ error: 'Invalid tournament ID' });
+    }
+
+    const tournament = db.prepare(`
+      SELECT id, name, date, format, checkout, status, created_at
+      FROM tournaments WHERE id = ?
+    `).get(tournamentId);
+
+    if (!tournament) {
+      return res.status(404).json({ error: 'Tournament not found' });
+    }
+
+    // Registered players
+    const players = db.prepare(`
+      SELECT p.id, p.name, p.nickname
+      FROM players p
+      JOIN tournament_registrations tr ON tr.player_id = p.id
+      WHERE tr.tournament_id = ?
+      ORDER BY p.name
+    `).all(tournamentId);
+
+    // Prepared statements reused per player
+    const stmtGames = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM games
+      WHERE tournament_id = ? AND status = 'finished'
+        AND (player1_id = ? OR player2_id = ?)
+    `);
+    const stmtWins = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM games
+      WHERE tournament_id = ? AND status = 'finished' AND winner_id = ?
+    `);
+    const stmtThrows = db.prepare(`
+      SELECT t.score, t.remaining, t.segment
+      FROM throws t
+      JOIN games g ON t.game_id = g.id
+      WHERE g.tournament_id = ? AND t.player_id = ? AND t.is_bulloff = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws
+          WHERE undo_of IS NOT NULL
+            AND game_id IN (SELECT id FROM games WHERE tournament_id = ?)
+        )
+      ORDER BY t.id ASC
+    `);
+    const stmtCheckouts = db.prepare(`
+      SELECT t.score AS checkout_score
+      FROM throws t
+      JOIN games g ON t.game_id = g.id
+      WHERE g.tournament_id = ? AND t.player_id = ? AND t.is_bulloff = 0
+        AND t.remaining = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws
+          WHERE undo_of IS NOT NULL
+            AND game_id IN (SELECT id FROM games WHERE tournament_id = ?)
+        )
+    `);
+    const stmtBestLeg = db.prepare(`
+      SELECT g.id AS game_id, COUNT(t.id) AS throw_count
+      FROM games g
+      JOIN throws t ON t.game_id = g.id AND t.player_id = ? AND t.is_bulloff = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws
+          WHERE undo_of IS NOT NULL AND game_id = g.id
+        )
+      WHERE g.tournament_id = ? AND g.status = 'finished' AND g.winner_id = ?
+      GROUP BY g.id
+      ORDER BY throw_count ASC
+      LIMIT 1
+    `);
+
+    const playerStats = players.map(p => {
+      const gamesPlayed = stmtGames.get(tournamentId, p.id, p.id).cnt;
+      const wins = stmtWins.get(tournamentId, p.id).cnt;
+      const losses = gamesPlayed - wins;
+
+      const throws = stmtThrows.all(tournamentId, p.id, tournamentId);
+      const totalScore = throws.reduce((s, t) => s + t.score, 0);
+      const throwCount = throws.length;
+      const threeDartAvg = throwCount >= 3
+        ? Math.round((totalScore / throwCount) * 3 * 100) / 100
+        : null;
+
+      // 180s: groups of 3 consecutive throws summing to 180
+      let oneEighties = 0;
+      for (let i = 0; i + 2 < throws.length; i += 3) {
+        if (throws[i].score + throws[i + 1].score + throws[i + 2].score === 180) {
+          oneEighties++;
+        }
+      }
+
+      const checkouts = stmtCheckouts.all(tournamentId, p.id, tournamentId);
+      const highestCheckout = checkouts.length > 0
+        ? Math.max(...checkouts.map(c => c.checkout_score))
+        : null;
+      const checkoutPct = wins > 0
+        ? Math.round((checkouts.length / wins) * 100 * 100) / 100
+        : null;
+
+      const bestLeg = stmtBestLeg.get(p.id, tournamentId, p.id);
+
+      return {
+        id: p.id,
+        name: p.name,
+        nickname: p.nickname,
+        games_played: gamesPlayed,
+        wins,
+        losses,
+        three_dart_avg: threeDartAvg,
+        one_eighties: oneEighties,
+        checkout_pct: checkoutPct,
+        highest_checkout: highestCheckout,
+        best_leg: bestLeg ? bestLeg.throw_count : null,
+      };
+    });
+
+    // Games list
+    const games = db.prepare(`
+      SELECT g.id, g.round, g.status, g.winner_id,
+        p1.name AS player1_name, p1.id AS player1_id,
+        p2.name AS player2_name, p2.id AS player2_id,
+        w.name AS winner_name
+      FROM games g
+      LEFT JOIN players p1 ON g.player1_id = p1.id
+      LEFT JOIN players p2 ON g.player2_id = p2.id
+      LEFT JOIN players w ON g.winner_id = w.id
+      WHERE g.tournament_id = ?
+      ORDER BY g.round, g.id
+    `).all(tournamentId);
+
+    res.json({
+      tournament,
+      players: playerStats,
+      games,
+    });
+  } catch (err) {
+    console.error('[history]', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/players.js
+++ b/backend/src/routes/players.js
@@ -16,6 +16,9 @@ router.get('/:id/players', (req, res) => {
 
   const players = db.prepare(`
     SELECT p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube,
+           p.walkon_title, p.walkon_artist,
+           (p.walkon_file IS NOT NULL) AS has_walkon,
+           (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
            tr.seed, tr.registered_at, tr.id as registration_id
     FROM players p
     JOIN tournament_registrations tr ON tr.player_id = p.id
@@ -177,7 +180,11 @@ router.delete('/:id/players/:playerId', requireAdminOrDirector, (req, res) => {
 router.get('/', (req, res) => {
   const players = db.prepare(`
     SELECT
-      p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube, p.registered_at,
+      p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube,
+      p.walkon_title, p.walkon_artist,
+      (p.walkon_file IS NOT NULL) AS has_walkon,
+      (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+      p.registered_at,
       COUNT(DISTINCT tr.tournament_id) as tournaments_count,
       COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) as wins,
       COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = p.id OR g.player2_id = p.id) AND g.winner_id != p.id THEN 1 END) as losses

--- a/backend/src/routes/players.js
+++ b/backend/src/routes/players.js
@@ -197,7 +197,133 @@ router.get('/', (req, res) => {
   res.json(players);
 });
 
-// GET /api/players/:id — Spielerprofil mit Turnierhistorie
+// GET /api/players/:id/stats — Career stats across all tournaments
+router.get('/:id/stats', (req, res) => {
+  try {
+    const playerId = parseInt(req.params.id, 10);
+    if (!playerId || playerId <= 0) {
+      return res.status(400).json({ error: 'Invalid player ID' });
+    }
+
+    const player = db.prepare(
+      'SELECT id, name, vorname, nickname, nachname, registered_at FROM players WHERE id = ?'
+    ).get(playerId);
+    if (!player) {
+      return res.status(404).json({ error: 'Player not found' });
+    }
+
+    const totalGames = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM games
+      WHERE status = 'finished' AND (player1_id = ? OR player2_id = ?)
+    `).get(playerId, playerId).cnt;
+
+    const totalWins = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM games
+      WHERE status = 'finished' AND winner_id = ?
+    `).get(playerId).cnt;
+
+    const totalLosses = totalGames - totalWins;
+
+    // All active throws (non-bulloff, non-undone)
+    const allThrows = db.prepare(`
+      SELECT t.score, t.remaining, t.segment
+      FROM throws t
+      JOIN games g ON t.game_id = g.id
+      WHERE t.player_id = ? AND t.is_bulloff = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws WHERE undo_of IS NOT NULL
+        )
+      ORDER BY t.id ASC
+    `).all(playerId);
+
+    const totalScore = allThrows.reduce((s, t) => s + t.score, 0);
+    const throwCount = allThrows.length;
+    const threeDartAvg = throwCount >= 3
+      ? Math.round((totalScore / throwCount) * 3 * 100) / 100
+      : null;
+
+    let oneEighties = 0;
+    for (let i = 0; i + 2 < throwCount; i += 3) {
+      if (allThrows[i].score + allThrows[i + 1].score + allThrows[i + 2].score === 180) {
+        oneEighties++;
+      }
+    }
+
+    const checkouts = allThrows.filter(t => t.remaining === 0);
+    const highestCheckout = checkouts.length > 0
+      ? Math.max(...checkouts.map(c => c.score))
+      : null;
+    const checkoutPct = totalWins > 0
+      ? Math.round((checkouts.length / totalWins) * 100 * 100) / 100
+      : null;
+
+    const bestLeg = db.prepare(`
+      SELECT g.id AS game_id, COUNT(t.id) AS throw_count
+      FROM games g
+      JOIN throws t ON t.game_id = g.id AND t.player_id = ? AND t.is_bulloff = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws WHERE undo_of IS NOT NULL AND game_id = g.id
+        )
+      WHERE g.status = 'finished' AND g.winner_id = ?
+      GROUP BY g.id
+      ORDER BY throw_count ASC
+      LIMIT 1
+    `).get(playerId, playerId);
+
+    const tournamentsPlayed = db.prepare(`
+      SELECT COUNT(DISTINCT tr.tournament_id) AS cnt
+      FROM tournament_registrations tr WHERE tr.player_id = ?
+    `).get(playerId).cnt;
+
+    const tournamentWins = db.prepare(`
+      SELECT COUNT(DISTINCT g.tournament_id) AS cnt
+      FROM games g
+      WHERE g.status = 'finished' AND g.winner_id = ?
+        AND g.round = (
+          SELECT MAX(g2.round) FROM games g2
+          WHERE g2.tournament_id = g.tournament_id AND g2.status = 'finished'
+        )
+    `).get(playerId).cnt;
+
+    const tournamentHistory = db.prepare(`
+      SELECT
+        t.id, t.name, t.date, t.format, t.status AS tournament_status,
+        COUNT(CASE WHEN g.winner_id = ? THEN 1 END) AS wins,
+        COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = ? OR g.player2_id = ?) AND g.winner_id != ? THEN 1 END) AS losses
+      FROM tournament_registrations tr
+      JOIN tournaments t ON tr.tournament_id = t.id
+      LEFT JOIN games g ON g.tournament_id = t.id AND (g.player1_id = ? OR g.player2_id = ?) AND g.status = 'finished'
+      WHERE tr.player_id = ?
+      GROUP BY t.id
+      ORDER BY t.date DESC, t.created_at DESC
+    `).all(playerId, playerId, playerId, playerId, playerId, playerId, playerId);
+
+    res.json({
+      player,
+      career: {
+        tournaments_played: tournamentsPlayed,
+        tournament_wins: tournamentWins,
+        games_played: totalGames,
+        wins: totalWins,
+        losses: totalLosses,
+        win_rate: totalGames > 0 ? Math.round((totalWins / totalGames) * 100 * 100) / 100 : null,
+        three_dart_avg: threeDartAvg,
+        one_eighties: oneEighties,
+        checkout_pct: checkoutPct,
+        highest_checkout: highestCheckout,
+        best_leg: bestLeg ? bestLeg.throw_count : null,
+      },
+      tournament_history: tournamentHistory,
+    });
+  } catch (err) {
+    console.error('[players/stats]', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /api/players/:id/profile — Spielerprofil mit Turnierhistorie
 router.get('/:id/profile', (req, res) => {
   const player = db.prepare('SELECT * FROM players WHERE id = ?').get(req.params.id);
   if (!player) return res.status(404).json({ error: 'Spieler nicht gefunden' });

--- a/backend/src/routes/walkon.js
+++ b/backend/src/routes/walkon.js
@@ -173,7 +173,7 @@ router.get('/:playerId/status', (req, res) => {
   const playerId = parseInt(req.params.playerId, 10);
 
   const player = db.prepare(
-    'SELECT id, walkon_file, walkon_start, walkon_duration, walkon_youtube FROM players WHERE id = ?'
+    'SELECT id, walkon_file, walkon_start, walkon_duration, walkon_youtube, walkon_title, walkon_artist FROM players WHERE id = ?'
   ).get(playerId);
   if (!player) {
     return res.status(404).json({ error: 'Spieler nicht gefunden' });
@@ -189,6 +189,8 @@ router.get('/:playerId/status', (req, res) => {
     walkon_start:    player.walkon_start,
     walkon_duration: player.walkon_duration,
     walkon_url:      player.walkon_youtube,
+    walkon_title:    player.walkon_title,
+    walkon_artist:   player.walkon_artist,
     job:             job || null
   });
 });

--- a/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
+++ b/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
@@ -43,7 +43,7 @@ ALTER TABLE players ADD COLUMN walkon_title  TEXT;
 ALTER TABLE players ADD COLUMN walkon_artist TEXT;
 ```
 
-Migration in `db.js` via try/catch auf ALTER TABLE (identisches Pattern zu bestehenden `vorname`/`nickname`/`nachname` Migrationen).
+Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pattern (SQLite: try/catch auf ALTER).
 
 ---
 
@@ -51,171 +51,58 @@ Migration in `db.js` via try/catch auf ALTER TABLE (identisches Pattern zu beste
 
 #### 1. `GET /api/players/search?q=<term>&tournament_id=<id>`
 
-**Routing — wichtig:** `players.js` ist in `app.js` an **zwei** Pfaden gemountet: `/api/tournaments` und `/api/players`. Eine neue Route in `players.js` würde also auch unter `/api/tournaments/search` erreichbar sein. Um diese Kollision zu vermeiden, wird der Search-Endpoint in einer **eigenen Datei** `backend/src/routes/playerSearch.js` implementiert und in `app.js` ausschließlich unter `/api/players/search` gemountet:
-
-```js
-// app.js
-const playerSearchRoutes = require('./routes/playerSearch');
-app.use('/api/players/search', playerSearchRoutes);
-```
-
-- Kein Auth erforderlich (konsistent mit bestehendem `GET /api/players`; beide Endpunkte sind interne Admin-Tools ohne Zugriff von außen via CORS)
-- Nur ausgeführt wenn `q` mindestens 2 Zeichen lang ist, sonst `400`
-- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE `%q%`, case-insensitive via `LOWER()`)
-- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus (Subquery auf `tournament_registrations`)
+- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE, case-insensitive)
+- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus
 - Gibt max. 10 Treffer zurück
-
-SQL-Grundstruktur:
-```sql
-SELECT
-  p.id, p.name, p.vorname, p.nickname, p.nachname,
-  p.walkon_title, p.walkon_artist,
-  (p.walkon_file IS NOT NULL) AS has_walkon,
-  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
-  COUNT(DISTINCT tr.tournament_id) AS tournaments_count,
-  COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) AS wins,
-  COUNT(CASE WHEN g.status = 'finished'
-        AND (g.player1_id = p.id OR g.player2_id = p.id)
-        AND g.winner_id != p.id THEN 1 END) AS losses
-FROM players p
-LEFT JOIN tournament_registrations tr ON tr.player_id = p.id
-LEFT JOIN games g ON (g.player1_id = p.id OR g.player2_id = p.id) AND g.status = 'finished'
-WHERE (
-  LOWER(p.name) LIKE LOWER(?)
-  OR LOWER(p.nickname) LIKE LOWER(?)
-  OR LOWER(p.vorname) LIKE LOWER(?)
-  OR LOWER(p.nachname) LIKE LOWER(?)
-)
-AND (? IS NULL OR p.id NOT IN (
-  SELECT player_id FROM tournament_registrations WHERE tournament_id = ?
-))
-GROUP BY p.id
-ORDER BY p.name ASC
-LIMIT 10
-```
-
-Die correlated Subquery für `walkon_status` steht im SELECT-List (nicht im WHERE/JOIN) — kein Einfluss auf GROUP BY.
-
-Response pro Spieler:
-```json
-{
-  "id": 1,
-  "name": "Martin \"Ace\" Hofmann",
-  "vorname": "Martin",
-  "nickname": "Ace",
-  "nachname": "Hofmann",
-  "walkon_title": "Seven Nation Army",
-  "walkon_artist": "The White Stripes",
-  "has_walkon": true,
-  "walkon_status": "ready",
-  "tournaments_count": 3,
-  "wins": 12,
-  "losses": 4
-}
-```
+- Response pro Spieler:
+  ```json
+  {
+    "id": 1,
+    "name": "Martin \"Ace\" Hofmann",
+    "vorname": "Martin",
+    "nickname": "Ace",
+    "nachname": "Hofmann",
+    "walkon_title": "Seven Nation Army",
+    "walkon_artist": "The White Stripes",
+    "walkon_file": "/path/or/null",
+    "tournaments_count": 3,
+    "wins": 12,
+    "losses": 4
+  }
+  ```
+- Kein Auth erforderlich (öffentliche Spielerdaten)
 
 #### 2. `POST /api/tournaments/:id/players` — Erweiterung
 
 Neuer optionaler Body-Parameter: `player_id` (Integer).
 
-**Wenn `player_id` gesetzt:**
-- Bestehende `requireFields(['vorname', 'nickname', 'nachname'])` Middleware wird durch **inline konditionelle Validierung** ersetzt (Middleware komplett entfernen, Validierung in den Route-Handler verlagern):
-  ```js
-  if (req.body.player_id) {
-    const pid = parseInt(req.body.player_id, 10);
-    if (!pid || pid <= 0) return res.status(400).json({ error: 'Ungültige player_id' });
-  } else {
-    if (!req.body.vorname || !req.body.nickname || !req.body.nachname) {
-      return res.status(400).json({ error: 'vorname, nickname und nachname sind Pflichtfelder' });
-    }
-  }
-  ```
-- Tournament-Status-Prüfung (`status !== 'open'` → 400) gilt **auch** für den `player_id`-Pfad
-- Spieler muss in `players` existieren → 404 wenn nicht gefunden
-- Expliziter Duplikat-Check: `SELECT id FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?` → 409 mit Meldung `"Spieler ist bereits in diesem Turnier angemeldet"`
-- Direkt `tournament_registrations` Eintrag anlegen ohne Profil anzulegen
-- `walkon_youtube` aus dem Body wird bei `player_id`-Pfad ignoriert
-- `seed`: optionaler Integer (kein Eindeutigkeits-Check — konsistent mit bestehendem Verhalten)
-
-**Wenn `player_id` nicht gesetzt:**
-- Bisheriges Verhalten vollständig erhalten (Profil per Nickname suchen oder neu anlegen, `walkon_youtube` aus Body verarbeiten)
+- Wenn `player_id` gesetzt: Spieler muss existieren → direkt `tournament_registrations` Eintrag anlegen, kein neues Profil erstellen
+- Wenn `player_id` nicht gesetzt: bisheriges Verhalten (Profil per Nickname suchen oder neu anlegen)
+- Duplikat-Check bleibt: gleicher Spieler darf nicht zweimal im selben Turnier angemeldet sein
 
 #### 3. Walk-On Route — Metadaten-Extraktion
 
-Metadaten-Extraktion läuft **vor** dem finalen `status = 'ready'` Update.
+Nach erfolgreichem yt-dlp Audio-Download:
 
-Reihenfolge in `downloadWalkon()`:
-
-```
-1. yt-dlp download → tempPath
-2. ffmpeg trim → finalPath
-3. tempPath löschen
-4. walkon_file in players aktualisieren
-5. [NEU] yt-dlp --print metadata → walkon_artist/walkon_title extrahieren (try/catch, jobId-Check)
-6. [NEU] walkon_title + walkon_artist in players aktualisieren
-7. Job status → 'ready'
+```bash
+yt-dlp --no-playlist --print title --print uploader <url>
 ```
 
-Metadaten-Extraktion (Schritt 5):
+Gibt zwei Zeilen aus: Zeile 1 = Titel, Zeile 2 = Uploader/Artist.
 
 ```js
-try {
-  // Prüfen ob dieser Job noch der aktuelle ist (Race-Condition-Schutz)
-  const currentJob = db.prepare('SELECT id FROM walkon_jobs WHERE player_id = ? ORDER BY id DESC LIMIT 1').get(playerId);
-  if (currentJob && currentJob.id === jobId) {
-    const meta = await new Promise((resolve) => {
-      const dlp = spawn('yt-dlp', [
-        '--no-playlist',
-        '--print', '%(artist,uploader)s',
-        '--print', 'title',
-        url
-      ]);
-      let out = '';
-      dlp.stdout.on('data', (d) => { out += d.toString(); });
-      dlp.on('close', () => resolve(out));
-      dlp.on('error', () => resolve(''));
-    });
-    const lines = meta.trim().split(/\r?\n/).map(l => l.trim());
-    const artist = (lines[0] && lines[0] !== 'NA') ? lines[0] : null;
-    const title  = (lines[1] && lines[1] !== 'NA') ? lines[1] : null;
-    db.prepare('UPDATE players SET walkon_artist = ?, walkon_title = ? WHERE id = ?').run(artist, title, playerId);
-  }
-} catch (_) { /* stilles Fallback */ }
+db.prepare('UPDATE players SET walkon_title = ?, walkon_artist = ? WHERE id = ?')
+  .run(title, artist, playerId);
 ```
 
-**DELETE `/api/walkon/:playerId`:** Bestehender Handler muss `walkon_title` und `walkon_artist` ebenfalls auf NULL zurücksetzen:
-```sql
-UPDATE players SET walkon_file = NULL, walkon_youtube = NULL,
-  walkon_start = NULL, walkon_duration = NULL,
-  walkon_title = NULL, walkon_artist = NULL
-WHERE id = ?
-```
-
-Wenn `has_walkon = false` (nach DELETE), ist `walkon_status` aus der Subquery NULL — kein Badge wird angezeigt. Der Fall "kein Badge" greift sobald `has_walkon` falsy ist, unabhängig von `walkon_status`.
+Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `ready`, Felder bleiben `NULL`.
 
 #### 4. Player-Responses erweitern
 
-`walkon_title`, `walkon_artist`, `has_walkon` und `walkon_status` in folgenden Responses ergänzen:
-
-- **`GET /api/players`** — `walkon_title`, `walkon_artist`, `has_walkon`, `walkon_status` (correlated Subquery im SELECT-List, nicht als JOIN — bestehende GROUP BY-Aggregation bleibt erhalten)
-- **`GET /api/tournaments/:id/players`** — `walkon_title`, `walkon_artist`, `walkon_status`, `has_walkon` via correlated Subquery ergänzen:
-  ```sql
-  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
-  (p.walkon_file IS NOT NULL) AS has_walkon
-  ```
-- **`GET /api/walkon/:playerId/status`** — Response um `walkon_title`, `walkon_artist` erweitern:
-  ```json
-  {
-    "player_id": 1,
-    "walkon_file": "/abs/path",
-    "walkon_start": 30,
-    "walkon_duration": 20,
-    "walkon_url": "https://...",
-    "walkon_title": "Seven Nation Army",
-    "walkon_artist": "The White Stripes",
-    "job": { "status": "ready", "id": 5 }
-  }
-  ```
+`walkon_title` und `walkon_artist` in allen bestehenden Player-Responses ergänzen:
+- `GET /api/players`
+- `GET /api/tournaments/:id/players`
+- `GET /api/walkon/:playerId/status`
 
 ---
 
@@ -223,78 +110,74 @@ Wenn `has_walkon = false` (nach DELETE), ist `walkon_status` aus der Subquery NU
 
 #### Spieler-Karte (Badge-Stil)
 
-Badge liest `walkon_status` direkt aus dem Player-Objekt (kein separater Polling-Call beim initialen Laden). Polling für laufende Downloads läuft weiterhin via `GET /api/walkon/:playerId/status`.
+Wenn Walk-On vorhanden (`walkon_youtube` gesetzt) und Status bekannt:
 
-| Bedingung | Badge |
-|-----------|-------|
-| `has_walkon` + `ready` + Metadaten vorhanden | `♪ {artist} — {title}` (grüner Badge) |
-| `has_walkon` + `ready` + keine Metadaten | `♪ bereit` (grüner Badge) |
+| Status | Badge |
+|--------|-------|
+| `ready` | `♪ Artist — Titel` (grüner Badge) |
 | `pending` / `downloading` | `⏳ lädt…` (gelber Badge) |
 | `error` | `✗ Fehler` (roter Badge) |
-| `!has_walkon` | kein Badge |
+| kein Walk-On | kein Badge |
 
-Badge-CSS (PE-Tokens):
+Badge-Stil:
 ```css
-/* ready */  background: rgba(0,229,160,0.1); border: 1px solid rgba(0,229,160,0.3); color: var(--pe-success);
-/* warning */ background: rgba(255,176,32,0.1); border: 1px solid rgba(255,176,32,0.3); color: var(--pe-warning);
-/* error */  background: rgba(255,69,96,0.1);  border: 1px solid rgba(255,69,96,0.3);  color: var(--pe-danger);
-/* shared */ border-radius: 6px; padding: 2px 7px; font-size: 11px; display: inline-flex; align-items: center; gap: 4px;
+background: rgba(0,229,160,0.1);
+border: 1px solid rgba(0,229,160,0.3);
+border-radius: 6px;
+padding: 2px 7px;
+font-size: 11px;
+color: var(--pe-success);
 ```
+
+Wenn `walkon_title` / `walkon_artist` vorhanden: `♪ {artist} — {title}` anzeigen.
+Wenn nicht vorhanden aber ready: `♪ bereit` anzeigen.
 
 #### Spieler hinzufügen — Suchflow
 
-Das bestehende Formular wird durch einen 2-Modus-Flow ersetzt:
+Das bestehende Formular (Vorname / Nickname / Nachname) wird durch einen 2-Modus-Flow ersetzt:
 
 **Modus 1: Suche (Standard)**
 
-1. Suchfeld — Debounce 300ms, min. 2 Zeichen → `GET /api/players/search?q=...&tournament_id=...`
-2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge wenn `has_walkon`
-3. 0 Treffer → Leer-Zustand + `+ Neuen Spieler anlegen "{Suchbegriff}"` CTA
-4. Klick auf Spieler → Confirm-Panel:
-   - Name, Stats, Walk-On Badge
-   - Optionales Setzungs-Feld (positive Integer)
-   - „Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
-   - „Abbrechen" → zurück zur Liste
-5. Unten: `+ Neuen Spieler anlegen` → Modus 2
+1. Suchfeld (Debounce 300ms) → `GET /api/players/search?q=...&tournament_id=...`
+2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge
+3. Klick auf Spieler → Confirm-Panel erscheint:
+   - Spielerinfo (Name, Stats, Walk-On)
+   - Optionales Setzungs-Feld
+   - "Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
+4. Unten: "+ Neuen Spieler anlegen" → wechselt zu Modus 2
 
 **Modus 2: Neuer Spieler**
 
 - Bisheriges Formular (Vorname / Nickname / Nachname / Walk-On URL / Start / Dauer)
-- Nickname vorausgefüllt aus Suchbegriff (falls aus Modus 1 gewechselt)
-- `← Zurück zur Suche` Link oben
+- "Zurück zur Suche" Link oben
+- Nickname wird aus dem Suchbegriff vorausgefüllt wenn vorhanden
 
 ---
 
 ## Fehlerbehandlung
 
-| Szenario | Verhalten |
-|----------|-----------|
-| `q` < 2 Zeichen | Keine API-Anfrage |
-| 0 Suchergebnisse | Leer-Zustand + CTA |
-| `player_id` nicht gefunden | 404 → Toast |
-| Spieler bereits im Turnier | 409 → Toast |
-| Turnier nicht `open` | 400 → Toast |
-| yt-dlp Metadaten-Fehler | Stilles Fallback, Status bleibt `ready` |
-| Zweiter Download während Metadaten-Extraktion | jobId-Check verhindert falschen Metadaten-Write |
+- Suchfeld leer oder < 2 Zeichen: keine API-Anfrage, keine Ergebnisliste
+- Keine Treffer: leerer Zustand mit "+ Neuen Spieler anlegen" CTA
+- `player_id` nicht gefunden: Backend gibt `404` zurück
+- Spieler bereits im Turnier: Backend gibt `409` zurück mit erklärender Meldung
+- yt-dlp Metadaten-Fehler: stilles Fallback, kein Einfluss auf Download-Status
 
 ---
 
 ## Implementierungsreihenfolge
 
-1. DB-Migration (`walkon_title`, `walkon_artist` in `db.js`)
-2. Backend: `playerSearch.js` neu anlegen + in `app.js` mounten
-3. Backend: `POST /api/tournaments/:id/players` um `player_id` erweitern
-4. Backend: Walk-On `DELETE` Handler um neue Felder erweitern
-5. Backend: Walk-On Metadaten-Extraktion in `downloadWalkon()` (inkl. jobId-Check)
-6. Backend: Player-Responses um neue Felder erweitern
-7. Frontend: Walk-On Badge in Spieler-Karte
-8. Frontend: Suchflow (Modus 1 + Modus 2)
+1. DB-Migration (walkon_title, walkon_artist)
+2. Backend: Search-Endpunkt
+3. Backend: POST players mit player_id
+4. Backend: Walk-On Metadaten-Extraktion
+5. Backend: Player-Responses erweitern
+6. Frontend: Spieler-Karte Badge
+7. Frontend: Suchflow
 
 ---
 
 ## Nicht geändert
 
-- Walk-On bleibt am `players`-Profil gebunden
-- `cancel_token` Mechanismus unverändert
-- Edit-Dialog für Spielerprofil-Daten unverändert
-- Audio-Streaming via `GET /api/walkon/:playerId/audio` unverändert
+- Walk-On ist und bleibt am `players`-Profil gebunden (nicht an `tournament_registrations`)
+- `cancel_token` Mechanismus bleibt unverändert
+- Spielerprofil-Daten (Name, Nickname) bleiben editierbar im bestehenden Edit-Dialog

--- a/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
+++ b/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
@@ -43,7 +43,7 @@ ALTER TABLE players ADD COLUMN walkon_title  TEXT;
 ALTER TABLE players ADD COLUMN walkon_artist TEXT;
 ```
 
-Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pattern (SQLite: try/catch auf ALTER).
+Migration in `db.js` via try/catch auf ALTER TABLE (identisches Pattern zu bestehenden `vorname`/`nickname`/`nachname` Migrationen).
 
 ---
 
@@ -51,58 +51,171 @@ Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pa
 
 #### 1. `GET /api/players/search?q=<term>&tournament_id=<id>`
 
-- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE, case-insensitive)
-- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus
+**Routing — wichtig:** `players.js` ist in `app.js` an **zwei** Pfaden gemountet: `/api/tournaments` und `/api/players`. Eine neue Route in `players.js` würde also auch unter `/api/tournaments/search` erreichbar sein. Um diese Kollision zu vermeiden, wird der Search-Endpoint in einer **eigenen Datei** `backend/src/routes/playerSearch.js` implementiert und in `app.js` ausschließlich unter `/api/players/search` gemountet:
+
+```js
+// app.js
+const playerSearchRoutes = require('./routes/playerSearch');
+app.use('/api/players/search', playerSearchRoutes);
+```
+
+- Kein Auth erforderlich (konsistent mit bestehendem `GET /api/players`; beide Endpunkte sind interne Admin-Tools ohne Zugriff von außen via CORS)
+- Nur ausgeführt wenn `q` mindestens 2 Zeichen lang ist, sonst `400`
+- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE `%q%`, case-insensitive via `LOWER()`)
+- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus (Subquery auf `tournament_registrations`)
 - Gibt max. 10 Treffer zurück
-- Response pro Spieler:
-  ```json
-  {
-    "id": 1,
-    "name": "Martin \"Ace\" Hofmann",
-    "vorname": "Martin",
-    "nickname": "Ace",
-    "nachname": "Hofmann",
-    "walkon_title": "Seven Nation Army",
-    "walkon_artist": "The White Stripes",
-    "walkon_file": "/path/or/null",
-    "tournaments_count": 3,
-    "wins": 12,
-    "losses": 4
-  }
-  ```
-- Kein Auth erforderlich (öffentliche Spielerdaten)
+
+SQL-Grundstruktur:
+```sql
+SELECT
+  p.id, p.name, p.vorname, p.nickname, p.nachname,
+  p.walkon_title, p.walkon_artist,
+  (p.walkon_file IS NOT NULL) AS has_walkon,
+  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+  COUNT(DISTINCT tr.tournament_id) AS tournaments_count,
+  COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) AS wins,
+  COUNT(CASE WHEN g.status = 'finished'
+        AND (g.player1_id = p.id OR g.player2_id = p.id)
+        AND g.winner_id != p.id THEN 1 END) AS losses
+FROM players p
+LEFT JOIN tournament_registrations tr ON tr.player_id = p.id
+LEFT JOIN games g ON (g.player1_id = p.id OR g.player2_id = p.id) AND g.status = 'finished'
+WHERE (
+  LOWER(p.name) LIKE LOWER(?)
+  OR LOWER(p.nickname) LIKE LOWER(?)
+  OR LOWER(p.vorname) LIKE LOWER(?)
+  OR LOWER(p.nachname) LIKE LOWER(?)
+)
+AND (? IS NULL OR p.id NOT IN (
+  SELECT player_id FROM tournament_registrations WHERE tournament_id = ?
+))
+GROUP BY p.id
+ORDER BY p.name ASC
+LIMIT 10
+```
+
+Die correlated Subquery für `walkon_status` steht im SELECT-List (nicht im WHERE/JOIN) — kein Einfluss auf GROUP BY.
+
+Response pro Spieler:
+```json
+{
+  "id": 1,
+  "name": "Martin \"Ace\" Hofmann",
+  "vorname": "Martin",
+  "nickname": "Ace",
+  "nachname": "Hofmann",
+  "walkon_title": "Seven Nation Army",
+  "walkon_artist": "The White Stripes",
+  "has_walkon": true,
+  "walkon_status": "ready",
+  "tournaments_count": 3,
+  "wins": 12,
+  "losses": 4
+}
+```
 
 #### 2. `POST /api/tournaments/:id/players` — Erweiterung
 
 Neuer optionaler Body-Parameter: `player_id` (Integer).
 
-- Wenn `player_id` gesetzt: Spieler muss existieren → direkt `tournament_registrations` Eintrag anlegen, kein neues Profil erstellen
-- Wenn `player_id` nicht gesetzt: bisheriges Verhalten (Profil per Nickname suchen oder neu anlegen)
-- Duplikat-Check bleibt: gleicher Spieler darf nicht zweimal im selben Turnier angemeldet sein
+**Wenn `player_id` gesetzt:**
+- Bestehende `requireFields(['vorname', 'nickname', 'nachname'])` Middleware wird durch **inline konditionelle Validierung** ersetzt (Middleware komplett entfernen, Validierung in den Route-Handler verlagern):
+  ```js
+  if (req.body.player_id) {
+    const pid = parseInt(req.body.player_id, 10);
+    if (!pid || pid <= 0) return res.status(400).json({ error: 'Ungültige player_id' });
+  } else {
+    if (!req.body.vorname || !req.body.nickname || !req.body.nachname) {
+      return res.status(400).json({ error: 'vorname, nickname und nachname sind Pflichtfelder' });
+    }
+  }
+  ```
+- Tournament-Status-Prüfung (`status !== 'open'` → 400) gilt **auch** für den `player_id`-Pfad
+- Spieler muss in `players` existieren → 404 wenn nicht gefunden
+- Expliziter Duplikat-Check: `SELECT id FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?` → 409 mit Meldung `"Spieler ist bereits in diesem Turnier angemeldet"`
+- Direkt `tournament_registrations` Eintrag anlegen ohne Profil anzulegen
+- `walkon_youtube` aus dem Body wird bei `player_id`-Pfad ignoriert
+- `seed`: optionaler Integer (kein Eindeutigkeits-Check — konsistent mit bestehendem Verhalten)
+
+**Wenn `player_id` nicht gesetzt:**
+- Bisheriges Verhalten vollständig erhalten (Profil per Nickname suchen oder neu anlegen, `walkon_youtube` aus Body verarbeiten)
 
 #### 3. Walk-On Route — Metadaten-Extraktion
 
-Nach erfolgreichem yt-dlp Audio-Download:
+Metadaten-Extraktion läuft **vor** dem finalen `status = 'ready'` Update.
 
-```bash
-yt-dlp --no-playlist --print title --print uploader <url>
+Reihenfolge in `downloadWalkon()`:
+
+```
+1. yt-dlp download → tempPath
+2. ffmpeg trim → finalPath
+3. tempPath löschen
+4. walkon_file in players aktualisieren
+5. [NEU] yt-dlp --print metadata → walkon_artist/walkon_title extrahieren (try/catch, jobId-Check)
+6. [NEU] walkon_title + walkon_artist in players aktualisieren
+7. Job status → 'ready'
 ```
 
-Gibt zwei Zeilen aus: Zeile 1 = Titel, Zeile 2 = Uploader/Artist.
+Metadaten-Extraktion (Schritt 5):
 
 ```js
-db.prepare('UPDATE players SET walkon_title = ?, walkon_artist = ? WHERE id = ?')
-  .run(title, artist, playerId);
+try {
+  // Prüfen ob dieser Job noch der aktuelle ist (Race-Condition-Schutz)
+  const currentJob = db.prepare('SELECT id FROM walkon_jobs WHERE player_id = ? ORDER BY id DESC LIMIT 1').get(playerId);
+  if (currentJob && currentJob.id === jobId) {
+    const meta = await new Promise((resolve) => {
+      const dlp = spawn('yt-dlp', [
+        '--no-playlist',
+        '--print', '%(artist,uploader)s',
+        '--print', 'title',
+        url
+      ]);
+      let out = '';
+      dlp.stdout.on('data', (d) => { out += d.toString(); });
+      dlp.on('close', () => resolve(out));
+      dlp.on('error', () => resolve(''));
+    });
+    const lines = meta.trim().split(/\r?\n/).map(l => l.trim());
+    const artist = (lines[0] && lines[0] !== 'NA') ? lines[0] : null;
+    const title  = (lines[1] && lines[1] !== 'NA') ? lines[1] : null;
+    db.prepare('UPDATE players SET walkon_artist = ?, walkon_title = ? WHERE id = ?').run(artist, title, playerId);
+  }
+} catch (_) { /* stilles Fallback */ }
 ```
 
-Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `ready`, Felder bleiben `NULL`.
+**DELETE `/api/walkon/:playerId`:** Bestehender Handler muss `walkon_title` und `walkon_artist` ebenfalls auf NULL zurücksetzen:
+```sql
+UPDATE players SET walkon_file = NULL, walkon_youtube = NULL,
+  walkon_start = NULL, walkon_duration = NULL,
+  walkon_title = NULL, walkon_artist = NULL
+WHERE id = ?
+```
+
+Wenn `has_walkon = false` (nach DELETE), ist `walkon_status` aus der Subquery NULL — kein Badge wird angezeigt. Der Fall "kein Badge" greift sobald `has_walkon` falsy ist, unabhängig von `walkon_status`.
 
 #### 4. Player-Responses erweitern
 
-`walkon_title` und `walkon_artist` in allen bestehenden Player-Responses ergänzen:
-- `GET /api/players`
-- `GET /api/tournaments/:id/players`
-- `GET /api/walkon/:playerId/status`
+`walkon_title`, `walkon_artist`, `has_walkon` und `walkon_status` in folgenden Responses ergänzen:
+
+- **`GET /api/players`** — `walkon_title`, `walkon_artist`, `has_walkon`, `walkon_status` (correlated Subquery im SELECT-List, nicht als JOIN — bestehende GROUP BY-Aggregation bleibt erhalten)
+- **`GET /api/tournaments/:id/players`** — `walkon_title`, `walkon_artist`, `walkon_status`, `has_walkon` via correlated Subquery ergänzen:
+  ```sql
+  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+  (p.walkon_file IS NOT NULL) AS has_walkon
+  ```
+- **`GET /api/walkon/:playerId/status`** — Response um `walkon_title`, `walkon_artist` erweitern:
+  ```json
+  {
+    "player_id": 1,
+    "walkon_file": "/abs/path",
+    "walkon_start": 30,
+    "walkon_duration": 20,
+    "walkon_url": "https://...",
+    "walkon_title": "Seven Nation Army",
+    "walkon_artist": "The White Stripes",
+    "job": { "status": "ready", "id": 5 }
+  }
+  ```
 
 ---
 
@@ -110,74 +223,78 @@ Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `
 
 #### Spieler-Karte (Badge-Stil)
 
-Wenn Walk-On vorhanden (`walkon_youtube` gesetzt) und Status bekannt:
+Badge liest `walkon_status` direkt aus dem Player-Objekt (kein separater Polling-Call beim initialen Laden). Polling für laufende Downloads läuft weiterhin via `GET /api/walkon/:playerId/status`.
 
-| Status | Badge |
-|--------|-------|
-| `ready` | `♪ Artist — Titel` (grüner Badge) |
+| Bedingung | Badge |
+|-----------|-------|
+| `has_walkon` + `ready` + Metadaten vorhanden | `♪ {artist} — {title}` (grüner Badge) |
+| `has_walkon` + `ready` + keine Metadaten | `♪ bereit` (grüner Badge) |
 | `pending` / `downloading` | `⏳ lädt…` (gelber Badge) |
 | `error` | `✗ Fehler` (roter Badge) |
-| kein Walk-On | kein Badge |
+| `!has_walkon` | kein Badge |
 
-Badge-Stil:
+Badge-CSS (PE-Tokens):
 ```css
-background: rgba(0,229,160,0.1);
-border: 1px solid rgba(0,229,160,0.3);
-border-radius: 6px;
-padding: 2px 7px;
-font-size: 11px;
-color: var(--pe-success);
+/* ready */  background: rgba(0,229,160,0.1); border: 1px solid rgba(0,229,160,0.3); color: var(--pe-success);
+/* warning */ background: rgba(255,176,32,0.1); border: 1px solid rgba(255,176,32,0.3); color: var(--pe-warning);
+/* error */  background: rgba(255,69,96,0.1);  border: 1px solid rgba(255,69,96,0.3);  color: var(--pe-danger);
+/* shared */ border-radius: 6px; padding: 2px 7px; font-size: 11px; display: inline-flex; align-items: center; gap: 4px;
 ```
-
-Wenn `walkon_title` / `walkon_artist` vorhanden: `♪ {artist} — {title}` anzeigen.
-Wenn nicht vorhanden aber ready: `♪ bereit` anzeigen.
 
 #### Spieler hinzufügen — Suchflow
 
-Das bestehende Formular (Vorname / Nickname / Nachname) wird durch einen 2-Modus-Flow ersetzt:
+Das bestehende Formular wird durch einen 2-Modus-Flow ersetzt:
 
 **Modus 1: Suche (Standard)**
 
-1. Suchfeld (Debounce 300ms) → `GET /api/players/search?q=...&tournament_id=...`
-2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge
-3. Klick auf Spieler → Confirm-Panel erscheint:
-   - Spielerinfo (Name, Stats, Walk-On)
-   - Optionales Setzungs-Feld
-   - "Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
-4. Unten: "+ Neuen Spieler anlegen" → wechselt zu Modus 2
+1. Suchfeld — Debounce 300ms, min. 2 Zeichen → `GET /api/players/search?q=...&tournament_id=...`
+2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge wenn `has_walkon`
+3. 0 Treffer → Leer-Zustand + `+ Neuen Spieler anlegen "{Suchbegriff}"` CTA
+4. Klick auf Spieler → Confirm-Panel:
+   - Name, Stats, Walk-On Badge
+   - Optionales Setzungs-Feld (positive Integer)
+   - „Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
+   - „Abbrechen" → zurück zur Liste
+5. Unten: `+ Neuen Spieler anlegen` → Modus 2
 
 **Modus 2: Neuer Spieler**
 
 - Bisheriges Formular (Vorname / Nickname / Nachname / Walk-On URL / Start / Dauer)
-- "Zurück zur Suche" Link oben
-- Nickname wird aus dem Suchbegriff vorausgefüllt wenn vorhanden
+- Nickname vorausgefüllt aus Suchbegriff (falls aus Modus 1 gewechselt)
+- `← Zurück zur Suche` Link oben
 
 ---
 
 ## Fehlerbehandlung
 
-- Suchfeld leer oder < 2 Zeichen: keine API-Anfrage, keine Ergebnisliste
-- Keine Treffer: leerer Zustand mit "+ Neuen Spieler anlegen" CTA
-- `player_id` nicht gefunden: Backend gibt `404` zurück
-- Spieler bereits im Turnier: Backend gibt `409` zurück mit erklärender Meldung
-- yt-dlp Metadaten-Fehler: stilles Fallback, kein Einfluss auf Download-Status
+| Szenario | Verhalten |
+|----------|-----------|
+| `q` < 2 Zeichen | Keine API-Anfrage |
+| 0 Suchergebnisse | Leer-Zustand + CTA |
+| `player_id` nicht gefunden | 404 → Toast |
+| Spieler bereits im Turnier | 409 → Toast |
+| Turnier nicht `open` | 400 → Toast |
+| yt-dlp Metadaten-Fehler | Stilles Fallback, Status bleibt `ready` |
+| Zweiter Download während Metadaten-Extraktion | jobId-Check verhindert falschen Metadaten-Write |
 
 ---
 
 ## Implementierungsreihenfolge
 
-1. DB-Migration (walkon_title, walkon_artist)
-2. Backend: Search-Endpunkt
-3. Backend: POST players mit player_id
-4. Backend: Walk-On Metadaten-Extraktion
-5. Backend: Player-Responses erweitern
-6. Frontend: Spieler-Karte Badge
-7. Frontend: Suchflow
+1. DB-Migration (`walkon_title`, `walkon_artist` in `db.js`)
+2. Backend: `playerSearch.js` neu anlegen + in `app.js` mounten
+3. Backend: `POST /api/tournaments/:id/players` um `player_id` erweitern
+4. Backend: Walk-On `DELETE` Handler um neue Felder erweitern
+5. Backend: Walk-On Metadaten-Extraktion in `downloadWalkon()` (inkl. jobId-Check)
+6. Backend: Player-Responses um neue Felder erweitern
+7. Frontend: Walk-On Badge in Spieler-Karte
+8. Frontend: Suchflow (Modus 1 + Modus 2)
 
 ---
 
 ## Nicht geändert
 
-- Walk-On ist und bleibt am `players`-Profil gebunden (nicht an `tournament_registrations`)
-- `cancel_token` Mechanismus bleibt unverändert
-- Spielerprofil-Daten (Name, Nickname) bleiben editierbar im bestehenden Edit-Dialog
+- Walk-On bleibt am `players`-Profil gebunden
+- `cancel_token` Mechanismus unverändert
+- Edit-Dialog für Spielerprofil-Daten unverändert
+- Audio-Streaming via `GET /api/walkon/:playerId/audio` unverändert

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -514,6 +514,7 @@ function PlayersTab() {
       setAddMode(null);
       setSearchQuery('');
       setSearchResults([]);
+      setConfirmPlayer(null);
       await loadPlayers();
     } catch (err) {
       addToast({ type: 'error', message: err.message || 'Spieler konnte nicht angelegt werden' });

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -310,12 +310,47 @@ function BoardsTab() {
 
 // NEU: Tab "Spieler" — Anlegen, Walk-On Song, Statistiken
 // Walk-On Status Badge
-function WalkonBadge({ status }) {
-  if (!status) return <span style={{ fontSize: '11px', color: 'var(--pe-text-muted)', marginLeft: '6px' }}>♪</span>;
-  if (status === 'ready') return <span style={{ fontSize: '11px', color: 'var(--pe-success)', marginLeft: '6px' }} title="Bereit">✓</span>;
-  if (status === 'error') return <span style={{ fontSize: '11px', color: 'var(--pe-danger)', marginLeft: '6px' }} title="Fehler">✗</span>;
-  if (status === 'pending' || status === 'downloading') return <span style={{ fontSize: '11px', color: 'var(--pe-warning)', marginLeft: '6px' }} title="Wird geladen">⏳</span>;
-  return <span style={{ fontSize: '11px', color: 'var(--pe-text-muted)', marginLeft: '6px' }}>♪</span>;
+function WalkonBadge({ status, title, artist }) {
+  let bg, border, color, text;
+
+  if (status === 'ready') {
+    bg     = 'rgba(0,229,160,0.1)';
+    border = 'rgba(0,229,160,0.3)';
+    color  = 'var(--pe-success)';
+    const label = (artist && title) ? `${artist} — ${title}` : (title || artist || 'bereit');
+    text = `♪ ${label}`;
+  } else if (status === 'pending' || status === 'downloading') {
+    bg     = 'rgba(255,176,32,0.1)';
+    border = 'rgba(255,176,32,0.3)';
+    color  = 'var(--pe-warning)';
+    text   = '⏳ lädt…';
+  } else if (status === 'error') {
+    bg     = 'rgba(255,69,96,0.1)';
+    border = 'rgba(255,69,96,0.3)';
+    color  = 'var(--pe-danger)';
+    text   = '✗ Fehler';
+  } else {
+    // has_walkon but no known status yet — muted fallback
+    bg     = 'transparent';
+    border = 'transparent';
+    color  = 'var(--pe-text-muted)';
+    text   = '♪';
+  }
+
+  if (!text) return null;
+
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: '4px',
+      background: bg, border: `1px solid ${border}`,
+      borderRadius: '6px', padding: '2px 7px',
+      fontSize: '11px', color,
+      fontFamily: 'Verdana, Geneva, sans-serif',
+      maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    }}>
+      {text}
+    </span>
+  );
 }
 
 function PlayersTab() {
@@ -402,16 +437,13 @@ function PlayersTab() {
   const loadPlayers = async () => {
     const updated = await api.get(`/tournaments/${selectedTournament}/players`);
     setPlayers(updated);
-    // Load walkon statuses for players that have a walkon_url
+    // Use server-side walkon_status instead of per-player API calls
     const statuses = {};
-    await Promise.all(
-      updated.filter(p => p.walkon_url || p.walkon_youtube).map(async (p) => {
-        try {
-          const s = await api.get(`/walkon/${p.id}/status`);
-          statuses[p.id] = s.job?.status;
-        } catch { statuses[p.id] = null; }
-      })
-    );
+    for (const p of updated) {
+      if (p.has_walkon || p.walkon_youtube) {
+        statuses[p.id] = p.walkon_status || null;
+      }
+    }
     setWalkonStatuses(statuses);
   };
 
@@ -580,16 +612,7 @@ function PlayersTab() {
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px' }}>
           {players.map((p) => {
             const isExpanded = editingPlayer?.id === p.id;
-            const hasWalkon = p.walkon_url || p.walkon_youtube;
-            const walkonStatus = walkonStatuses[p.id];
-            let walkonText = '♪ —';
-            let walkonColor = 'var(--pe-text-muted)';
-            if (hasWalkon) {
-              if (walkonStatus === 'ready')                                               { walkonText = '♪ bereit'; walkonColor = 'var(--pe-success)'; }
-              else if (walkonStatus === 'downloading' || walkonStatus === 'pending')      { walkonText = '⏳ lädt';  walkonColor = 'var(--pe-warning)'; }
-              else if (walkonStatus === 'error')                                          { walkonText = '✗ Fehler'; walkonColor = 'var(--pe-danger)'; }
-              else                                                                        { walkonText = '♪ —';     walkonColor = 'var(--pe-text-muted)'; }
-            }
+            const effectiveWalkonStatus = walkonStatuses[p.id] ?? p.walkon_status;
             return (
               <div key={p.id} style={{ background: 'var(--pe-bg-card)', border: `1px solid ${isExpanded ? 'var(--pe-cyan-bright)' : 'var(--pe-border)'}`, borderRadius: '10px', padding: '12px' }}>
                 {/* Collapsed header — always visible */}
@@ -601,7 +624,13 @@ function PlayersTab() {
                   {/* Name + walk-on status */}
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ fontSize: '12px', fontWeight: 'bold', color: 'var(--pe-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</div>
-                    <div style={{ fontSize: '10px', color: walkonColor, marginTop: '2px' }}>{walkonText}</div>
+                    {(p.has_walkon || p.walkon_youtube) && (
+                      <WalkonBadge
+                        status={effectiveWalkonStatus}
+                        title={p.walkon_title}
+                        artist={p.walkon_artist}
+                      />
+                    )}
                   </div>
                   {/* Edit / Close button */}
                   <button
@@ -665,8 +694,12 @@ function PlayersTab() {
             <div key={p.id} className="p-3 rounded-lg flex justify-between items-center" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
               <div>
                 <span className="font-bold" style={{ color: 'var(--pe-text)' }}>{p.name}</span>
-                {(p.walkon_url || p.walkon_youtube) && (
-                  <WalkonBadge status={walkonStatuses[p.id]} />
+                {(p.has_walkon || p.walkon_youtube) && (
+                  <WalkonBadge
+                    status={walkonStatuses[p.id] ?? p.walkon_status}
+                    title={p.walkon_title}
+                    artist={p.walkon_artist}
+                  />
                 )}
                 <span className="ml-3 text-xs" style={{ color: 'var(--pe-text-muted)' }}>Seed: {p.seed || '—'}</span>
               </div>

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -42,7 +42,7 @@ const inputStyle = {
   border: '1px solid var(--pe-border)',
   color: 'var(--pe-text)',
   minHeight: '52px',
-  fontFamily: 'var(--pe-font-body)',
+  fontFamily: 'Verdana, Geneva, sans-serif',
 };
 
 const selectStyle = {
@@ -57,7 +57,7 @@ const selectStyle = {
 };
 
 const btnSmall = {
-  fontFamily: 'var(--pe-font-body)',
+  fontFamily: 'Verdana, Geneva, sans-serif',
   borderRadius: '8px',
   fontWeight: 'bold',
   border: '1px solid var(--pe-border)',
@@ -96,11 +96,11 @@ function OverviewTab() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-6">
         <div className="p-4 rounded-xl" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
           <p className="text-sm" style={{ color: 'var(--pe-text-muted)' }}>Aktive Spiele</p>
-          <p className="pe-score" style={{ fontSize: '2rem', color: 'var(--pe-success)' }}>{games.length}</p>
+          <p className="text-3xl font-bold" style={{ color: 'var(--pe-success)' }}>{games.length}</p>
         </div>
         <div className="p-4 rounded-xl" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
           <p className="text-sm" style={{ color: 'var(--pe-text-muted)' }}>Boards</p>
-          <p className="pe-score" style={{ fontSize: '2rem', color: 'var(--pe-cyan-bright)' }}>{boards.length}</p>
+          <p className="text-3xl font-bold" style={{ color: 'var(--pe-cyan-bright)' }}>{boards.length}</p>
         </div>
       </div>
       <h3 className="text-sm font-bold mb-3" style={{ color: 'var(--pe-text-sub)' }}>LAUFENDE SPIELE</h3>
@@ -171,7 +171,7 @@ function BoardsTab() {
     <div>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: '44px', marginBottom: '16px' }}>
         <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px', margin: 0 }}>Boards</h2>
-        <button onClick={() => setShowForm(!showForm)} disabled={!selectedTournamentId} className="px-4 py-2 rounded-lg text-sm font-bold disabled:opacity-50" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)' }}>
+        <button onClick={() => setShowForm(!showForm)} disabled={!selectedTournamentId} className="px-4 py-2 rounded-lg text-sm font-bold disabled:opacity-50" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif' }}>
           {showForm ? 'Abbrechen' : '+ Neu'}
         </button>
       </div>
@@ -202,7 +202,7 @@ function BoardsTab() {
             Wird als Board {boards.length + 1} für &ldquo;{selectedTournament?.name}&rdquo; angelegt
           </p>
           <input type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="Name (optional)" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
-          <button type="submit" className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'var(--pe-font-body)' }}>
+          <button type="submit" className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}>
             Board erstellen
           </button>
         </form>
@@ -361,7 +361,12 @@ function PlayersTab() {
   const [players, setPlayers] = useState([]);
   const [walkonStatuses, setWalkonStatuses] = useState({}); // { [playerId]: status string }
   const [walkonLoadingToasts, setWalkonLoadingToasts] = useState({}); // { [playerId]: toastId }
-  const [showForm, setShowForm] = useState(false);
+  const [addMode, setAddMode] = useState(null); // null | 'search' | 'new'
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [confirmPlayer, setConfirmPlayer] = useState(null); // player object to confirm
+  const [confirmSeed, setConfirmSeed] = useState('');
 
   const [isDesktop, setIsDesktop] = useState(() => window.matchMedia('(min-width: 768px)').matches);
   useEffect(() => {
@@ -447,6 +452,46 @@ function PlayersTab() {
     setWalkonStatuses(statuses);
   };
 
+  useEffect(() => {
+    if (!searchQuery || searchQuery.trim().length < 2) {
+      setSearchResults([]);
+      setConfirmPlayer(null);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      setSearchLoading(true);
+      try {
+        const results = await api.get(
+          `/players/search?q=${encodeURIComponent(searchQuery.trim())}&tournament_id=${selectedTournament}`
+        );
+        setSearchResults(results);
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setSearchLoading(false);
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery, selectedTournament]);
+
+  const handleRegisterExisting = async () => {
+    if (!confirmPlayer || !selectedTournament) return;
+    try {
+      await api.post(`/tournaments/${selectedTournament}/players`, {
+        player_id: confirmPlayer.id,
+        seed: confirmSeed ? parseInt(confirmSeed, 10) : undefined,
+      });
+      setAddMode(null);
+      setSearchQuery('');
+      setSearchResults([]);
+      setConfirmPlayer(null);
+      setConfirmSeed('');
+      await loadPlayers();
+      addToast({ type: 'success', message: `${confirmPlayer.name} angemeldet` });
+    } catch (err) {
+      addToast({ type: 'error', message: err.message || 'Anmeldung fehlgeschlagen' });
+    }
+  };
 
   const handleCreate = async (e) => {
     e.preventDefault();
@@ -466,7 +511,9 @@ function PlayersTab() {
         }
       }
       setForm({ vorname: '', nickname: '', nachname: '', walk_on_song: '', walkon_start: 0, walkon_duration: 30 });
-      setShowForm(false);
+      setAddMode(null);
+      setSearchQuery('');
+      setSearchResults([]);
       await loadPlayers();
     } catch (err) {
       addToast({ type: 'error', message: err.message || 'Spieler konnte nicht angelegt werden' });
@@ -516,8 +563,12 @@ function PlayersTab() {
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: '44px', marginBottom: '16px' }}>
         <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px', margin: 0 }}>Spieler</h2>
         {!isActive && (
-          <button onClick={() => setShowForm(!showForm)} className="px-4 py-2 rounded-lg text-sm font-bold" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)' }}>
-            {showForm ? 'Abbrechen' : '+ Neu'}
+          <button
+            onClick={() => { setAddMode(addMode ? null : 'search'); setSearchQuery(''); setSearchResults([]); setConfirmPlayer(null); }}
+            className="px-4 py-2 rounded-lg text-sm font-bold"
+            style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif' }}
+          >
+            {addMode ? 'Abbrechen' : '+ Spieler'}
           </button>
         )}
       </div>
@@ -532,41 +583,170 @@ function PlayersTab() {
         </div>
       )}
 
-      {showForm && !isActive && (
-        <form onSubmit={handleCreate} className="p-4 rounded-xl mb-6 space-y-3" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
-          <input type="text" value={form.vorname} onChange={(e) => setForm({ ...form, vorname: e.target.value })} placeholder="Vorname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
-          <input type="text" value={form.nickname} onChange={(e) => setForm({ ...form, nickname: e.target.value })} placeholder="Nickname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
-          <input type="text" value={form.nachname} onChange={(e) => setForm({ ...form, nachname: e.target.value })} placeholder="Nachname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
-          <input type="url" value={form.walk_on_song} onChange={(e) => setForm({ ...form, walk_on_song: e.target.value })} placeholder="Walk-On Song URL (optional)" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
-          {form.walk_on_song && (
-            <div className="flex gap-2">
-              <div style={{ flex: 1 }}>
-                <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Startzeit (Sek.)</label>
-                <input
-                  type="number" min="0" value={form.walkon_start}
-                  onChange={(e) => setForm({ ...form, walkon_start: e.target.value })}
-                  required className="w-full p-3 rounded-lg outline-none" style={inputStyle}
-                />
+      {addMode && !isActive && (
+        <div className="p-4 rounded-xl mb-6" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
+
+          {/* Mode: search */}
+          {addMode === 'search' && !confirmPlayer && (
+            <>
+              <input
+                type="text"
+                autoFocus
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Name oder Nickname suchen…"
+                className="w-full p-3 rounded-lg outline-none mb-3"
+                style={inputStyle}
+              />
+              {searchLoading && (
+                <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)', textAlign: 'center', padding: '8px' }}>Suche…</p>
+              )}
+              {!searchLoading && searchQuery.trim().length >= 2 && searchResults.length === 0 && (
+                <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)', textAlign: 'center', padding: '8px' }}>
+                  Keine Spieler gefunden.
+                </p>
+              )}
+              {searchResults.map((p) => (
+                <div
+                  key={p.id}
+                  onClick={() => { setConfirmPlayer(p); setConfirmSeed(''); }}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '10px',
+                    background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)',
+                    borderRadius: '8px', padding: '10px 12px', marginBottom: '6px', cursor: 'pointer',
+                  }}
+                >
+                  <div style={{
+                    width: '36px', height: '36px', borderRadius: '8px', flexShrink: 0,
+                    background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: '11px', fontWeight: 'bold', color: 'var(--pe-cyan-bright)',
+                  }}>
+                    {((p.vorname?.[0] || '') + (p.nachname?.[0] || '')).toUpperCase() || '?'}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: '13px', fontWeight: 'bold', color: 'var(--pe-text)' }}>{p.name}</div>
+                    <div style={{ fontSize: '11px', color: 'var(--pe-text-muted)', marginTop: '2px' }}>
+                      {p.tournaments_count} Turnier{p.tournaments_count !== 1 ? 'e' : ''} · {p.wins}S / {p.losses}N
+                      {p.has_walkon ? <span style={{ marginLeft: '6px', color: 'var(--pe-success)' }}>♪</span> : null}
+                    </div>
+                  </div>
+                </div>
+              ))}
+              <button
+                onClick={() => {
+                  setForm({ vorname: '', nickname: searchQuery.trim(), nachname: '', walk_on_song: '', walkon_start: 0, walkon_duration: 30 });
+                  setAddMode('new');
+                }}
+                style={{
+                  width: '100%', marginTop: '6px', padding: '10px',
+                  border: '1px dashed var(--pe-border)', borderRadius: '8px',
+                  background: 'none', color: 'var(--pe-cyan-bright)',
+                  fontSize: '12px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif',
+                }}
+              >
+                + Neuen Spieler anlegen{searchQuery.trim() ? ` "${searchQuery.trim()}"` : ''}
+              </button>
+            </>
+          )}
+
+          {/* Confirm panel after selecting a player */}
+          {addMode === 'search' && confirmPlayer && (
+            <div>
+              <button
+                onClick={() => setConfirmPlayer(null)}
+                style={{ fontSize: '11px', color: 'var(--pe-text-muted)', background: 'none', border: 'none', cursor: 'pointer', marginBottom: '12px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+              >
+                ← Zurück zur Suche
+              </button>
+              <div style={{ background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-cyan-bright)', borderRadius: '10px', padding: '14px', marginBottom: '12px' }}>
+                <div style={{ fontSize: '10px', color: 'var(--pe-cyan-bright)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '6px' }}>Gefundener Spieler</div>
+                <div style={{ fontSize: '15px', fontWeight: 'bold', color: 'var(--pe-text)', marginBottom: '4px' }}>{confirmPlayer.name}</div>
+                <div style={{ fontSize: '11px', color: 'var(--pe-text-sub)', marginBottom: '8px' }}>
+                  {confirmPlayer.tournaments_count} Turnier{confirmPlayer.tournaments_count !== 1 ? 'e' : ''} · {confirmPlayer.wins} Siege / {confirmPlayer.losses} Niederlagen
+                </div>
+                {confirmPlayer.has_walkon && (
+                  <WalkonBadge
+                    status={confirmPlayer.walkon_status}
+                    title={confirmPlayer.walkon_title}
+                    artist={confirmPlayer.walkon_artist}
+                  />
+                )}
               </div>
-              <div style={{ flex: 1 }}>
-                <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Länge (Sek.)</label>
-                <input
-                  type="number" min="5" max="120" value={form.walkon_duration}
-                  onChange={(e) => setForm({ ...form, walkon_duration: e.target.value })}
-                  required className="w-full p-3 rounded-lg outline-none" style={inputStyle}
-                />
+              <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Setzung (optional)</label>
+              <input
+                type="number"
+                min="1"
+                value={confirmSeed}
+                onChange={(e) => setConfirmSeed(e.target.value)}
+                placeholder="z.B. 1"
+                className="w-full p-3 rounded-lg outline-none mb-3"
+                style={inputStyle}
+              />
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <button
+                  onClick={handleRegisterExisting}
+                  className="flex-1 py-3 rounded-lg font-bold"
+                  style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+                >
+                  Anmelden
+                </button>
+                <button
+                  onClick={() => setConfirmPlayer(null)}
+                  className="px-4 py-3 rounded-lg"
+                  style={{ background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif' }}
+                >
+                  Abbrechen
+                </button>
               </div>
             </div>
           )}
-          {form.vorname && form.nickname && form.nachname && (
-            <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)' }}>
-              Angezeigt als: <strong style={{ color: 'var(--pe-text)' }}>{form.vorname.trim()} &ldquo;{form.nickname.trim()}&rdquo; {form.nachname.trim()}</strong>
-            </p>
+
+          {/* Mode: new player form */}
+          {addMode === 'new' && (
+            <form onSubmit={handleCreate} className="space-y-3">
+              <button
+                type="button"
+                onClick={() => setAddMode('search')}
+                style={{ fontSize: '11px', color: 'var(--pe-text-muted)', background: 'none', border: 'none', cursor: 'pointer', marginBottom: '4px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+              >
+                ← Zurück zur Suche
+              </button>
+              <input type="text" value={form.vorname} onChange={(e) => setForm({ ...form, vorname: e.target.value })} placeholder="Vorname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+              <input
+                type="text"
+                value={form.nickname}
+                onChange={(e) => setForm({ ...form, nickname: e.target.value })}
+                placeholder="Nickname *"
+                required
+                className="w-full p-3 rounded-lg outline-none"
+                style={inputStyle}
+              />
+              <input type="text" value={form.nachname} onChange={(e) => setForm({ ...form, nachname: e.target.value })} placeholder="Nachname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+              <input type="url" value={form.walk_on_song} onChange={(e) => setForm({ ...form, walk_on_song: e.target.value })} placeholder="Walk-On Song URL (optional)" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+              {form.walk_on_song && (
+                <div className="flex gap-2">
+                  <div style={{ flex: 1 }}>
+                    <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Startzeit (Sek.)</label>
+                    <input type="number" min="0" value={form.walkon_start} onChange={(e) => setForm({ ...form, walkon_start: e.target.value })} required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+                  </div>
+                  <div style={{ flex: 1 }}>
+                    <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Länge (Sek.)</label>
+                    <input type="number" min="5" max="120" value={form.walkon_duration} onChange={(e) => setForm({ ...form, walkon_duration: e.target.value })} required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+                  </div>
+                </div>
+              )}
+              {form.vorname && form.nickname && form.nachname && (
+                <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)' }}>
+                  Angezeigt als: <strong style={{ color: 'var(--pe-text)' }}>{form.vorname.trim()} &ldquo;{form.nickname.trim()}&rdquo; {form.nachname.trim()}</strong>
+                </p>
+              )}
+              <button type="submit" disabled={!form.vorname.trim() || !form.nickname.trim() || !form.nachname.trim()} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+                Spieler anlegen & anmelden
+              </button>
+            </form>
           )}
-          <button type="submit" disabled={!form.vorname.trim() || !form.nickname.trim() || !form.nachname.trim()} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'var(--pe-font-body)' }}>
-            Spieler anlegen
-          </button>
-        </form>
+        </div>
       )}
 
       {editingPlayer && !isDesktop && (
@@ -602,8 +782,8 @@ function PlayersTab() {
             </p>
           )}
           <div className="flex gap-2">
-            <button type="submit" disabled={isSaving} className="flex-1 py-2 rounded-lg font-bold" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)', opacity: isSaving ? 0.7 : 1, cursor: isSaving ? 'not-allowed' : 'pointer' }}>{isSaving ? 'Speichert…' : 'Speichern'}</button>
-            <button type="button" onClick={() => setEditingPlayer(null)} className="px-4 py-2 rounded-lg" style={{ background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', fontFamily: 'var(--pe-font-body)' }}>Abbrechen</button>
+            <button type="submit" disabled={isSaving} className="flex-1 py-2 rounded-lg font-bold" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif', opacity: isSaving ? 0.7 : 1, cursor: isSaving ? 'not-allowed' : 'pointer' }}>{isSaving ? 'Speichert…' : 'Speichern'}</button>
+            <button type="button" onClick={() => setEditingPlayer(null)} className="px-4 py-2 rounded-lg" style={{ background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif' }}>Abbrechen</button>
           </div>
         </form>
       )}
@@ -812,7 +992,7 @@ function UsersTab() {
     <div>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: '44px', marginBottom: '16px' }}>
         <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px', margin: 0 }}>User</h2>
-        <button onClick={() => { setShowCreate(!showCreate); setEditId(null); }} className="px-4 py-2 rounded-lg text-sm font-bold" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)' }}>
+        <button onClick={() => { setShowCreate(!showCreate); setEditId(null); }} className="px-4 py-2 rounded-lg text-sm font-bold" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif' }}>
           {showCreate ? 'Abbrechen' : '+ Neu'}
         </button>
       </div>
@@ -835,7 +1015,7 @@ function UsersTab() {
             <option value="gastronomy">Gastronomie</option>
             <option value="admin">Admin</option>
           </select>
-          <button type="submit" disabled={!canSubmit} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'var(--pe-font-body)', border: 'none', cursor: canSubmit ? 'pointer' : 'not-allowed' }}>
+          <button type="submit" disabled={!canSubmit} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif', border: 'none', cursor: canSubmit ? 'pointer' : 'not-allowed' }}>
             User anlegen
           </button>
         </form>
@@ -979,7 +1159,7 @@ function UsersTab() {
                       <input type="password" value={editForm.password} onChange={e => setEditForm({ ...editForm, password: e.target.value })} placeholder="Leer = unverändert" style={{ ...inputStyle, width: '100%', padding: '10px 12px', boxSizing: 'border-box' }} />
                     </div>
                   </div>
-                  <button onClick={() => handleSaveEdit(u.id)} style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', borderRadius: '8px', padding: '12px 20px', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', width: '100%', minHeight: '44px' }}>
+                  <button onClick={() => handleSaveEdit(u.id)} style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', borderRadius: '8px', padding: '12px 20px', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', width: '100%', minHeight: '44px' }}>
                     Änderungen speichern
                   </button>
                 </div>
@@ -1080,7 +1260,7 @@ function GastroAdminTab() {
             </select>
             <input type="number" step="0.01" min="0" value={form.price} onChange={e => setForm({ ...form, price: e.target.value })} placeholder="Preis (€) *" required style={inputStyle} />
             <input type="number" value={form.sort_order} onChange={e => setForm({ ...form, sort_order: e.target.value })} placeholder="Sortierung" style={inputStyle} />
-            <button type="submit" disabled={!form.name.trim() || !form.price} style={{ gridColumn: '1/-1', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', borderRadius: '8px', padding: '12px', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '44px', opacity: (!form.name.trim() || !form.price) ? 0.5 : 1 }}>
+            <button type="submit" disabled={!form.name.trim() || !form.price} style={{ gridColumn: '1/-1', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', borderRadius: '8px', padding: '12px', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '44px', opacity: (!form.name.trim() || !form.price) ? 0.5 : 1 }}>
               Produkt anlegen
             </button>
           </form>
@@ -1222,7 +1402,7 @@ function MailingTab() {
     <div>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: '44px', marginBottom: '16px' }}>
         <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px', margin: 0 }}>Mailing</h2>
-        <button onClick={() => setShowForm(!showForm)} className="px-4 py-2 rounded-lg text-sm font-bold" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)' }}>
+        <button onClick={() => setShowForm(!showForm)} className="px-4 py-2 rounded-lg text-sm font-bold" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif' }}>
           {showForm ? 'Abbrechen' : '+ Template'}
         </button>
       </div>
@@ -1232,7 +1412,7 @@ function MailingTab() {
           <input type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="Template-Name" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
           <input type="text" value={form.subject} onChange={(e) => setForm({ ...form, subject: e.target.value })} placeholder="Betreff" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
           <textarea value={form.body_html} onChange={(e) => setForm({ ...form, body_html: e.target.value })} placeholder="HTML Body" rows={6} className="w-full p-3 rounded-lg outline-none resize-y" style={{ ...inputStyle, minHeight: '120px' }} />
-          <button type="submit" disabled={!form.name.trim() || !form.subject.trim()} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'var(--pe-font-body)' }}>
+          <button type="submit" disabled={!form.name.trim() || !form.subject.trim()} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}>
             Template speichern
           </button>
         </form>
@@ -1252,7 +1432,7 @@ function MailingTab() {
         <h3 className="text-sm font-bold mb-3" style={{ color: 'var(--pe-text-sub)' }}>TEST-MAIL</h3>
         <div className="flex gap-2">
           <input type="email" value={testEmail} onChange={(e) => setTestEmail(e.target.value)} placeholder="test@email.de" className="flex-1 p-3 rounded-lg outline-none" style={inputStyle} />
-          <button onClick={handleTestMail} disabled={sending || !testEmail.trim()} className="px-4 py-3 rounded-lg font-bold text-sm disabled:opacity-50" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)' }}>
+          <button onClick={handleTestMail} disabled={sending || !testEmail.trim()} className="px-4 py-3 rounded-lg font-bold text-sm disabled:opacity-50" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif' }}>
             Senden
           </button>
         </div>
@@ -1262,7 +1442,7 @@ function MailingTab() {
         onClick={handleSendEventSummary}
         disabled={sending}
         className="w-full py-3 rounded-lg font-bold disabled:opacity-50"
-        style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'var(--pe-font-body)' }}
+        style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}
       >
         {sending ? 'Wird gesendet...' : 'Event-Zusammenfassung senden'}
       </button>
@@ -1355,7 +1535,7 @@ function TournamentDirectorTab() {
   }
   const unassigned = games.filter(g => !g.board_id);
 
-  const btnBase = { border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', borderRadius: '8px', fontSize: '12px', minHeight: '36px' };
+  const btnBase = { border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', borderRadius: '8px', fontSize: '12px', minHeight: '36px' };
 
   const tapGame = tapGameId ? games.find(g => g.id === tapGameId) : null;
 
@@ -1836,11 +2016,11 @@ function TournamentExtendedTab() {
             {/* Seeding toggle */}
             <div style={{ marginTop: '12px', padding: '12px 14px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)' }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: createForm.use_seed ? '8px' : '0' }}>
-                <span style={{ color: 'var(--pe-text-sub)', fontSize: '13px', fontWeight: 'bold', fontFamily: 'var(--pe-font-body)' }}>Seeding verwenden?</span>
+                <span style={{ color: 'var(--pe-text-sub)', fontSize: '13px', fontWeight: 'bold', fontFamily: 'Verdana, Geneva, sans-serif' }}>Seeding verwenden?</span>
                 <button
                   type="button"
                   onClick={() => setCreateForm({...createForm, use_seed: !createForm.use_seed})}
-                  style={{ padding: '6px 16px', borderRadius: '20px', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '13px', cursor: 'pointer', minHeight: '36px', minWidth: '64px', background: createForm.use_seed ? 'var(--pe-success)' : 'var(--pe-bg-card)', color: createForm.use_seed ? '#000' : 'var(--pe-text-muted)', border: createForm.use_seed ? 'none' : '1px solid var(--pe-border)', transition: 'background 0.2s' }}
+                  style={{ padding: '6px 16px', borderRadius: '20px', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '13px', cursor: 'pointer', minHeight: '36px', minWidth: '64px', background: createForm.use_seed ? 'var(--pe-success)' : 'var(--pe-bg-card)', color: createForm.use_seed ? '#000' : 'var(--pe-text-muted)', border: createForm.use_seed ? 'none' : '1px solid var(--pe-border)', transition: 'background 0.2s' }}
                 >
                   {createForm.use_seed ? 'ON' : 'OFF'}
                 </button>
@@ -1854,7 +2034,7 @@ function TournamentExtendedTab() {
                 : null
               }
             </div>
-            <button type="submit" disabled={creating || !createForm.name.trim()} style={{ width: '100%', marginTop: '16px', padding: '14px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '52px', opacity: creating ? 0.6 : 1 }}>
+            <button type="submit" disabled={creating || !createForm.name.trim()} style={{ width: '100%', marginTop: '16px', padding: '14px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '52px', opacity: creating ? 0.6 : 1 }}>
               {creating ? 'Wird angelegt...' : 'Turnier anlegen & weiter →'}
             </button>
           </form>
@@ -1885,7 +2065,7 @@ function TournamentExtendedTab() {
               <span style={{ color: 'var(--pe-text-sub)', fontSize: '13px', fontWeight: 'bold' }}>Anzahl Boards</span>
               <input type="number" min="1" value={config.board_count} onChange={e => setConfig({...config, board_count: e.target.value})} style={{ ...inputStyle, width: '70px', padding: '8px', textAlign: 'center' }} />
             </div>
-            <button onClick={handleSaveConfig} disabled={savingConfig} style={{ width: '100%', marginTop: '16px', padding: '14px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '52px', opacity: savingConfig ? 0.6 : 1 }}>
+            <button onClick={handleSaveConfig} disabled={savingConfig} style={{ width: '100%', marginTop: '16px', padding: '14px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '52px', opacity: savingConfig ? 0.6 : 1 }}>
               {savingConfig ? 'Speichern...' : 'Format speichern & weiter →'}
             </button>
           </div>
@@ -1905,12 +2085,12 @@ function TournamentExtendedTab() {
                 <div style={{ display: 'flex', gap: '6px' }}>
                   {(newTournament?.use_seed || createForm.use_seed) && (
                   <div style={{ display: 'flex', alignItems: 'center', gap: '4px', background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', borderRadius: '8px', padding: '4px 8px' }}>
-                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: String(Math.max(1, (parseInt(playerForm.seed) || 1) - 1))})} style={{ minHeight: '44px', minWidth: '36px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '6px', fontWeight: 'bold', fontSize: '18px', cursor: 'pointer', fontFamily: 'var(--pe-font-body)' }}>−</button>
+                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: String(Math.max(1, (parseInt(playerForm.seed) || 1) - 1))})} style={{ minHeight: '44px', minWidth: '36px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '6px', fontWeight: 'bold', fontSize: '18px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif' }}>−</button>
                     <span style={{ minWidth: '32px', textAlign: 'center', color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '14px' }}>{playerForm.seed || '—'}</span>
-                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: String((parseInt(playerForm.seed) || 0) + 1)})} style={{ minHeight: '44px', minWidth: '36px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '6px', fontWeight: 'bold', fontSize: '18px', cursor: 'pointer', fontFamily: 'var(--pe-font-body)' }}>+</button>
+                    <button type="button" onClick={() => setPlayerForm({...playerForm, seed: String((parseInt(playerForm.seed) || 0) + 1)})} style={{ minHeight: '44px', minWidth: '36px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '6px', fontWeight: 'bold', fontSize: '18px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif' }}>+</button>
                   </div>
                 )}
-                  <button type="submit" disabled={!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()} style={{ flex: 1, padding: '10px 16px', borderRadius: '8px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px', fontSize: '13px', opacity: (!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()) ? 0.5 : 1 }}>+ Spieler hinzufügen</button>
+                  <button type="submit" disabled={!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()} style={{ flex: 1, padding: '10px 16px', borderRadius: '8px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px', fontSize: '13px', opacity: (!playerForm.vorname.trim() || !playerForm.nickname.trim() || !playerForm.nachname.trim()) ? 0.5 : 1 }}>+ Spieler hinzufügen</button>
                 </div>
               </form>
               {/* Mock */}
@@ -1921,7 +2101,7 @@ function TournamentExtendedTab() {
                   placeholder="Anzahl (2–64)"
                   style={{ flex: 1, ...inputStyle, padding: '8px' }}
                 />
-                <button onClick={handleMock} style={{ padding: '8px 16px', borderRadius: '8px', background: 'var(--pe-warning)', color: '#000', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>Simulieren</button>
+                <button onClick={handleMock} style={{ padding: '8px 16px', borderRadius: '8px', background: 'var(--pe-warning)', color: '#000', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>Simulieren</button>
               </div>
             </div>
             {/* Spieler-Liste */}
@@ -1938,8 +2118,8 @@ function TournamentExtendedTab() {
               {players.length === 0 && <p style={{ color: 'var(--pe-text-muted)', textAlign: 'center', padding: '16px' }}>Noch keine Spieler</p>}
             </div>
             <div style={{ display: 'flex', gap: '8px' }}>
-              <button onClick={() => setWizardStep(2)} style={{ flex: 1, padding: '14px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', border: '1px solid var(--pe-border)', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '52px' }}>← Zurück</button>
-              <button onClick={() => setWizardStep(4)} disabled={players.length < 2} style={{ flex: 2, padding: '14px', borderRadius: '10px', background: players.length >= 2 ? 'var(--pe-gradient)' : 'var(--pe-bg-elevated)', color: players.length >= 2 ? 'var(--pe-text)' : 'var(--pe-text-muted)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '16px', cursor: players.length >= 2 ? 'pointer' : 'not-allowed', minHeight: '52px' }}>
+              <button onClick={() => setWizardStep(2)} style={{ flex: 1, padding: '14px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', border: '1px solid var(--pe-border)', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '52px' }}>← Zurück</button>
+              <button onClick={() => setWizardStep(4)} disabled={players.length < 2} style={{ flex: 2, padding: '14px', borderRadius: '10px', background: players.length >= 2 ? 'var(--pe-gradient)' : 'var(--pe-bg-elevated)', color: players.length >= 2 ? 'var(--pe-text)' : 'var(--pe-text-muted)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '16px', cursor: players.length >= 2 ? 'pointer' : 'not-allowed', minHeight: '52px' }}>
                 Weiter mit {players.length} Spielern →
               </button>
             </div>
@@ -1961,7 +2141,7 @@ function TournamentExtendedTab() {
                   <div style={{ color: 'var(--pe-text-sub)', fontSize: '14px', marginBottom: '24px' }}>
                     {wizardTour?.name || newTournament?.name} wurde erfolgreich gestartet.
                   </div>
-                  <button onClick={() => { setWizardStep(0); setNewTournament(null); setWizardTour(null); }} style={{ padding: '14px 28px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '52px' }}>
+                  <button onClick={() => { setWizardStep(0); setNewTournament(null); setWizardTour(null); }} style={{ padding: '14px 28px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '52px' }}>
                     Zur Turnierliste →
                   </button>
                 </div>
@@ -2022,7 +2202,7 @@ function TournamentExtendedTab() {
                             value={g.board_id || ''}
                             onClick={e => e.stopPropagation()}
                             onChange={e => assignGroupToBoard(g.id, e.target.value ? parseInt(e.target.value) : null)}
-                            style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '8px', padding: '6px 10px', fontSize: '13px', fontFamily: 'var(--pe-font-body)', minHeight: '44px', marginRight: '10px', cursor: 'pointer', appearance: 'none', WebkitAppearance: 'none', backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%235A7394' d='M6 8L1 3h10z'/%3E%3C%2Fsvg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 10px center', paddingRight: '30px' }}
+                            style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '8px', padding: '6px 10px', fontSize: '13px', fontFamily: 'Verdana, Geneva, sans-serif', minHeight: '44px', marginRight: '10px', cursor: 'pointer', appearance: 'none', WebkitAppearance: 'none', backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%235A7394' d='M6 8L1 3h10z'/%3E%3C%2Fsvg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 10px center', paddingRight: '30px' }}
                           >
                             <option value="">Kein Board</option>
                             {boards.map(b => <option key={b.id} value={b.id}>Board {b.number}{b.is_final ? ' ★' : ''}</option>)}
@@ -2049,13 +2229,13 @@ function TournamentExtendedTab() {
                 </div>
 
                 {/* Primärer CTA */}
-                <button onClick={generateGroupSchedule} style={{ width: '100%', padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '60px', fontSize: '15px', marginBottom: '8px' }}>
+                <button onClick={generateGroupSchedule} style={{ width: '100%', padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '60px', fontSize: '15px', marginBottom: '8px' }}>
                   🎲 Spielplan generieren & Turnier starten
                 </button>
                 <p style={{ color: 'var(--pe-text-muted)', fontSize: '11px', textAlign: 'center', marginBottom: '16px' }}>
                   Boards werden per Los zugewiesen und der komplette Round-Robin Spielplan erstellt.
                 </p>
-                <button onClick={() => setWizardStep(3)} style={{ width: '100%', padding: '10px', borderRadius: '10px', background: 'transparent', color: 'var(--pe-text-muted)', border: '1px solid var(--pe-border)', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer' }}>← Zurück zu Spielern</button>
+                <button onClick={() => setWizardStep(3)} style={{ width: '100%', padding: '10px', borderRadius: '10px', background: 'transparent', color: 'var(--pe-text-muted)', border: '1px solid var(--pe-border)', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer' }}>← Zurück zu Spielern</button>
               </div>
             );
           }
@@ -2070,12 +2250,12 @@ function TournamentExtendedTab() {
 
                   {/* Gruppenanzahl-Auswahl */}
                   <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '10px 14px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)' }}>
-                    <label htmlFor="numGroupsSelect" style={{ color: 'var(--pe-text-sub)', fontSize: '13px', fontFamily: 'var(--pe-font-body)', flexShrink: 0 }}>Anzahl Gruppen:</label>
+                    <label htmlFor="numGroupsSelect" style={{ color: 'var(--pe-text-sub)', fontSize: '13px', fontFamily: 'Verdana, Geneva, sans-serif', flexShrink: 0 }}>Anzahl Gruppen:</label>
                     <select
                       id="numGroupsSelect"
                       value={numGroups}
                       onChange={e => setNumGroups(Number(e.target.value))}
-                      style={{ flex: 1, padding: '10px 12px', borderRadius: '8px', background: 'var(--pe-bg-card)', color: 'var(--pe-text)', border: '1px solid var(--pe-border)', fontFamily: 'var(--pe-font-body)', fontSize: '14px', minHeight: '44px', cursor: 'pointer', appearance: 'none', WebkitAppearance: 'none', backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%235A7394' d='M6 8L1 3h10z'/%3E%3C%2Fsvg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 10px center', paddingRight: '30px' }}
+                      style={{ flex: 1, padding: '10px 12px', borderRadius: '8px', background: 'var(--pe-bg-card)', color: 'var(--pe-text)', border: '1px solid var(--pe-border)', fontFamily: 'Verdana, Geneva, sans-serif', fontSize: '14px', minHeight: '44px', cursor: 'pointer', appearance: 'none', WebkitAppearance: 'none', backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%235A7394' d='M6 8L1 3h10z'/%3E%3C%2Fsvg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 10px center', paddingRight: '30px' }}
                     >
                       {[2, 3, 4, 6, 8].map(n => (
                         <option key={n} value={n}>{n} Gruppen</option>
@@ -2084,7 +2264,7 @@ function TournamentExtendedTab() {
                   </div>
 
                   {/* Option A: Gruppenphase */}
-                  <button onClick={drawGroups} style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', boxShadow: '0 4px 14px rgba(0,184,255,0.3)', fontFamily: 'var(--pe-font-body)', cursor: 'pointer', minHeight: '64px', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '14px' }}>
+                  <button onClick={drawGroups} style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', boxShadow: '0 4px 14px rgba(0,184,255,0.3)', fontFamily: 'Verdana, Geneva, sans-serif', cursor: 'pointer', minHeight: '64px', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '14px' }}>
                     <span style={{ fontSize: '28px', flexShrink: 0 }}>🏆</span>
                     <div>
                       <div style={{ fontWeight: 'bold', fontSize: '15px' }}>Mit Gruppenphase starten</div>
@@ -2094,7 +2274,7 @@ function TournamentExtendedTab() {
                   </button>
 
                   {/* Option B: Direkt KO */}
-                  <button onClick={startTournament} style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-text)', border: '1px solid var(--pe-border)', fontFamily: 'var(--pe-font-body)', cursor: 'pointer', minHeight: '64px', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '14px' }}>
+                  <button onClick={startTournament} style={{ padding: '16px', borderRadius: '12px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-text)', border: '1px solid var(--pe-border)', fontFamily: 'Verdana, Geneva, sans-serif', cursor: 'pointer', minHeight: '64px', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '14px' }}>
                     <span style={{ fontSize: '28px', flexShrink: 0 }}>⚡</span>
                     <div>
                       <div style={{ fontWeight: 'bold', fontSize: '15px' }}>Direkt KO-Bracket</div>
@@ -2104,7 +2284,7 @@ function TournamentExtendedTab() {
                   </button>
                 </div>
               </div>
-              <button onClick={() => setWizardStep(3)} style={{ width: '100%', padding: '10px', borderRadius: '10px', background: 'transparent', color: 'var(--pe-text-muted)', border: '1px solid var(--pe-border)', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer' }}>← Zurück zu Spielern</button>
+              <button onClick={() => setWizardStep(3)} style={{ width: '100%', padding: '10px', borderRadius: '10px', background: 'transparent', color: 'var(--pe-text-muted)', border: '1px solid var(--pe-border)', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer' }}>← Zurück zu Spielern</button>
             </div>
           );
         })()}
@@ -2118,7 +2298,7 @@ function TournamentExtendedTab() {
       {/* Header */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: '44px', marginBottom: '16px' }}>
         <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px', margin: 0 }}>Turniere</h2>
-        <button onClick={() => { setWizardStep(1); setNewTournament(null); setCreateForm({ name: '', date: '', format: '501', checkout: 'double_out', use_seed: false }); }} className="px-4 py-2 rounded-lg text-sm font-bold" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)' }}>
+        <button onClick={() => { setWizardStep(1); setNewTournament(null); setCreateForm({ name: '', date: '', format: '501', checkout: 'double_out', use_seed: false }); }} className="px-4 py-2 rounded-lg text-sm font-bold" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif' }}>
           + Neues Turnier
         </button>
       </div>
@@ -2135,7 +2315,7 @@ function TournamentExtendedTab() {
       {tournaments.length === 0 && (
         <div style={{ textAlign: 'center', padding: '48px 16px' }}>
           <p style={{ color: 'var(--pe-text-muted)', fontSize: '16px', marginBottom: '16px' }}>Noch keine Turniere vorhanden.</p>
-          <button onClick={() => setWizardStep(1)} style={{ padding: '14px 28px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '52px' }}>
+          <button onClick={() => setWizardStep(1)} style={{ padding: '14px 28px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '52px' }}>
             Erstes Turnier anlegen
           </button>
         </div>
@@ -2193,14 +2373,14 @@ function TournamentExtendedTab() {
                     <span style={{ color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '13px' }}>Gruppe {g.name}</span>
                     <span style={{ color: 'var(--pe-text-muted)', fontSize: '11px', marginLeft: '8px' }}>{(g.standings||[]).length} Spieler</span>
                   </div>
-                  <select value={g.board_id || ''} onChange={e => assignGroupToBoard(g.id, e.target.value ? parseInt(e.target.value) : null)} style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '8px', padding: '4px 8px', fontSize: '12px', fontFamily: 'var(--pe-font-body)', appearance: 'none', WebkitAppearance: 'none', backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%235A7394' d='M6 8L1 3h10z'/%3E%3C%2Fsvg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 10px center', paddingRight: '24px' }}>
+                  <select value={g.board_id || ''} onChange={e => assignGroupToBoard(g.id, e.target.value ? parseInt(e.target.value) : null)} style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', borderRadius: '8px', padding: '4px 8px', fontSize: '12px', fontFamily: 'Verdana, Geneva, sans-serif', appearance: 'none', WebkitAppearance: 'none', backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%235A7394' d='M6 8L1 3h10z'/%3E%3C%2Fsvg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 10px center', paddingRight: '24px' }}>
                     <option value="">Kein Board</option>
                     {boards.map(b => <option key={b.id} value={b.id}>Board {b.number}{b.is_final ? ' ★' : ''}</option>)}
                   </select>
                 </div>
               ))}
               {selectedTournament.status === 'open' && !selectedTournament.group_draw_done && (
-                <button onClick={generateGroupSchedule} style={{ width: '100%', marginTop: '8px', padding: '12px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '44px', fontSize: '13px' }}>
+                <button onClick={generateGroupSchedule} style={{ width: '100%', marginTop: '8px', padding: '12px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '44px', fontSize: '13px' }}>
                   Spielplan generieren
                 </button>
               )}
@@ -2210,20 +2390,20 @@ function TournamentExtendedTab() {
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
             {selectedTournament.status === 'open' && (
               <>
-                <button onClick={() => { setWizardStep(3); }} style={{ padding: '12px 16px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '13px', cursor: 'pointer', minHeight: '48px', textAlign: 'left' }}>
+                <button onClick={() => { setWizardStep(3); }} style={{ padding: '12px 16px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '13px', cursor: 'pointer', minHeight: '48px', textAlign: 'left' }}>
                   Spieler verwalten →
                 </button>
-                <button onClick={() => { setWizardStep(4); }} style={{ padding: '12px 16px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '13px', cursor: 'pointer', minHeight: '48px', textAlign: 'left' }}>
+                <button onClick={() => { setWizardStep(4); }} style={{ padding: '12px 16px', borderRadius: '10px', background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '13px', cursor: 'pointer', minHeight: '48px', textAlign: 'left' }}>
                   Auslosung →
                 </button>
               </>
             )}
             {selectedTournament.status === 'active' && !selectedTournament.locked && (
-              <button onClick={lockTournament} style={{ padding: '12px 16px', borderRadius: '10px', background: 'var(--pe-warning)', color: '#000', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
+              <button onClick={lockTournament} style={{ padding: '12px 16px', borderRadius: '10px', background: 'var(--pe-warning)', color: '#000', border: 'none', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
                 Turnier abschließen
               </button>
             )}
-            <button onClick={() => deleteTournament(selectedId)} style={{ padding: '12px 16px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-danger)', border: '1px solid var(--pe-danger)', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
+            <button onClick={() => deleteTournament(selectedId)} style={{ padding: '12px 16px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-danger)', border: '1px solid var(--pe-danger)', fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', cursor: 'pointer', minHeight: '48px' }}>
               Turnier löschen
             </button>
           </div>
@@ -2479,7 +2659,7 @@ function SettingsTab() {
           {PRESETS.map(preset => (
             <button key={preset.name} onClick={() => applyPreset(preset)} style={{
               padding: '12px 8px', borderRadius: '10px', border: '2px solid transparent',
-              background: preset.color_bg, cursor: 'pointer', fontFamily: 'var(--pe-font-body)',
+              background: preset.color_bg, cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif',
               transition: 'border-color 0.15s',
             }}
               onMouseEnter={e => e.currentTarget.style.borderColor = preset.color_accent}
@@ -2521,7 +2701,7 @@ function SettingsTab() {
           style={{
             flex: 2, padding: '14px', borderRadius: '10px', border: 'none', cursor: saving ? 'not-allowed' : 'pointer',
             background: saved ? 'var(--pe-success)' : 'var(--pe-gradient)', color: saved ? '#000' : 'var(--pe-text)',
-            fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '15px', minHeight: '52px',
+            fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', fontSize: '15px', minHeight: '52px',
             opacity: saving ? 0.6 : 1,
           }}
         >
@@ -2532,7 +2712,7 @@ function SettingsTab() {
           style={{
             flex: 1, padding: '14px', borderRadius: '10px', border: '1px solid var(--pe-border)', cursor: 'pointer',
             background: 'var(--pe-bg-elevated)', color: 'var(--pe-warning)',
-            fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', minHeight: '52px',
+            fontFamily: 'Verdana, Geneva, sans-serif', fontWeight: 'bold', minHeight: '52px',
           }}
         >
           Zurücksetzen
@@ -2731,7 +2911,7 @@ function AdminDashboard() {
   const setActiveTab = (tab) => setSearchParams({ tab }, { replace: true });
 
   return (
-    <div style={{ fontFamily: 'var(--pe-font-body)', padding: '16px', maxWidth: '1200px', margin: '0 auto', minHeight: 'calc(100vh - 200px)' }}>
+    <div style={{ fontFamily: 'Verdana, Geneva, sans-serif', padding: '16px', maxWidth: '1200px', margin: '0 auto', minHeight: 'calc(100vh - 200px)' }}>
       {activeTab === 'overview'    && <OverviewTab />}
       {activeTab === 'director'    && <TournamentDirectorTab />}
       {activeTab === 'tournaments' && <TournamentExtendedTab />}

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -317,7 +317,7 @@ function WalkonBadge({ status, title, artist }) {
     bg     = 'rgba(0,229,160,0.1)';
     border = 'rgba(0,229,160,0.3)';
     color  = 'var(--pe-success)';
-    const label = (artist && title) ? `${artist} — ${title}` : (title || artist || 'bereit');
+    const label = (artist && title) ? `${artist} — ${title}` : 'bereit';
     text = `♪ ${label}`;
   } else if (status === 'pending' || status === 'downloading') {
     bg     = 'rgba(255,176,32,0.1)';

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -628,7 +628,7 @@ function PlayersTab() {
                     <div style={{ fontSize: '13px', fontWeight: 'bold', color: 'var(--pe-text)' }}>{p.name}</div>
                     <div style={{ fontSize: '11px', color: 'var(--pe-text-muted)', marginTop: '2px' }}>
                       {p.tournaments_count} Turnier{p.tournaments_count !== 1 ? 'e' : ''} · {p.wins}S / {p.losses}N
-                      {p.has_walkon ? <span style={{ marginLeft: '6px', color: 'var(--pe-success)' }}>♪</span> : null}
+                      {p.has_walkon ? <WalkonBadge status={p.walkon_status} title={p.walkon_title} artist={p.walkon_artist} /> : null}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Admin can search existing player profiles when adding to a tournament (search-first flow with debounced lookup)
- Walk-on artist/title automatically extracted from YouTube via yt-dlp after download
- Player cards show artist/title in a styled badge instead of plain note icon
- New `GET /api/players/search` endpoint (own route file to avoid double-mount collision)
- `POST /api/tournaments/:id/players` accepts optional `player_id` for direct registration of existing players
- `walkon_title`, `walkon_artist` columns added to players table via safe ALTER TABLE migration

## Test plan
- [ ] Search for an existing player by name/nickname → results appear with avatar, stats, walk-on badge
- [ ] Select player → confirm panel shows name, stats, walk-on badge, seed field
- [ ] Register existing player → appears in player list, success toast
- [ ] Duplicate registration → 409 toast shown
- [ ] `+ Neuen Spieler anlegen "{query}"` → form opens with nickname pre-filled
- [ ] New player creation still works as before
- [ ] Walk-on badge shows `♪ Artist — Title` after download completes
- [ ] Walk-on badge shows `♪ bereit` when ready but no metadata available
- [ ] Deleting a walk-on clears title/artist from DB (badge disappears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)