### PR TITLE
feat: add stats & history API endpoints

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -24,6 +24,7 @@ const productRoutes = require('./routes/products');
 const registrationRoutes = require('./routes/registration');
 const configRoutes = require('./routes/config');
 const walkonRoutes = require('./routes/walkon');
+const historyRoutes = require('./routes/history');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -77,6 +78,7 @@ app.use('/api/products', productRoutes);
 app.use('/api/registration', registrationRoutes);
 app.use('/api/config', configRoutes);
 app.use('/api/walkon', walkonRoutes);
+app.use('/api/history', historyRoutes);
 
 // Health check
 app.get('/api/health', (req, res) => {

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -2,7 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const { db } = require('../db/db');
-const { requireAdmin, requireAdminOrDirector } = require('../middleware/auth');
+const { requireAdmin, requireAdminOrDirector, requireAny } = require('../middleware/auth');
 const { auditLog } = require('../lib/auditLog');
 
 // POST /api/admin/wipe — Alle Turnierdaten löschen (Boards + Users + Produkte bleiben)
@@ -78,6 +78,76 @@ router.get('/logs/export', requireAdmin, (req, res) => {
   res.setHeader('Content-Type', 'text/csv');
   res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
   res.send(csv);
+});
+
+// GET /api/admin/reports/gastro — Gastro report (admin/gastro only)
+router.get('/reports/gastro', requireAny(['admin', 'gastro']), (req, res) => {
+  try {
+    const revenue = db.prepare(`
+      SELECT
+        COALESCE(SUM(o.quantity * p.price), 0) AS total_revenue,
+        COALESCE(SUM(CASE WHEN o.status = 'paid' THEN o.quantity * p.price ELSE 0 END), 0) AS paid_revenue,
+        COALESCE(SUM(CASE WHEN o.status = 'open' THEN o.quantity * p.price ELSE 0 END), 0) AS open_revenue,
+        COUNT(DISTINCT o.id) AS total_orders,
+        COUNT(DISTINCT o.guest_id) AS total_guests
+      FROM orders o
+      JOIN products p ON o.product_id = p.id
+    `).get();
+
+    const topProducts = db.prepare(`
+      SELECT
+        p.id, p.name, p.category, p.price,
+        COALESCE(SUM(o.quantity), 0) AS total_quantity,
+        COALESCE(SUM(o.quantity * p.price), 0) AS total_revenue
+      FROM products p
+      LEFT JOIN orders o ON o.product_id = p.id
+      GROUP BY p.id
+      HAVING total_quantity > 0
+      ORDER BY total_revenue DESC
+    `).all();
+
+    const ordersPerGuest = db.prepare(`
+      SELECT
+        g.id AS guest_id, g.name AS guest_name,
+        COUNT(o.id) AS order_count,
+        COALESCE(SUM(o.quantity), 0) AS total_items,
+        COALESCE(SUM(o.quantity * p.price), 0) AS total_spent,
+        COALESCE(SUM(CASE WHEN o.status = 'open' THEN o.quantity * p.price ELSE 0 END), 0) AS open_amount,
+        COALESCE(SUM(CASE WHEN o.status = 'paid' THEN o.quantity * p.price ELSE 0 END), 0) AS paid_amount
+      FROM guests g
+      JOIN orders o ON o.guest_id = g.id
+      JOIN products p ON o.product_id = p.id
+      GROUP BY g.id
+      ORDER BY total_spent DESC
+    `).all();
+
+    const byCategory = db.prepare(`
+      SELECT
+        p.category,
+        COALESCE(SUM(o.quantity), 0) AS total_quantity,
+        COALESCE(SUM(o.quantity * p.price), 0) AS total_revenue
+      FROM orders o
+      JOIN products p ON o.product_id = p.id
+      GROUP BY p.category
+      ORDER BY total_revenue DESC
+    `).all();
+
+    const settlements = db.prepare(`
+      SELECT COUNT(*) AS count, COALESCE(SUM(total_amount), 0) AS total
+      FROM settlements
+    `).get();
+
+    res.json({
+      revenue,
+      top_products: topProducts,
+      orders_per_guest: ordersPerGuest,
+      by_category: byCategory,
+      settlements,
+    });
+  } catch (err) {
+    console.error('[admin/reports/gastro]', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 
 module.exports = router;

--- a/backend/src/routes/history.js
+++ b/backend/src/routes/history.js
@@ -1,0 +1,192 @@
+const express = require('express');
+const { db } = require('../db/db');
+
+const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// GET /api/history — List all finished tournaments
+// ---------------------------------------------------------------------------
+router.get('/', (req, res) => {
+  try {
+    const tournaments = db.prepare(`
+      SELECT
+        t.id, t.name, t.date, t.format, t.checkout, t.status, t.created_at,
+        COUNT(DISTINCT tr.player_id) AS player_count,
+        COUNT(DISTINCT CASE WHEN g.status = 'finished' THEN g.id END) AS games_played,
+        w.name AS winner_name, w.id AS winner_id
+      FROM tournaments t
+      LEFT JOIN tournament_registrations tr ON tr.tournament_id = t.id
+      LEFT JOIN games g ON g.tournament_id = t.id
+      LEFT JOIN (
+        SELECT g2.tournament_id, g2.winner_id
+        FROM games g2
+        WHERE g2.status = 'finished'
+          AND g2.round = (
+            SELECT MAX(g3.round) FROM games g3
+            WHERE g3.tournament_id = g2.tournament_id AND g3.status = 'finished'
+          )
+      ) final_game ON final_game.tournament_id = t.id
+      LEFT JOIN players w ON w.id = final_game.winner_id
+      WHERE t.status = 'finished'
+      GROUP BY t.id
+      ORDER BY t.date DESC, t.created_at DESC
+    `).all();
+
+    res.json(tournaments);
+  } catch (err) {
+    console.error('[history]', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/history/:id — Tournament detail + per-player stats
+// Stats: 3-dart average, W/L, 180s, checkout%, best leg, highest checkout
+// ---------------------------------------------------------------------------
+router.get('/:id', (req, res) => {
+  try {
+    const tournamentId = parseInt(req.params.id, 10);
+    if (!tournamentId || tournamentId <= 0) {
+      return res.status(400).json({ error: 'Invalid tournament ID' });
+    }
+
+    const tournament = db.prepare(`
+      SELECT id, name, date, format, checkout, status, created_at
+      FROM tournaments WHERE id = ?
+    `).get(tournamentId);
+
+    if (!tournament) {
+      return res.status(404).json({ error: 'Tournament not found' });
+    }
+
+    // Registered players
+    const players = db.prepare(`
+      SELECT p.id, p.name, p.nickname
+      FROM players p
+      JOIN tournament_registrations tr ON tr.player_id = p.id
+      WHERE tr.tournament_id = ?
+      ORDER BY p.name
+    `).all(tournamentId);
+
+    // Prepared statements reused per player
+    const stmtGames = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM games
+      WHERE tournament_id = ? AND status = 'finished'
+        AND (player1_id = ? OR player2_id = ?)
+    `);
+    const stmtWins = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM games
+      WHERE tournament_id = ? AND status = 'finished' AND winner_id = ?
+    `);
+    const stmtThrows = db.prepare(`
+      SELECT t.score, t.remaining, t.segment
+      FROM throws t
+      JOIN games g ON t.game_id = g.id
+      WHERE g.tournament_id = ? AND t.player_id = ? AND t.is_bulloff = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws
+          WHERE undo_of IS NOT NULL
+            AND game_id IN (SELECT id FROM games WHERE tournament_id = ?)
+        )
+      ORDER BY t.id ASC
+    `);
+    const stmtCheckouts = db.prepare(`
+      SELECT t.score AS checkout_score
+      FROM throws t
+      JOIN games g ON t.game_id = g.id
+      WHERE g.tournament_id = ? AND t.player_id = ? AND t.is_bulloff = 0
+        AND t.remaining = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws
+          WHERE undo_of IS NOT NULL
+            AND game_id IN (SELECT id FROM games WHERE tournament_id = ?)
+        )
+    `);
+    const stmtBestLeg = db.prepare(`
+      SELECT g.id AS game_id, COUNT(t.id) AS throw_count
+      FROM games g
+      JOIN throws t ON t.game_id = g.id AND t.player_id = ? AND t.is_bulloff = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws
+          WHERE undo_of IS NOT NULL AND game_id = g.id
+        )
+      WHERE g.tournament_id = ? AND g.status = 'finished' AND g.winner_id = ?
+      GROUP BY g.id
+      ORDER BY throw_count ASC
+      LIMIT 1
+    `);
+
+    const playerStats = players.map(p => {
+      const gamesPlayed = stmtGames.get(tournamentId, p.id, p.id).cnt;
+      const wins = stmtWins.get(tournamentId, p.id).cnt;
+      const losses = gamesPlayed - wins;
+
+      const throws = stmtThrows.all(tournamentId, p.id, tournamentId);
+      const totalScore = throws.reduce((s, t) => s + t.score, 0);
+      const throwCount = throws.length;
+      const threeDartAvg = throwCount >= 3
+        ? Math.round((totalScore / throwCount) * 3 * 100) / 100
+        : null;
+
+      // 180s: groups of 3 consecutive throws summing to 180
+      let oneEighties = 0;
+      for (let i = 0; i + 2 < throws.length; i += 3) {
+        if (throws[i].score + throws[i + 1].score + throws[i + 2].score === 180) {
+          oneEighties++;
+        }
+      }
+
+      const checkouts = stmtCheckouts.all(tournamentId, p.id, tournamentId);
+      const highestCheckout = checkouts.length > 0
+        ? Math.max(...checkouts.map(c => c.checkout_score))
+        : null;
+      const checkoutPct = wins > 0
+        ? Math.round((checkouts.length / wins) * 100 * 100) / 100
+        : null;
+
+      const bestLeg = stmtBestLeg.get(p.id, tournamentId, p.id);
+
+      return {
+        id: p.id,
+        name: p.name,
+        nickname: p.nickname,
+        games_played: gamesPlayed,
+        wins,
+        losses,
+        three_dart_avg: threeDartAvg,
+        one_eighties: oneEighties,
+        checkout_pct: checkoutPct,
+        highest_checkout: highestCheckout,
+        best_leg: bestLeg ? bestLeg.throw_count : null,
+      };
+    });
+
+    // Games list
+    const games = db.prepare(`
+      SELECT g.id, g.round, g.status, g.winner_id,
+        p1.name AS player1_name, p1.id AS player1_id,
+        p2.name AS player2_name, p2.id AS player2_id,
+        w.name AS winner_name
+      FROM games g
+      LEFT JOIN players p1 ON g.player1_id = p1.id
+      LEFT JOIN players p2 ON g.player2_id = p2.id
+      LEFT JOIN players w ON g.winner_id = w.id
+      WHERE g.tournament_id = ?
+      ORDER BY g.round, g.id
+    `).all(tournamentId);
+
+    res.json({
+      tournament,
+      players: playerStats,
+      games,
+    });
+  } catch (err) {
+    console.error('[history]', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/players.js
+++ b/backend/src/routes/players.js
@@ -162,7 +162,133 @@ router.get('/', (req, res) => {
   res.json(players);
 });
 
-// GET /api/players/:id — Spielerprofil mit Turnierhistorie
+// GET /api/players/:id/stats — Career stats across all tournaments
+router.get('/:id/stats', (req, res) => {
+  try {
+    const playerId = parseInt(req.params.id, 10);
+    if (!playerId || playerId <= 0) {
+      return res.status(400).json({ error: 'Invalid player ID' });
+    }
+
+    const player = db.prepare(
+      'SELECT id, name, vorname, nickname, nachname, registered_at FROM players WHERE id = ?'
+    ).get(playerId);
+    if (!player) {
+      return res.status(404).json({ error: 'Player not found' });
+    }
+
+    const totalGames = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM games
+      WHERE status = 'finished' AND (player1_id = ? OR player2_id = ?)
+    `).get(playerId, playerId).cnt;
+
+    const totalWins = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM games
+      WHERE status = 'finished' AND winner_id = ?
+    `).get(playerId).cnt;
+
+    const totalLosses = totalGames - totalWins;
+
+    // All active throws (non-bulloff, non-undone)
+    const allThrows = db.prepare(`
+      SELECT t.score, t.remaining, t.segment
+      FROM throws t
+      JOIN games g ON t.game_id = g.id
+      WHERE t.player_id = ? AND t.is_bulloff = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws WHERE undo_of IS NOT NULL
+        )
+      ORDER BY t.id ASC
+    `).all(playerId);
+
+    const totalScore = allThrows.reduce((s, t) => s + t.score, 0);
+    const throwCount = allThrows.length;
+    const threeDartAvg = throwCount >= 3
+      ? Math.round((totalScore / throwCount) * 3 * 100) / 100
+      : null;
+
+    let oneEighties = 0;
+    for (let i = 0; i + 2 < throwCount; i += 3) {
+      if (allThrows[i].score + allThrows[i + 1].score + allThrows[i + 2].score === 180) {
+        oneEighties++;
+      }
+    }
+
+    const checkouts = allThrows.filter(t => t.remaining === 0);
+    const highestCheckout = checkouts.length > 0
+      ? Math.max(...checkouts.map(c => c.score))
+      : null;
+    const checkoutPct = totalWins > 0
+      ? Math.round((checkouts.length / totalWins) * 100 * 100) / 100
+      : null;
+
+    const bestLeg = db.prepare(`
+      SELECT g.id AS game_id, COUNT(t.id) AS throw_count
+      FROM games g
+      JOIN throws t ON t.game_id = g.id AND t.player_id = ? AND t.is_bulloff = 0
+        AND t.undo_of IS NULL
+        AND t.id NOT IN (
+          SELECT COALESCE(undo_of, 0) FROM throws WHERE undo_of IS NOT NULL AND game_id = g.id
+        )
+      WHERE g.status = 'finished' AND g.winner_id = ?
+      GROUP BY g.id
+      ORDER BY throw_count ASC
+      LIMIT 1
+    `).get(playerId, playerId);
+
+    const tournamentsPlayed = db.prepare(`
+      SELECT COUNT(DISTINCT tr.tournament_id) AS cnt
+      FROM tournament_registrations tr WHERE tr.player_id = ?
+    `).get(playerId).cnt;
+
+    const tournamentWins = db.prepare(`
+      SELECT COUNT(DISTINCT g.tournament_id) AS cnt
+      FROM games g
+      WHERE g.status = 'finished' AND g.winner_id = ?
+        AND g.round = (
+          SELECT MAX(g2.round) FROM games g2
+          WHERE g2.tournament_id = g.tournament_id AND g2.status = 'finished'
+        )
+    `).get(playerId).cnt;
+
+    const tournamentHistory = db.prepare(`
+      SELECT
+        t.id, t.name, t.date, t.format, t.status AS tournament_status,
+        COUNT(CASE WHEN g.winner_id = ? THEN 1 END) AS wins,
+        COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = ? OR g.player2_id = ?) AND g.winner_id != ? THEN 1 END) AS losses
+      FROM tournament_registrations tr
+      JOIN tournaments t ON tr.tournament_id = t.id
+      LEFT JOIN games g ON g.tournament_id = t.id AND (g.player1_id = ? OR g.player2_id = ?) AND g.status = 'finished'
+      WHERE tr.player_id = ?
+      GROUP BY t.id
+      ORDER BY t.date DESC, t.created_at DESC
+    `).all(playerId, playerId, playerId, playerId, playerId, playerId, playerId);
+
+    res.json({
+      player,
+      career: {
+        tournaments_played: tournamentsPlayed,
+        tournament_wins: tournamentWins,
+        games_played: totalGames,
+        wins: totalWins,
+        losses: totalLosses,
+        win_rate: totalGames > 0 ? Math.round((totalWins / totalGames) * 100 * 100) / 100 : null,
+        three_dart_avg: threeDartAvg,
+        one_eighties: oneEighties,
+        checkout_pct: checkoutPct,
+        highest_checkout: highestCheckout,
+        best_leg: bestLeg ? bestLeg.throw_count : null,
+      },
+      tournament_history: tournamentHistory,
+    });
+  } catch (err) {
+    console.error('[players/stats]', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /api/players/:id/profile — Spielerprofil mit Turnierhistorie
 router.get('/:id/profile', (req, res) => {
   const player = db.prepare('SELECT * FROM players WHERE id = ?').get(req.params.id);
   if (!player) return res.status(404).json({ error: 'Spieler nicht gefunden' });

--- a/docs/superpowers/plans/2026-03-16-persistent-players-walkon-metadata.md
+++ b/docs/superpowers/plans/2026-03-16-persistent-players-walkon-metadata.md
@@ -1,0 +1,1070 @@
+# Persistent Player Lookup & Walk-On Metadata — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow admins to search and reuse existing player profiles when adding players to a tournament, and automatically extract + display Walk-On artist/title metadata.
+
+**Architecture:** Backend adds DB migration, a new dedicated search route, extended `POST /api/tournaments/:id/players`, metadata extraction in the download pipeline, and enriched player responses. Frontend replaces the "add player" form with a search-first flow and upgrades the Walk-On badge to show artist/title.
+
+**Tech Stack:** Node.js + Express + better-sqlite3 + yt-dlp (backend), React 18 + Zustand (frontend), Node built-in test runner (`node:test`)
+
+**Spec:** `docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md`
+
+---
+
+## Chunk 1: Backend
+
+### Task 1: DB Migration — walkon_title & walkon_artist
+
+**Files:**
+- Modify: `backend/src/db/db.js` (alterStatements array, lines 61–93)
+
+- [ ] **Step 1: Add two ALTER TABLE statements to alterStatements array in `db.js`**
+
+Find the `alterStatements` array (after line 91 `"ALTER TABLE tournaments ADD COLUMN use_seed BOOLEAN DEFAULT 0",`) and append:
+
+```js
+"ALTER TABLE players ADD COLUMN walkon_title TEXT",
+"ALTER TABLE players ADD COLUMN walkon_artist TEXT",
+```
+
+- [ ] **Step 2: Verify migration runs cleanly**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend
+node -e "const { db, initialize } = require('./src/db/db'); initialize(); const cols = db.prepare(\"PRAGMA table_info(players)\").all().map(c => c.name); console.log(cols.includes('walkon_title') && cols.includes('walkon_artist') ? 'OK: columns exist' : 'FAIL: missing columns');"
+```
+
+Expected output: `OK: columns exist`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/db/db.js
+git commit -m "feat: add walkon_title and walkon_artist columns to players"
+```
+
+---
+
+### Task 2: New Player Search Endpoint
+
+**Files:**
+- Create: `backend/src/routes/playerSearch.js`
+- Modify: `backend/src/app.js` (add mount after line 65)
+
+- [ ] **Step 1: Create `backend/src/routes/playerSearch.js`**
+
+```js
+// backend/src/routes/playerSearch.js
+const express = require('express');
+const { db } = require('../db/db');
+
+const router = express.Router();
+
+// GET /api/players/search?q=<term>&tournament_id=<id>
+// Mounted at /api/players/search in app.js (NOT in players.js to avoid double-mount collision)
+router.get('/', (req, res) => {
+  const { q, tournament_id } = req.query;
+
+  if (!q || q.trim().length < 2) {
+    return res.status(400).json({ error: 'Suchbegriff muss mindestens 2 Zeichen lang sein' });
+  }
+
+  const term = `%${q.trim()}%`;
+  const tid = tournament_id ? parseInt(tournament_id, 10) : null;
+
+  const players = db.prepare(`
+    SELECT
+      p.id, p.name, p.vorname, p.nickname, p.nachname,
+      p.walkon_title, p.walkon_artist,
+      (p.walkon_file IS NOT NULL) AS has_walkon,
+      (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+      COUNT(DISTINCT tr.tournament_id) AS tournaments_count,
+      COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) AS wins,
+      COUNT(CASE WHEN g.status = 'finished'
+            AND (g.player1_id = p.id OR g.player2_id = p.id)
+            AND g.winner_id != p.id THEN 1 END) AS losses
+    FROM players p
+    LEFT JOIN tournament_registrations tr ON tr.player_id = p.id
+    LEFT JOIN games g ON (g.player1_id = p.id OR g.player2_id = p.id) AND g.status = 'finished'
+    WHERE (
+      LOWER(p.name)     LIKE LOWER(?) OR
+      LOWER(p.nickname) LIKE LOWER(?) OR
+      LOWER(p.vorname)  LIKE LOWER(?) OR
+      LOWER(p.nachname) LIKE LOWER(?)
+    )
+    AND (? IS NULL OR p.id NOT IN (
+      SELECT player_id FROM tournament_registrations WHERE tournament_id = ?
+    ))
+    GROUP BY p.id
+    ORDER BY p.name ASC
+    LIMIT 10
+  `).all(term, term, term, term, tid, tid);
+
+  res.json(players);
+});
+
+module.exports = router;
+```
+
+- [ ] **Step 2: Mount route in `backend/src/app.js`**
+
+After the line `app.use('/api/players', playerRoutes);` (line 65), add:
+
+```js
+const playerSearchRoutes = require('./routes/playerSearch');
+app.use('/api/players/search', playerSearchRoutes);
+```
+
+Also add the require near the top with the other requires (after `const playerRoutes = require('./routes/players');`):
+
+```js
+const playerSearchRoutes = require('./routes/playerSearch');
+```
+
+And the mount after line 65:
+
+```js
+app.use('/api/players/search', playerSearchRoutes);
+```
+
+- [ ] **Step 3: Write a test for the search endpoint**
+
+Create `backend/src/routes/playerSearch.test.js`:
+
+```js
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const Database = require('better-sqlite3');
+const express = require('express');
+const http = require('http');
+
+// Use in-memory DB for tests
+process.env.DB_PATH = ':memory:';
+const { db, initialize } = require('../db/db');
+
+describe('GET /api/players/search', () => {
+  let server;
+  let port;
+
+  before(() => {
+    initialize();
+    // Seed test data
+    db.prepare("INSERT INTO players (name, vorname, nickname, nachname) VALUES (?, ?, ?, ?)")
+      .run('Martin "Ace" Hofmann', 'Martin', 'Ace', 'Hofmann');
+    db.prepare("INSERT INTO players (name, vorname, nickname, nachname) VALUES (?, ?, ?, ?)")
+      .run('Julia "Blitz" Braun', 'Julia', 'Blitz', 'Braun');
+
+    const app = express();
+    const router = require('./playerSearch');
+    app.use('/', router);
+    server = http.createServer(app);
+    server.listen(0);
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('returns 400 for query shorter than 2 chars', async () => {
+    const res = await fetch(`http://localhost:${port}/?q=a`);
+    assert.equal(res.status, 400);
+  });
+
+  it('finds player by nickname', async () => {
+    const res = await fetch(`http://localhost:${port}/?q=ace`);
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.length, 1);
+    assert.equal(data[0].nickname, 'Ace');
+  });
+
+  it('finds player by vorname', async () => {
+    const res = await fetch(`http://localhost:${port}/?q=julia`);
+    const data = await res.json();
+    assert.equal(data[0].nickname, 'Blitz');
+  });
+
+  it('returns has_walkon false when no walkon_file', async () => {
+    const res = await fetch(`http://localhost:${port}/?q=ace`);
+    const data = await res.json();
+    assert.equal(data[0].has_walkon, 0);
+  });
+
+  it('limits to 10 results', async () => {
+    // Insert 11 more players named "Test"
+    for (let i = 0; i < 11; i++) {
+      db.prepare("INSERT INTO players (name, vorname, nickname, nachname) VALUES (?, ?, ?, ?)")
+        .run(`Test${i} "T${i}" X`, `Test${i}`, `T${i}`, 'X');
+    }
+    const res = await fetch(`http://localhost:${port}/?q=test`);
+    const data = await res.json();
+    assert.ok(data.length <= 10);
+  });
+});
+```
+
+- [ ] **Step 4: Run the test — expect it to pass**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend
+node --test src/routes/playerSearch.test.js
+```
+
+Expected: all tests pass (✓)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/playerSearch.js backend/src/routes/playerSearch.test.js backend/src/app.js
+git commit -m "feat: add GET /api/players/search endpoint"
+```
+
+---
+
+### Task 3: Extend POST /api/tournaments/:id/players with player_id
+
+**Files:**
+- Modify: `backend/src/routes/players.js` (lines 30–98)
+
+- [ ] **Step 1: Replace `requireFields` middleware and add `player_id` path**
+
+Replace the route definition starting at line 30:
+
+```js
+router.post('/:id/players', requireFields(['vorname', 'nickname', 'nachname']), (req, res) => {
+```
+
+with (remove requireFields from this route, add inline validation):
+
+```js
+router.post('/:id/players', (req, res) => {
+  const tournament = db.prepare('SELECT * FROM tournaments WHERE id = ?').get(req.params.id);
+  if (!tournament) {
+    return res.status(404).json({ error: 'Turnier nicht gefunden' });
+  }
+  if (tournament.status !== 'open') {
+    return res.status(400).json({ error: 'Die Anmeldephase für dieses Turnier ist bereits geschlossen' });
+  }
+
+  // ── Path A: existing player by player_id ────────────────────
+  if (req.body.player_id) {
+    const pid = parseInt(req.body.player_id, 10);
+    if (!pid || pid <= 0) {
+      return res.status(400).json({ error: 'Ungültige player_id' });
+    }
+    const player = db.prepare('SELECT * FROM players WHERE id = ?').get(pid);
+    if (!player) {
+      return res.status(404).json({ error: 'Spieler nicht gefunden' });
+    }
+    const alreadyRegistered = db.prepare(
+      'SELECT id FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?'
+    ).get(pid, req.params.id);
+    if (alreadyRegistered) {
+      return res.status(409).json({ error: 'Spieler ist bereits in diesem Turnier angemeldet' });
+    }
+    const cancelToken = crypto.randomBytes(32).toString('hex');
+    db.prepare(
+      'INSERT INTO tournament_registrations (player_id, tournament_id, seed, cancel_token) VALUES (?, ?, ?, ?)'
+    ).run(pid, req.params.id, req.body.seed || null, cancelToken);
+    auditLog(req, 'player', 'REGISTER', `Spieler "${player.name}" (bestehend) in Turnier "${tournament.name}" angemeldet`, pid);
+    return res.status(201).json({ ...player, cancel_token: cancelToken });
+  }
+
+  // ── Path B: new or existing player by name fields ────────────
+  const { vorname, nickname, nachname, seed } = req.body;
+  if (!vorname || !nickname || !nachname) {
+    return res.status(400).json({ error: 'vorname, nickname und nachname sind Pflichtfelder' });
+  }
+```
+
+Then close with the existing logic (the code from `const vn = vorname.trim()` onward stays unchanged). The closing brace of the route handler stays the same.
+
+- [ ] **Step 2: Verify the import of `crypto` is present at the top of `players.js`**
+
+Line 1 of `players.js` should already have `const crypto = require('crypto');` — verify it's there.
+
+- [ ] **Step 3: Write a test for the player_id path**
+
+Add to `backend/src/routes/playerSearch.test.js` or create `backend/src/routes/players.test.js`:
+
+```js
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.DB_PATH = ':memory:';
+const { db, initialize } = require('../db/db');
+
+describe('POST /api/tournaments/:id/players with player_id', () => {
+  before(() => {
+    initialize();
+    db.prepare("INSERT INTO tournaments (name, format, checkout, status) VALUES (?, ?, ?, ?)").run('Test', '501', 'double_out', 'open');
+    db.prepare("INSERT INTO players (name, vorname, nickname, nachname) VALUES (?, ?, ?, ?)").run('Ace Hofmann', 'Martin', 'Ace', 'Hofmann');
+  });
+
+  it('registers existing player by player_id', () => {
+    const tournament = db.prepare('SELECT id FROM tournaments LIMIT 1').get();
+    const player = db.prepare('SELECT id FROM players LIMIT 1').get();
+    // Simulate the DB operation directly (route logic)
+    const cancelToken = 'testtoken123';
+    db.prepare('INSERT INTO tournament_registrations (player_id, tournament_id, seed, cancel_token) VALUES (?, ?, ?, ?)')
+      .run(player.id, tournament.id, null, cancelToken);
+    const reg = db.prepare('SELECT * FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?').get(player.id, tournament.id);
+    assert.ok(reg);
+    assert.equal(reg.player_id, player.id);
+  });
+
+  it('duplicate check: same player cannot register twice', () => {
+    const tournament = db.prepare('SELECT id FROM tournaments LIMIT 1').get();
+    const player = db.prepare('SELECT id FROM players LIMIT 1').get();
+    const existing = db.prepare('SELECT id FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?').get(player.id, tournament.id);
+    assert.ok(existing, 'Should already be registered from previous test');
+  });
+});
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend
+node --test src/routes/players.test.js
+```
+
+Expected: all pass (✓)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/players.js backend/src/routes/players.test.js
+git commit -m "feat: extend POST /tournaments/:id/players to accept player_id for existing players"
+```
+
+---
+
+### Task 4: Fix Walk-On DELETE to clear new metadata columns
+
+**Files:**
+- Modify: `backend/src/routes/walkon.js` (DELETE handler, ~line 230)
+
+- [ ] **Step 1: Update the UPDATE statement in the DELETE handler**
+
+Find the existing UPDATE in the DELETE handler (around line 231):
+
+```js
+db.prepare(
+  'UPDATE players SET walkon_file = NULL, walkon_youtube = NULL, walkon_start = NULL, walkon_duration = NULL WHERE id = ?'
+).run(playerId);
+```
+
+Replace with:
+
+```js
+db.prepare(
+  'UPDATE players SET walkon_file = NULL, walkon_youtube = NULL, walkon_start = NULL, walkon_duration = NULL, walkon_title = NULL, walkon_artist = NULL WHERE id = ?'
+).run(playerId);
+```
+
+- [ ] **Step 2: Verify — run a quick node check**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend
+node -e "
+const { db, initialize } = require('./src/db/db');
+initialize();
+db.prepare('INSERT OR IGNORE INTO players (id, name, walkon_title, walkon_artist) VALUES (999, \"test\", \"Title\", \"Artist\")').run();
+db.prepare('UPDATE players SET walkon_file = NULL, walkon_youtube = NULL, walkon_start = NULL, walkon_duration = NULL, walkon_title = NULL, walkon_artist = NULL WHERE id = 999').run();
+const p = db.prepare('SELECT walkon_title, walkon_artist FROM players WHERE id = 999').get();
+console.log(p.walkon_title === null && p.walkon_artist === null ? 'OK' : 'FAIL');
+db.prepare('DELETE FROM players WHERE id = 999').run();
+"
+```
+
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/routes/walkon.js
+git commit -m "fix: clear walkon_title and walkon_artist on walk-on delete"
+```
+
+---
+
+### Task 5: Walk-On Metadata Extraction in downloadWalkon()
+
+**Files:**
+- Modify: `backend/src/routes/walkon.js` (downloadWalkon function, lines 13–99)
+
+- [ ] **Step 1: Add metadata extraction step after walkon_file update (step 4), before job status ready (step 8)**
+
+Find the block after `fs.unlinkSync(tempPath)` cleanup (around line 82) and before the `status = 'ready'` update (around line 88). Insert between them:
+
+```js
+    // 5. Metadaten extrahieren (artist, title) — unkritisch, kein Fehler bei Fehlschlag
+    try {
+      const currentJob = db.prepare('SELECT id FROM walkon_jobs WHERE player_id = ? ORDER BY id DESC LIMIT 1').get(playerId);
+      if (currentJob && currentJob.id === jobId) {
+        const meta = await new Promise((resolve) => {
+          const dlpMeta = spawn('yt-dlp', [
+            '--no-playlist',
+            '--print', '%(artist,uploader)s',
+            '--print', 'title',
+            url
+          ]);
+          let out = '';
+          dlpMeta.stdout.on('data', (d) => { out += d.toString(); });
+          dlpMeta.on('close', () => resolve(out));
+          dlpMeta.on('error', () => resolve(''));
+        });
+        const lines = meta.trim().split(/\r?\n/).map(l => l.trim());
+        const artist = (lines[0] && lines[0] !== 'NA') ? lines[0] : null;
+        const title  = (lines[1] && lines[1] !== 'NA') ? lines[1] : null;
+        db.prepare('UPDATE players SET walkon_artist = ?, walkon_title = ? WHERE id = ?').run(artist, title, playerId);
+      }
+    } catch (_) { /* stilles Fallback — kein Einfluss auf Download-Status */ }
+```
+
+The complete reordered sequence in the `try` block of `downloadWalkon` should be:
+1. yt-dlp spawn (download) → resolve/reject
+2. ffmpeg spawn (trim) → resolve/reject
+3. `fs.unlinkSync(tempPath)`
+4. `db.prepare('UPDATE players SET walkon_file = ?').run(finalPath, playerId)`
+5. **[NEW]** metadata extraction block (above)
+6. `db.prepare("UPDATE walkon_jobs SET status = 'ready'...").run(jobId)` ← unchanged, stays last
+
+- [ ] **Step 2: Verify the function compiles (syntax check)**
+
+```bash
+node --check /home/moritzwolf/dartsturnier/backend/src/routes/walkon.js
+```
+
+Expected: no output (clean)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/routes/walkon.js
+git commit -m "feat: extract walk-on artist/title metadata from yt-dlp after download"
+```
+
+---
+
+### Task 6: Enrich Player Responses with walkon_title, walkon_artist, has_walkon, walkon_status
+
+**Files:**
+- Modify: `backend/src/routes/players.js` (GET /, GET /:id/players)
+- Modify: `backend/src/routes/walkon.js` (GET /:playerId/status)
+
+The correlated subquery to reuse in all three places:
+
+```sql
+(SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+(p.walkon_file IS NOT NULL) AS has_walkon
+```
+
+- [ ] **Step 1: Update `GET /api/players` (all players, line ~150)**
+
+Find the SQL in `router.get('/', ...)`. Replace the SELECT columns:
+
+Current:
+```js
+SELECT
+  p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube, p.registered_at,
+  COUNT(DISTINCT tr.tournament_id) as tournaments_count,
+  COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) as wins,
+  COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = p.id OR g.player2_id = p.id) AND g.winner_id != p.id THEN 1 END) as losses
+```
+
+Replace with:
+```js
+SELECT
+  p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube,
+  p.walkon_title, p.walkon_artist,
+  (p.walkon_file IS NOT NULL) AS has_walkon,
+  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+  p.registered_at,
+  COUNT(DISTINCT tr.tournament_id) as tournaments_count,
+  COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) as wins,
+  COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = p.id OR g.player2_id = p.id) AND g.winner_id != p.id THEN 1 END) as losses
+```
+
+- [ ] **Step 2: Update `GET /api/tournaments/:id/players` (line ~17)**
+
+Current SELECT:
+```js
+SELECT p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube,
+       tr.seed, tr.registered_at, tr.id as registration_id
+```
+
+Replace with:
+```js
+SELECT p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube,
+       p.walkon_title, p.walkon_artist,
+       (p.walkon_file IS NOT NULL) AS has_walkon,
+       (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+       tr.seed, tr.registered_at, tr.id as registration_id
+```
+
+- [ ] **Step 3: Update `GET /api/walkon/:playerId/status` response (line ~152)**
+
+Find the `db.prepare('SELECT id, walkon_file, walkon_start, walkon_duration, walkon_youtube FROM players WHERE id = ?')`.
+
+Replace with:
+```js
+const player = db.prepare(
+  'SELECT id, walkon_file, walkon_start, walkon_duration, walkon_youtube, walkon_title, walkon_artist FROM players WHERE id = ?'
+).get(playerId);
+```
+
+And update the `res.json(...)` call to include the new fields:
+```js
+res.json({
+  player_id:       player.id,
+  walkon_file:     player.walkon_file,
+  walkon_start:    player.walkon_start,
+  walkon_duration: player.walkon_duration,
+  walkon_url:      player.walkon_youtube,
+  walkon_title:    player.walkon_title,
+  walkon_artist:   player.walkon_artist,
+  job:             job || null
+});
+```
+
+- [ ] **Step 4: Syntax-check both files**
+
+```bash
+node --check /home/moritzwolf/dartsturnier/backend/src/routes/players.js
+node --check /home/moritzwolf/dartsturnier/backend/src/routes/walkon.js
+```
+
+Expected: no output
+
+- [ ] **Step 5: Smoke-test the backend**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend && node src/app.js &
+sleep 2
+curl -s http://localhost:3001/api/players | node -e "const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); console.log(Array.isArray(d) && 'walkon_title' in d[0] ? 'OK' : d.length === 0 ? 'OK (empty)' : 'FAIL');"
+kill %1
+```
+
+Expected: `OK` or `OK (empty)`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/routes/players.js backend/src/routes/walkon.js
+git commit -m "feat: enrich player responses with walkon_title, walkon_artist, has_walkon, walkon_status"
+```
+
+---
+
+## Chunk 2: Frontend
+
+### Task 7: Walk-On Badge — Badge-Stil mit Artist/Titel
+
+**Files:**
+- Modify: `frontend/src/pages/AdminPage.jsx`
+  - `WalkonBadge` component (around line 305–320)
+  - Desktop player card walk-on display (around lines 583–604)
+  - Mobile player card walk-on display (around lines 668–670)
+
+- [ ] **Step 1: Rewrite the `WalkonBadge` component**
+
+Find the existing `WalkonBadge` function (around line 305) and replace it entirely:
+
+```jsx
+function WalkonBadge({ status, title, artist }) {
+  let bg, border, color, text;
+
+  if (status === 'ready') {
+    bg     = 'rgba(0,229,160,0.1)';
+    border = 'rgba(0,229,160,0.3)';
+    color  = 'var(--pe-success)';
+    const label = (artist && title) ? `${artist} — ${title}` : (title || artist || 'bereit');
+    text = `♪ ${label}`;
+  } else if (status === 'pending' || status === 'downloading') {
+    bg     = 'rgba(255,176,32,0.1)';
+    border = 'rgba(255,176,32,0.3)';
+    color  = 'var(--pe-warning)';
+    text   = '⏳ lädt…';
+  } else if (status === 'error') {
+    bg     = 'rgba(255,69,96,0.1)';
+    border = 'rgba(255,69,96,0.3)';
+    color  = 'var(--pe-danger)';
+    text   = '✗ Fehler';
+  } else {
+    // has_walkon but no known status yet (e.g. fresh row, no job recorded) — muted fallback
+    bg     = 'transparent';
+    border = 'transparent';
+    color  = 'var(--pe-text-muted)';
+    text   = '♪';
+  }
+
+  if (!text) return null;
+
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: '4px',
+      background: bg, border: `1px solid ${border}`,
+      borderRadius: '6px', padding: '2px 7px',
+      fontSize: '11px', color,
+      fontFamily: 'Verdana, Geneva, sans-serif',
+      maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    }}>
+      {text}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Update `loadPlayers` to use server-returned walkon_status directly**
+
+Find `loadPlayers` (around line 402). Currently it makes per-player `/walkon/:id/status` calls. Replace it with a simpler version that uses the server-side data:
+
+```jsx
+const loadPlayers = async () => {
+  const updated = await api.get(`/tournaments/${selectedTournament}/players`);
+  setPlayers(updated);
+  // Seed walkonStatuses from server-side walkon_status field (no per-player API calls needed)
+  const statuses = {};
+  for (const p of updated) {
+    if (p.has_walkon || p.walkon_youtube) {
+      statuses[p.id] = p.walkon_status || null;
+    }
+  }
+  setWalkonStatuses(statuses);
+};
+```
+
+- [ ] **Step 3: Update the desktop player card walk-on display**
+
+Find the block in the desktop grid (around lines 583–604) that computes `walkonText`/`walkonColor`:
+
+```jsx
+const hasWalkon = p.walkon_url || p.walkon_youtube;
+const walkonStatus = walkonStatuses[p.id];
+let walkonText = '♪ —';
+let walkonColor = 'var(--pe-text-muted)';
+if (hasWalkon) { ... }
+```
+
+Replace the entire block and the `<div style={{ fontSize: '10px', color: walkonColor ... }}>{walkonText}</div>` line with:
+
+```jsx
+const effectiveWalkonStatus = walkonStatuses[p.id] ?? p.walkon_status;
+```
+
+And replace the sub-line element:
+```jsx
+<div style={{ fontSize: '10px', color: walkonColor, marginTop: '2px' }}>{walkonText}</div>
+```
+with:
+```jsx
+{(p.has_walkon || p.walkon_youtube) && (
+  <WalkonBadge
+    status={effectiveWalkonStatus}
+    title={p.walkon_title}
+    artist={p.walkon_artist}
+  />
+)}
+```
+
+- [ ] **Step 4: Update the mobile player card walk-on display**
+
+Find around line 668:
+```jsx
+{(p.walkon_url || p.walkon_youtube) && (
+  <WalkonBadge status={walkonStatuses[p.id]} />
+)}
+```
+
+Replace with:
+```jsx
+{(p.has_walkon || p.walkon_youtube) && (
+  <WalkonBadge
+    status={walkonStatuses[p.id] ?? p.walkon_status}
+    title={p.walkon_title}
+    artist={p.walkon_artist}
+  />
+)}
+```
+
+- [ ] **Step 5: Verify no build errors**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend
+npm run build 2>&1 | tail -5
+```
+
+Expected: `built in Xs` with no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/AdminPage.jsx
+git commit -m "feat: walk-on badge shows artist and title in player cards"
+```
+
+---
+
+### Task 8: Player Search Flow — Replace Add-Player Form
+
+**Files:**
+- Modify: `frontend/src/pages/AdminPage.jsx`
+  - `PlayersTab` component state and JSX (lines 321–700)
+
+This task replaces the `showForm` state + `handleCreate` form with a 2-mode search-first flow.
+
+- [ ] **Step 1: Replace state declarations for the add-player flow**
+
+In `PlayersTab`, find:
+```jsx
+const [showForm, setShowForm] = useState(false);
+```
+
+Replace with:
+```jsx
+const [addMode, setAddMode] = useState(null); // null | 'search' | 'new'
+const [searchQuery, setSearchQuery] = useState('');
+const [searchResults, setSearchResults] = useState([]);
+const [searchLoading, setSearchLoading] = useState(false);
+const [confirmPlayer, setConfirmPlayer] = useState(null); // player object to confirm
+const [confirmSeed, setConfirmSeed] = useState('');
+```
+
+- [ ] **Step 2: Add debounced search effect**
+
+After the `loadPlayers` function definition, add:
+
+```jsx
+useEffect(() => {
+  if (!searchQuery || searchQuery.trim().length < 2) {
+    setSearchResults([]);
+    setConfirmPlayer(null);
+    return;
+  }
+  const timer = setTimeout(async () => {
+    setSearchLoading(true);
+    try {
+      const results = await api.get(
+        `/players/search?q=${encodeURIComponent(searchQuery.trim())}&tournament_id=${selectedTournament}`
+      );
+      setSearchResults(results);
+    } catch {
+      setSearchResults([]);
+    } finally {
+      setSearchLoading(false);
+    }
+  }, 300);
+  return () => clearTimeout(timer);
+}, [searchQuery, selectedTournament]);
+```
+
+- [ ] **Step 3: Add `handleRegisterExisting` handler**
+
+After the debounced search effect, add:
+
+```jsx
+const handleRegisterExisting = async () => {
+  if (!confirmPlayer || !selectedTournament) return;
+  try {
+    await api.post(`/tournaments/${selectedTournament}/players`, {
+      player_id: confirmPlayer.id,
+      seed: confirmSeed ? parseInt(confirmSeed, 10) : undefined,
+    });
+    setAddMode(null);
+    setSearchQuery('');
+    setSearchResults([]);
+    setConfirmPlayer(null);
+    setConfirmSeed('');
+    await loadPlayers();
+    addToast({ type: 'success', message: `${confirmPlayer.name} angemeldet` });
+  } catch (err) {
+    addToast({ type: 'error', message: err.message || 'Anmeldung fehlgeschlagen' });
+  }
+};
+```
+
+- [ ] **Step 4: Update `handleCreate` to reset addMode instead of showForm**
+
+Find in `handleCreate`:
+```jsx
+setShowForm(false);
+```
+Replace with:
+```jsx
+setAddMode(null);
+setSearchQuery('');
+setSearchResults([]);
+```
+
+Also update the form reset:
+```jsx
+setForm({ vorname: '', nickname: '', nachname: '', walk_on_song: '', walkon_start: 0, walkon_duration: 30 });
+```
+(keep as-is, just make sure it also clears after new player creation)
+
+- [ ] **Step 5: Update the header button — "+ Neu" triggers search mode**
+
+Find the header button:
+```jsx
+<button onClick={() => setShowForm(!showForm)} ...>
+  {showForm ? 'Abbrechen' : '+ Neu'}
+</button>
+```
+
+Replace with:
+```jsx
+<button
+  onClick={() => { setAddMode(addMode ? null : 'search'); setSearchQuery(''); setSearchResults([]); setConfirmPlayer(null); }}
+  className="px-4 py-2 rounded-lg text-sm font-bold"
+  style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif' }}
+>
+  {addMode ? 'Abbrechen' : '+ Spieler'}
+</button>
+```
+
+- [ ] **Step 6: Replace the old form JSX with the new search UI**
+
+Find the `{showForm && !isActive && (<form onSubmit={handleCreate} ...>` block (lines 503–538) and replace the entire block with:
+
+```jsx
+{addMode && !isActive && (
+  <div className="p-4 rounded-xl mb-6" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
+
+    {/* Mode: search */}
+    {addMode === 'search' && !confirmPlayer && (
+      <>
+        <input
+          type="text"
+          autoFocus
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Name oder Nickname suchen…"
+          className="w-full p-3 rounded-lg outline-none mb-3"
+          style={inputStyle}
+        />
+        {searchLoading && (
+          <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)', textAlign: 'center', padding: '8px' }}>Suche…</p>
+        )}
+        {!searchLoading && searchQuery.trim().length >= 2 && searchResults.length === 0 && (
+          <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)', textAlign: 'center', padding: '8px' }}>
+            Keine Spieler gefunden.
+          </p>
+        )}
+        {searchResults.map((p) => (
+          <div
+            key={p.id}
+            onClick={() => { setConfirmPlayer(p); setConfirmSeed(''); }}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '10px',
+              background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)',
+              borderRadius: '8px', padding: '10px 12px', marginBottom: '6px', cursor: 'pointer',
+            }}
+            className="pe-card-interactive"
+          >
+            <div style={{
+              width: '36px', height: '36px', borderRadius: '8px', flexShrink: 0,
+              background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: '11px', fontWeight: 'bold', color: 'var(--pe-cyan-bright)',
+            }}>
+              {((p.vorname?.[0] || '') + (p.nachname?.[0] || '')).toUpperCase() || '?'}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: '13px', fontWeight: 'bold', color: 'var(--pe-text)' }}>{p.name}</div>
+              <div style={{ fontSize: '11px', color: 'var(--pe-text-muted)', marginTop: '2px' }}>
+                {p.tournaments_count} Turnier{p.tournaments_count !== 1 ? 'e' : ''} · {p.wins}S / {p.losses}N
+                {p.has_walkon ? <span style={{ marginLeft: '6px', color: 'var(--pe-success)' }}>♪</span> : null}
+              </div>
+            </div>
+          </div>
+        ))}
+        <button
+          onClick={() => setAddMode('new')}
+          style={{
+            width: '100%', marginTop: '6px', padding: '10px',
+            border: '1px dashed var(--pe-border)', borderRadius: '8px',
+            background: 'none', color: 'var(--pe-cyan-bright)',
+            fontSize: '12px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          + Neuen Spieler anlegen{searchQuery.trim() ? ` "${searchQuery.trim()}"` : ''}
+        </button>
+      </>
+    )}
+
+    {/* Confirm panel after selecting a player */}
+    {addMode === 'search' && confirmPlayer && (
+      <div>
+        <button
+          onClick={() => setConfirmPlayer(null)}
+          style={{ fontSize: '11px', color: 'var(--pe-text-muted)', background: 'none', border: 'none', cursor: 'pointer', marginBottom: '12px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+        >
+          ← Zurück zur Suche
+        </button>
+        <div style={{ background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-cyan-bright)', borderRadius: '10px', padding: '14px', marginBottom: '12px' }}>
+          <div style={{ fontSize: '10px', color: 'var(--pe-cyan-bright)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '6px' }}>Gefundener Spieler</div>
+          <div style={{ fontSize: '15px', fontWeight: 'bold', color: 'var(--pe-text)', marginBottom: '4px' }}>{confirmPlayer.name}</div>
+          <div style={{ fontSize: '11px', color: 'var(--pe-text-sub)', marginBottom: '8px' }}>
+            {confirmPlayer.tournaments_count} Turnier{confirmPlayer.tournaments_count !== 1 ? 'e' : ''} · {confirmPlayer.wins} Siege / {confirmPlayer.losses} Niederlagen
+          </div>
+          {confirmPlayer.has_walkon && (
+            <WalkonBadge
+              status={confirmPlayer.walkon_status}
+              title={confirmPlayer.walkon_title}
+              artist={confirmPlayer.walkon_artist}
+            />
+          )}
+        </div>
+        <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Setzung (optional)</label>
+        <input
+          type="number"
+          min="1"
+          value={confirmSeed}
+          onChange={(e) => setConfirmSeed(e.target.value)}
+          placeholder="z.B. 1"
+          className="w-full p-3 rounded-lg outline-none mb-3"
+          style={inputStyle}
+        />
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            onClick={handleRegisterExisting}
+            className="flex-1 py-3 rounded-lg font-bold"
+            style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+          >
+            Anmelden
+          </button>
+          <button
+            onClick={() => setConfirmPlayer(null)}
+            className="px-4 py-3 rounded-lg"
+            style={{ background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif' }}
+          >
+            Abbrechen
+          </button>
+        </div>
+      </div>
+    )}
+
+    {/* Mode: new player form */}
+    {addMode === 'new' && (
+      <form onSubmit={handleCreate} className="space-y-3">
+        <button
+          type="button"
+          onClick={() => setAddMode('search')}
+          style={{ fontSize: '11px', color: 'var(--pe-text-muted)', background: 'none', border: 'none', cursor: 'pointer', marginBottom: '4px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+        >
+          ← Zurück zur Suche
+        </button>
+        <input type="text" value={form.vorname} onChange={(e) => setForm({ ...form, vorname: e.target.value })} placeholder="Vorname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+        <input
+          type="text"
+          value={form.nickname}
+          onChange={(e) => setForm({ ...form, nickname: e.target.value })}
+          placeholder="Nickname *"
+          required
+          className="w-full p-3 rounded-lg outline-none"
+          style={inputStyle}
+        />
+        <input type="text" value={form.nachname} onChange={(e) => setForm({ ...form, nachname: e.target.value })} placeholder="Nachname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+        <input type="url" value={form.walk_on_song} onChange={(e) => setForm({ ...form, walk_on_song: e.target.value })} placeholder="Walk-On Song URL (optional)" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+        {form.walk_on_song && (
+          <div className="flex gap-2">
+            <div style={{ flex: 1 }}>
+              <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Startzeit (Sek.)</label>
+              <input type="number" min="0" value={form.walkon_start} onChange={(e) => setForm({ ...form, walkon_start: e.target.value })} required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Länge (Sek.)</label>
+              <input type="number" min="5" max="120" value={form.walkon_duration} onChange={(e) => setForm({ ...form, walkon_duration: e.target.value })} required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+            </div>
+          </div>
+        )}
+        {form.vorname && form.nickname && form.nachname && (
+          <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)' }}>
+            Angezeigt als: <strong style={{ color: 'var(--pe-text)' }}>{form.vorname.trim()} &ldquo;{form.nickname.trim()}&rdquo; {form.nachname.trim()}</strong>
+          </p>
+        )}
+        <button type="submit" disabled={!form.vorname.trim() || !form.nickname.trim() || !form.nachname.trim()} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+          Spieler anlegen & anmelden
+        </button>
+      </form>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 7: Pre-fill nickname in "new" mode when coming from search**
+
+In the `handleCreate` — no change needed since the form is initialized empty. But when "+ Neuen Spieler anlegen" button is clicked, pre-fill the nickname from `searchQuery`. Update the button's `onClick`:
+
+```jsx
+onClick={() => {
+  setForm({ vorname: '', nickname: searchQuery.trim(), nachname: '', walk_on_song: '', walkon_start: 0, walkon_duration: 30 });
+  setAddMode('new');
+}}
+```
+
+- [ ] **Step 8: Apply all state-change steps atomically, then build**
+
+> **Important:** Steps 1, 4, and 5 of this task all touch `showForm`/`setShowForm`. The JSX references in the button (Step 5) and form guard (Step 6 replaces the old `{showForm && ...}` block) must all be replaced before running a build — a partial application leaves dangling `showForm` references that will cause a runtime warning. Complete all steps in order before running the build check below.
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend
+npm run build 2>&1 | tail -10
+```
+
+Expected: clean build, no errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/pages/AdminPage.jsx
+git commit -m "feat: replace add-player form with search-first flow (existing player lookup)"
+```
+
+---
+
+### Task 9: Create PR and Cleanup
+
+- [ ] **Step 1: Create feature branch from dev and push**
+
+```bash
+git checkout dev && git pull origin dev
+git checkout -b feat/persistent-player-lookup-walkon-metadata
+git cherry-pick <all commits from tasks 1-8>
+git push origin feat/persistent-player-lookup-walkon-metadata
+```
+
+Actually — if work was done directly on `dev`, create the branch properly:
+```bash
+# If working on a feature branch already:
+git push origin feat/persistent-player-lookup-walkon-metadata
+gh pr create --base dev --head feat/persistent-player-lookup-walkon-metadata \
+  --title "feat: persistent player lookup and walk-on metadata" \
+  --body "$(cat <<'EOF'
+## Summary
+- Admin can search existing player profiles when adding to a tournament (search-first flow)
+- Walk-on artist/title automatically extracted from YouTube via yt-dlp after download
+- Player cards show artist/title as badge instead of plain text status
+- New `GET /api/players/search` endpoint (own route file, avoids double-mount issue)
+- `POST /api/tournaments/:id/players` accepts optional `player_id` for direct registration
+- `walkon_title`, `walkon_artist` columns added to players table
+
+## Test plan
+- [ ] Search for an existing player by name/nickname → results appear
+- [ ] Select player → confirm panel shows stats + walk-on badge
+- [ ] Register existing player → appears in player list
+- [ ] "+ Neuen Spieler anlegen" → form opens with nickname pre-filled
+- [ ] New player creation still works as before
+- [ ] Walk-on badge shows artist/title after download completes
+- [ ] Deleting a walk-on clears title/artist from DB
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+**Plan complete.** 9 tasks, ~25 steps total. All backend tasks (1–6) are independent and can run in sequence. Frontend tasks (7–8) depend on backend being done first (new fields in responses).

--- a/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
+++ b/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
@@ -1,0 +1,183 @@
+# Design: Persistente Spieler — Turnier-Lookup & Walk-On Metadaten
+
+**Date:** 2026-03-16
+**Status:** Approved
+**Scope:** Backend + Frontend
+
+---
+
+## Problem
+
+Spielerprofile sind bereits persistent (eigene `players` Tabelle, losgelöst von Turnieren). Dennoch gibt es beim Hinzufügen eines Spielers zu einem Turnier nur ein leeres Formular — bestehende Spieler können nicht gesucht oder wiederverwendet werden.
+
+Zusätzlich fehlen zwei UX-Verbesserungen in der Spielerliste:
+1. Walk-On Metadaten (Interpret, Titel) werden von yt-dlp nicht extrahiert und nicht angezeigt.
+2. Die Walk-On Anzeige in der Spieler-Karte ist zu klein und informationsarm.
+
+---
+
+## Ziele
+
+1. Admin kann beim Turnier-Spieler-Management bestehende Spielerprofile suchen und direkt anmelden.
+2. Beim Walk-On Download werden Interpret und Titel automatisch per yt-dlp extrahiert und gespeichert.
+3. Die Spieler-Karte zeigt Walk-On als lesbaren Badge mit Interpret und Titel.
+
+---
+
+## Nicht im Scope
+
+- Spielerprofil-Detailseite / History (eigenes Feature #76)
+- Walk-On Audio Player im Admin (bereits vorhanden)
+- Öffentliche Spielersuche / Public API
+
+---
+
+## Architektur
+
+### Datenbank
+
+Zwei neue Spalten in `players`:
+
+```sql
+ALTER TABLE players ADD COLUMN walkon_title  TEXT;
+ALTER TABLE players ADD COLUMN walkon_artist TEXT;
+```
+
+Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pattern (SQLite: try/catch auf ALTER).
+
+---
+
+### Backend
+
+#### 1. `GET /api/players/search?q=<term>&tournament_id=<id>`
+
+- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE, case-insensitive)
+- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus
+- Gibt max. 10 Treffer zurück
+- Response pro Spieler:
+  ```json
+  {
+    "id": 1,
+    "name": "Martin \"Ace\" Hofmann",
+    "vorname": "Martin",
+    "nickname": "Ace",
+    "nachname": "Hofmann",
+    "walkon_title": "Seven Nation Army",
+    "walkon_artist": "The White Stripes",
+    "walkon_file": "/path/or/null",
+    "tournaments_count": 3,
+    "wins": 12,
+    "losses": 4
+  }
+  ```
+- Kein Auth erforderlich (öffentliche Spielerdaten)
+
+#### 2. `POST /api/tournaments/:id/players` — Erweiterung
+
+Neuer optionaler Body-Parameter: `player_id` (Integer).
+
+- Wenn `player_id` gesetzt: Spieler muss existieren → direkt `tournament_registrations` Eintrag anlegen, kein neues Profil erstellen
+- Wenn `player_id` nicht gesetzt: bisheriges Verhalten (Profil per Nickname suchen oder neu anlegen)
+- Duplikat-Check bleibt: gleicher Spieler darf nicht zweimal im selben Turnier angemeldet sein
+
+#### 3. Walk-On Route — Metadaten-Extraktion
+
+Nach erfolgreichem yt-dlp Audio-Download:
+
+```bash
+yt-dlp --no-playlist --print title --print uploader <url>
+```
+
+Gibt zwei Zeilen aus: Zeile 1 = Titel, Zeile 2 = Uploader/Artist.
+
+```js
+db.prepare('UPDATE players SET walkon_title = ?, walkon_artist = ? WHERE id = ?')
+  .run(title, artist, playerId);
+```
+
+Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `ready`, Felder bleiben `NULL`.
+
+#### 4. Player-Responses erweitern
+
+`walkon_title` und `walkon_artist` in allen bestehenden Player-Responses ergänzen:
+- `GET /api/players`
+- `GET /api/tournaments/:id/players`
+- `GET /api/walkon/:playerId/status`
+
+---
+
+### Frontend
+
+#### Spieler-Karte (Badge-Stil)
+
+Wenn Walk-On vorhanden (`walkon_youtube` gesetzt) und Status bekannt:
+
+| Status | Badge |
+|--------|-------|
+| `ready` | `♪ Artist — Titel` (grüner Badge) |
+| `pending` / `downloading` | `⏳ lädt…` (gelber Badge) |
+| `error` | `✗ Fehler` (roter Badge) |
+| kein Walk-On | kein Badge |
+
+Badge-Stil:
+```css
+background: rgba(0,229,160,0.1);
+border: 1px solid rgba(0,229,160,0.3);
+border-radius: 6px;
+padding: 2px 7px;
+font-size: 11px;
+color: var(--pe-success);
+```
+
+Wenn `walkon_title` / `walkon_artist` vorhanden: `♪ {artist} — {title}` anzeigen.
+Wenn nicht vorhanden aber ready: `♪ bereit` anzeigen.
+
+#### Spieler hinzufügen — Suchflow
+
+Das bestehende Formular (Vorname / Nickname / Nachname) wird durch einen 2-Modus-Flow ersetzt:
+
+**Modus 1: Suche (Standard)**
+
+1. Suchfeld (Debounce 300ms) → `GET /api/players/search?q=...&tournament_id=...`
+2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge
+3. Klick auf Spieler → Confirm-Panel erscheint:
+   - Spielerinfo (Name, Stats, Walk-On)
+   - Optionales Setzungs-Feld
+   - "Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
+4. Unten: "+ Neuen Spieler anlegen" → wechselt zu Modus 2
+
+**Modus 2: Neuer Spieler**
+
+- Bisheriges Formular (Vorname / Nickname / Nachname / Walk-On URL / Start / Dauer)
+- "Zurück zur Suche" Link oben
+- Nickname wird aus dem Suchbegriff vorausgefüllt wenn vorhanden
+
+---
+
+## Fehlerbehandlung
+
+- Suchfeld leer oder < 2 Zeichen: keine API-Anfrage, keine Ergebnisliste
+- Keine Treffer: leerer Zustand mit "+ Neuen Spieler anlegen" CTA
+- `player_id` nicht gefunden: Backend gibt `404` zurück
+- Spieler bereits im Turnier: Backend gibt `409` zurück mit erklärender Meldung
+- yt-dlp Metadaten-Fehler: stilles Fallback, kein Einfluss auf Download-Status
+
+---
+
+## Implementierungsreihenfolge
+
+1. DB-Migration (walkon_title, walkon_artist)
+2. Backend: Search-Endpunkt
+3. Backend: POST players mit player_id
+4. Backend: Walk-On Metadaten-Extraktion
+5. Backend: Player-Responses erweitern
+6. Frontend: Spieler-Karte Badge
+7. Frontend: Suchflow
+
+---
+
+## Nicht geändert
+
+- Walk-On ist und bleibt am `players`-Profil gebunden (nicht an `tournament_registrations`)
+- `cancel_token` Mechanismus bleibt unverändert
+- Spielerprofil-Daten (Name, Nickname) bleiben editierbar im bestehenden Edit-Dialog

--- a/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
+++ b/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
@@ -43,7 +43,7 @@ ALTER TABLE players ADD COLUMN walkon_title  TEXT;
 ALTER TABLE players ADD COLUMN walkon_artist TEXT;
 ```
 
-Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pattern (SQLite: try/catch auf ALTER).
+Migration in `db.js` via try/catch auf ALTER TABLE (identisches Pattern zu bestehenden `vorname`/`nickname`/`nachname` Migrationen).
 
 ---
 
@@ -51,58 +51,171 @@ Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pa
 
 #### 1. `GET /api/players/search?q=<term>&tournament_id=<id>`
 
-- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE, case-insensitive)
-- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus
+**Routing — wichtig:** `players.js` ist in `app.js` an **zwei** Pfaden gemountet: `/api/tournaments` und `/api/players`. Eine neue Route in `players.js` würde also auch unter `/api/tournaments/search` erreichbar sein. Um diese Kollision zu vermeiden, wird der Search-Endpoint in einer **eigenen Datei** `backend/src/routes/playerSearch.js` implementiert und in `app.js` ausschließlich unter `/api/players/search` gemountet:
+
+```js
+// app.js
+const playerSearchRoutes = require('./routes/playerSearch');
+app.use('/api/players/search', playerSearchRoutes);
+```
+
+- Kein Auth erforderlich (konsistent mit bestehendem `GET /api/players`; beide Endpunkte sind interne Admin-Tools ohne Zugriff von außen via CORS)
+- Nur ausgeführt wenn `q` mindestens 2 Zeichen lang ist, sonst `400`
+- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE `%q%`, case-insensitive via `LOWER()`)
+- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus (Subquery auf `tournament_registrations`)
 - Gibt max. 10 Treffer zurück
-- Response pro Spieler:
-  ```json
-  {
-    "id": 1,
-    "name": "Martin \"Ace\" Hofmann",
-    "vorname": "Martin",
-    "nickname": "Ace",
-    "nachname": "Hofmann",
-    "walkon_title": "Seven Nation Army",
-    "walkon_artist": "The White Stripes",
-    "walkon_file": "/path/or/null",
-    "tournaments_count": 3,
-    "wins": 12,
-    "losses": 4
-  }
-  ```
-- Kein Auth erforderlich (öffentliche Spielerdaten)
+
+SQL-Grundstruktur:
+```sql
+SELECT
+  p.id, p.name, p.vorname, p.nickname, p.nachname,
+  p.walkon_title, p.walkon_artist,
+  (p.walkon_file IS NOT NULL) AS has_walkon,
+  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+  COUNT(DISTINCT tr.tournament_id) AS tournaments_count,
+  COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) AS wins,
+  COUNT(CASE WHEN g.status = 'finished'
+        AND (g.player1_id = p.id OR g.player2_id = p.id)
+        AND g.winner_id != p.id THEN 1 END) AS losses
+FROM players p
+LEFT JOIN tournament_registrations tr ON tr.player_id = p.id
+LEFT JOIN games g ON (g.player1_id = p.id OR g.player2_id = p.id) AND g.status = 'finished'
+WHERE (
+  LOWER(p.name) LIKE LOWER(?)
+  OR LOWER(p.nickname) LIKE LOWER(?)
+  OR LOWER(p.vorname) LIKE LOWER(?)
+  OR LOWER(p.nachname) LIKE LOWER(?)
+)
+AND (? IS NULL OR p.id NOT IN (
+  SELECT player_id FROM tournament_registrations WHERE tournament_id = ?
+))
+GROUP BY p.id
+ORDER BY p.name ASC
+LIMIT 10
+```
+
+Die correlated Subquery für `walkon_status` steht im SELECT-List (nicht im WHERE/JOIN) — kein Einfluss auf GROUP BY.
+
+Response pro Spieler:
+```json
+{
+  "id": 1,
+  "name": "Martin \"Ace\" Hofmann",
+  "vorname": "Martin",
+  "nickname": "Ace",
+  "nachname": "Hofmann",
+  "walkon_title": "Seven Nation Army",
+  "walkon_artist": "The White Stripes",
+  "has_walkon": true,
+  "walkon_status": "ready",
+  "tournaments_count": 3,
+  "wins": 12,
+  "losses": 4
+}
+```
 
 #### 2. `POST /api/tournaments/:id/players` — Erweiterung
 
 Neuer optionaler Body-Parameter: `player_id` (Integer).
 
-- Wenn `player_id` gesetzt: Spieler muss existieren → direkt `tournament_registrations` Eintrag anlegen, kein neues Profil erstellen
-- Wenn `player_id` nicht gesetzt: bisheriges Verhalten (Profil per Nickname suchen oder neu anlegen)
-- Duplikat-Check bleibt: gleicher Spieler darf nicht zweimal im selben Turnier angemeldet sein
+**Wenn `player_id` gesetzt:**
+- Bestehende `requireFields(['vorname', 'nickname', 'nachname'])` Middleware wird durch **inline konditionelle Validierung** ersetzt (Middleware komplett entfernen, Validierung in den Route-Handler verlagern):
+  ```js
+  if (req.body.player_id) {
+    const pid = parseInt(req.body.player_id, 10);
+    if (!pid || pid <= 0) return res.status(400).json({ error: 'Ungültige player_id' });
+  } else {
+    if (!req.body.vorname || !req.body.nickname || !req.body.nachname) {
+      return res.status(400).json({ error: 'vorname, nickname und nachname sind Pflichtfelder' });
+    }
+  }
+  ```
+- Tournament-Status-Prüfung (`status !== 'open'` → 400) gilt **auch** für den `player_id`-Pfad
+- Spieler muss in `players` existieren → 404 wenn nicht gefunden
+- Expliziter Duplikat-Check: `SELECT id FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?` → 409 mit Meldung `"Spieler ist bereits in diesem Turnier angemeldet"`
+- Direkt `tournament_registrations` Eintrag anlegen ohne Profil anzulegen
+- `walkon_youtube` aus dem Body wird bei `player_id`-Pfad ignoriert
+- `seed`: optionaler Integer (kein Eindeutigkeits-Check — konsistent mit bestehendem Verhalten)
+
+**Wenn `player_id` nicht gesetzt:**
+- Bisheriges Verhalten vollständig erhalten (Profil per Nickname suchen oder neu anlegen, `walkon_youtube` aus Body verarbeiten)
 
 #### 3. Walk-On Route — Metadaten-Extraktion
 
-Nach erfolgreichem yt-dlp Audio-Download:
+Metadaten-Extraktion läuft **vor** dem finalen `status = 'ready'` Update.
 
-```bash
-yt-dlp --no-playlist --print title --print uploader <url>
+Reihenfolge in `downloadWalkon()`:
+
+```
+1. yt-dlp download → tempPath
+2. ffmpeg trim → finalPath
+3. tempPath löschen
+4. walkon_file in players aktualisieren
+5. [NEU] yt-dlp --print metadata → walkon_artist/walkon_title extrahieren (try/catch, jobId-Check)
+6. [NEU] walkon_title + walkon_artist in players aktualisieren
+7. Job status → 'ready'
 ```
 
-Gibt zwei Zeilen aus: Zeile 1 = Titel, Zeile 2 = Uploader/Artist.
+Metadaten-Extraktion (Schritt 5):
 
 ```js
-db.prepare('UPDATE players SET walkon_title = ?, walkon_artist = ? WHERE id = ?')
-  .run(title, artist, playerId);
+try {
+  // Prüfen ob dieser Job noch der aktuelle ist (Race-Condition-Schutz)
+  const currentJob = db.prepare('SELECT id FROM walkon_jobs WHERE player_id = ? ORDER BY id DESC LIMIT 1').get(playerId);
+  if (currentJob && currentJob.id === jobId) {
+    const meta = await new Promise((resolve) => {
+      const dlp = spawn('yt-dlp', [
+        '--no-playlist',
+        '--print', '%(artist,uploader)s',
+        '--print', 'title',
+        url
+      ]);
+      let out = '';
+      dlp.stdout.on('data', (d) => { out += d.toString(); });
+      dlp.on('close', () => resolve(out));
+      dlp.on('error', () => resolve(''));
+    });
+    const lines = meta.trim().split(/\r?\n/).map(l => l.trim());
+    const artist = (lines[0] && lines[0] !== 'NA') ? lines[0] : null;
+    const title  = (lines[1] && lines[1] !== 'NA') ? lines[1] : null;
+    db.prepare('UPDATE players SET walkon_artist = ?, walkon_title = ? WHERE id = ?').run(artist, title, playerId);
+  }
+} catch (_) { /* stilles Fallback */ }
 ```
 
-Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `ready`, Felder bleiben `NULL`.
+**DELETE `/api/walkon/:playerId`:** Bestehender Handler muss `walkon_title` und `walkon_artist` ebenfalls auf NULL zurücksetzen:
+```sql
+UPDATE players SET walkon_file = NULL, walkon_youtube = NULL,
+  walkon_start = NULL, walkon_duration = NULL,
+  walkon_title = NULL, walkon_artist = NULL
+WHERE id = ?
+```
+
+Wenn `has_walkon = false` (nach DELETE), ist `walkon_status` aus der Subquery NULL — kein Badge wird angezeigt. Der Fall "kein Badge" greift sobald `has_walkon` falsy ist, unabhängig von `walkon_status`.
 
 #### 4. Player-Responses erweitern
 
-`walkon_title` und `walkon_artist` in allen bestehenden Player-Responses ergänzen:
-- `GET /api/players`
-- `GET /api/tournaments/:id/players`
-- `GET /api/walkon/:playerId/status`
+`walkon_title`, `walkon_artist`, `has_walkon` und `walkon_status` in folgenden Responses ergänzen:
+
+- **`GET /api/players`** — `walkon_title`, `walkon_artist`, `has_walkon`, `walkon_status` (correlated Subquery im SELECT-List, nicht als JOIN — bestehende GROUP BY-Aggregation bleibt erhalten)
+- **`GET /api/tournaments/:id/players`** — `walkon_title`, `walkon_artist`, `walkon_status`, `has_walkon` via correlated Subquery ergänzen:
+  ```sql
+  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+  (p.walkon_file IS NOT NULL) AS has_walkon
+  ```
+- **`GET /api/walkon/:playerId/status`** — Response um `walkon_title`, `walkon_artist` erweitern:
+  ```json
+  {
+    "player_id": 1,
+    "walkon_file": "/abs/path",
+    "walkon_start": 30,
+    "walkon_duration": 20,
+    "walkon_url": "https://...",
+    "walkon_title": "Seven Nation Army",
+    "walkon_artist": "The White Stripes",
+    "job": { "status": "ready", "id": 5 }
+  }
+  ```
 
 ---
 
@@ -110,74 +223,78 @@ Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `
 
 #### Spieler-Karte (Badge-Stil)
 
-Wenn Walk-On vorhanden (`walkon_youtube` gesetzt) und Status bekannt:
+Badge liest `walkon_status` direkt aus dem Player-Objekt (kein separater Polling-Call beim initialen Laden). Polling für laufende Downloads läuft weiterhin via `GET /api/walkon/:playerId/status`.
 
-| Status | Badge |
-|--------|-------|
-| `ready` | `♪ Artist — Titel` (grüner Badge) |
+| Bedingung | Badge |
+|-----------|-------|
+| `has_walkon` + `ready` + Metadaten vorhanden | `♪ {artist} — {title}` (grüner Badge) |
+| `has_walkon` + `ready` + keine Metadaten | `♪ bereit` (grüner Badge) |
 | `pending` / `downloading` | `⏳ lädt…` (gelber Badge) |
 | `error` | `✗ Fehler` (roter Badge) |
-| kein Walk-On | kein Badge |
+| `!has_walkon` | kein Badge |
 
-Badge-Stil:
+Badge-CSS (PE-Tokens):
 ```css
-background: rgba(0,229,160,0.1);
-border: 1px solid rgba(0,229,160,0.3);
-border-radius: 6px;
-padding: 2px 7px;
-font-size: 11px;
-color: var(--pe-success);
+/* ready */  background: rgba(0,229,160,0.1); border: 1px solid rgba(0,229,160,0.3); color: var(--pe-success);
+/* warning */ background: rgba(255,176,32,0.1); border: 1px solid rgba(255,176,32,0.3); color: var(--pe-warning);
+/* error */  background: rgba(255,69,96,0.1);  border: 1px solid rgba(255,69,96,0.3);  color: var(--pe-danger);
+/* shared */ border-radius: 6px; padding: 2px 7px; font-size: 11px; display: inline-flex; align-items: center; gap: 4px;
 ```
-
-Wenn `walkon_title` / `walkon_artist` vorhanden: `♪ {artist} — {title}` anzeigen.
-Wenn nicht vorhanden aber ready: `♪ bereit` anzeigen.
 
 #### Spieler hinzufügen — Suchflow
 
-Das bestehende Formular (Vorname / Nickname / Nachname) wird durch einen 2-Modus-Flow ersetzt:
+Das bestehende Formular wird durch einen 2-Modus-Flow ersetzt:
 
 **Modus 1: Suche (Standard)**
 
-1. Suchfeld (Debounce 300ms) → `GET /api/players/search?q=...&tournament_id=...`
-2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge
-3. Klick auf Spieler → Confirm-Panel erscheint:
-   - Spielerinfo (Name, Stats, Walk-On)
-   - Optionales Setzungs-Feld
-   - "Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
-4. Unten: "+ Neuen Spieler anlegen" → wechselt zu Modus 2
+1. Suchfeld — Debounce 300ms, min. 2 Zeichen → `GET /api/players/search?q=...&tournament_id=...`
+2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge wenn `has_walkon`
+3. 0 Treffer → Leer-Zustand + `+ Neuen Spieler anlegen "{Suchbegriff}"` CTA
+4. Klick auf Spieler → Confirm-Panel:
+   - Name, Stats, Walk-On Badge
+   - Optionales Setzungs-Feld (positive Integer)
+   - „Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
+   - „Abbrechen" → zurück zur Liste
+5. Unten: `+ Neuen Spieler anlegen` → Modus 2
 
 **Modus 2: Neuer Spieler**
 
 - Bisheriges Formular (Vorname / Nickname / Nachname / Walk-On URL / Start / Dauer)
-- "Zurück zur Suche" Link oben
-- Nickname wird aus dem Suchbegriff vorausgefüllt wenn vorhanden
+- Nickname vorausgefüllt aus Suchbegriff (falls aus Modus 1 gewechselt)
+- `← Zurück zur Suche` Link oben
 
 ---
 
 ## Fehlerbehandlung
 
-- Suchfeld leer oder < 2 Zeichen: keine API-Anfrage, keine Ergebnisliste
-- Keine Treffer: leerer Zustand mit "+ Neuen Spieler anlegen" CTA
-- `player_id` nicht gefunden: Backend gibt `404` zurück
-- Spieler bereits im Turnier: Backend gibt `409` zurück mit erklärender Meldung
-- yt-dlp Metadaten-Fehler: stilles Fallback, kein Einfluss auf Download-Status
+| Szenario | Verhalten |
+|----------|-----------|
+| `q` < 2 Zeichen | Keine API-Anfrage |
+| 0 Suchergebnisse | Leer-Zustand + CTA |
+| `player_id` nicht gefunden | 404 → Toast |
+| Spieler bereits im Turnier | 409 → Toast |
+| Turnier nicht `open` | 400 → Toast |
+| yt-dlp Metadaten-Fehler | Stilles Fallback, Status bleibt `ready` |
+| Zweiter Download während Metadaten-Extraktion | jobId-Check verhindert falschen Metadaten-Write |
 
 ---
 
 ## Implementierungsreihenfolge
 
-1. DB-Migration (walkon_title, walkon_artist)
-2. Backend: Search-Endpunkt
-3. Backend: POST players mit player_id
-4. Backend: Walk-On Metadaten-Extraktion
-5. Backend: Player-Responses erweitern
-6. Frontend: Spieler-Karte Badge
-7. Frontend: Suchflow
+1. DB-Migration (`walkon_title`, `walkon_artist` in `db.js`)
+2. Backend: `playerSearch.js` neu anlegen + in `app.js` mounten
+3. Backend: `POST /api/tournaments/:id/players` um `player_id` erweitern
+4. Backend: Walk-On `DELETE` Handler um neue Felder erweitern
+5. Backend: Walk-On Metadaten-Extraktion in `downloadWalkon()` (inkl. jobId-Check)
+6. Backend: Player-Responses um neue Felder erweitern
+7. Frontend: Walk-On Badge in Spieler-Karte
+8. Frontend: Suchflow (Modus 1 + Modus 2)
 
 ---
 
 ## Nicht geändert
 
-- Walk-On ist und bleibt am `players`-Profil gebunden (nicht an `tournament_registrations`)
-- `cancel_token` Mechanismus bleibt unverändert
-- Spielerprofil-Daten (Name, Nickname) bleiben editierbar im bestehenden Edit-Dialog
+- Walk-On bleibt am `players`-Profil gebunden
+- `cancel_token` Mechanismus unverändert
+- Edit-Dialog für Spielerprofil-Daten unverändert
+- Audio-Streaming via `GET /api/walkon/:playerId/audio` unverändert


### PR DESCRIPTION
## Summary
- **GET /api/history** — list all finished tournaments with winner name, player count, games played
- **GET /api/history/:id** — tournament detail with per-player stats: 3-dart average, W/L record, 180s count, checkout%, highest checkout, best leg (fewest throws)
- **GET /api/players/:id/stats** — career stats across all tournaments with tournament history breakdown
- **GET /api/admin/reports/gastro** — gastro report (total/paid/open revenue, top products by revenue, orders per guest, revenue by category, settlements) — restricted to admin/gastro roles

## Technical details
- All queries use prepared statements (no string concatenation)
- Undo-aware throw filtering (excludes bulloff throws, undone throws via undo_of)
- Input validation on all endpoints (integer ID parsing, bounds checking)
- Error handling with appropriate HTTP status codes
- history.js is a new route file, player stats added to existing players.js, gastro report added to existing admin.js

## Test plan
- [ ] Verify `/api/history` returns only finished tournaments
- [ ] Verify `/api/history/:id` returns correct player stats for a completed tournament
- [ ] Verify `/api/players/:id/stats` returns career stats with tournament history
- [ ] Verify `/api/admin/reports/gastro` requires admin/gastro role (returns 403 for other roles)
- [ ] Verify all endpoints return proper 404 for non-existent IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)