### PR TITLE
fix: add navigation links, font tokens and design audit fixes for stats pages

### DIFF
--- a/docs/superpowers/plans/2026-03-16-persistent-players-walkon-metadata.md
+++ b/docs/superpowers/plans/2026-03-16-persistent-players-walkon-metadata.md
@@ -1,0 +1,1070 @@
+# Persistent Player Lookup & Walk-On Metadata — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow admins to search and reuse existing player profiles when adding players to a tournament, and automatically extract + display Walk-On artist/title metadata.
+
+**Architecture:** Backend adds DB migration, a new dedicated search route, extended `POST /api/tournaments/:id/players`, metadata extraction in the download pipeline, and enriched player responses. Frontend replaces the "add player" form with a search-first flow and upgrades the Walk-On badge to show artist/title.
+
+**Tech Stack:** Node.js + Express + better-sqlite3 + yt-dlp (backend), React 18 + Zustand (frontend), Node built-in test runner (`node:test`)
+
+**Spec:** `docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md`
+
+---
+
+## Chunk 1: Backend
+
+### Task 1: DB Migration — walkon_title & walkon_artist
+
+**Files:**
+- Modify: `backend/src/db/db.js` (alterStatements array, lines 61–93)
+
+- [ ] **Step 1: Add two ALTER TABLE statements to alterStatements array in `db.js`**
+
+Find the `alterStatements` array (after line 91 `"ALTER TABLE tournaments ADD COLUMN use_seed BOOLEAN DEFAULT 0",`) and append:
+
+```js
+"ALTER TABLE players ADD COLUMN walkon_title TEXT",
+"ALTER TABLE players ADD COLUMN walkon_artist TEXT",
+```
+
+- [ ] **Step 2: Verify migration runs cleanly**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend
+node -e "const { db, initialize } = require('./src/db/db'); initialize(); const cols = db.prepare(\"PRAGMA table_info(players)\").all().map(c => c.name); console.log(cols.includes('walkon_title') && cols.includes('walkon_artist') ? 'OK: columns exist' : 'FAIL: missing columns');"
+```
+
+Expected output: `OK: columns exist`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/db/db.js
+git commit -m "feat: add walkon_title and walkon_artist columns to players"
+```
+
+---
+
+### Task 2: New Player Search Endpoint
+
+**Files:**
+- Create: `backend/src/routes/playerSearch.js`
+- Modify: `backend/src/app.js` (add mount after line 65)
+
+- [ ] **Step 1: Create `backend/src/routes/playerSearch.js`**
+
+```js
+// backend/src/routes/playerSearch.js
+const express = require('express');
+const { db } = require('../db/db');
+
+const router = express.Router();
+
+// GET /api/players/search?q=<term>&tournament_id=<id>
+// Mounted at /api/players/search in app.js (NOT in players.js to avoid double-mount collision)
+router.get('/', (req, res) => {
+  const { q, tournament_id } = req.query;
+
+  if (!q || q.trim().length < 2) {
+    return res.status(400).json({ error: 'Suchbegriff muss mindestens 2 Zeichen lang sein' });
+  }
+
+  const term = `%${q.trim()}%`;
+  const tid = tournament_id ? parseInt(tournament_id, 10) : null;
+
+  const players = db.prepare(`
+    SELECT
+      p.id, p.name, p.vorname, p.nickname, p.nachname,
+      p.walkon_title, p.walkon_artist,
+      (p.walkon_file IS NOT NULL) AS has_walkon,
+      (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+      COUNT(DISTINCT tr.tournament_id) AS tournaments_count,
+      COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) AS wins,
+      COUNT(CASE WHEN g.status = 'finished'
+            AND (g.player1_id = p.id OR g.player2_id = p.id)
+            AND g.winner_id != p.id THEN 1 END) AS losses
+    FROM players p
+    LEFT JOIN tournament_registrations tr ON tr.player_id = p.id
+    LEFT JOIN games g ON (g.player1_id = p.id OR g.player2_id = p.id) AND g.status = 'finished'
+    WHERE (
+      LOWER(p.name)     LIKE LOWER(?) OR
+      LOWER(p.nickname) LIKE LOWER(?) OR
+      LOWER(p.vorname)  LIKE LOWER(?) OR
+      LOWER(p.nachname) LIKE LOWER(?)
+    )
+    AND (? IS NULL OR p.id NOT IN (
+      SELECT player_id FROM tournament_registrations WHERE tournament_id = ?
+    ))
+    GROUP BY p.id
+    ORDER BY p.name ASC
+    LIMIT 10
+  `).all(term, term, term, term, tid, tid);
+
+  res.json(players);
+});
+
+module.exports = router;
+```
+
+- [ ] **Step 2: Mount route in `backend/src/app.js`**
+
+After the line `app.use('/api/players', playerRoutes);` (line 65), add:
+
+```js
+const playerSearchRoutes = require('./routes/playerSearch');
+app.use('/api/players/search', playerSearchRoutes);
+```
+
+Also add the require near the top with the other requires (after `const playerRoutes = require('./routes/players');`):
+
+```js
+const playerSearchRoutes = require('./routes/playerSearch');
+```
+
+And the mount after line 65:
+
+```js
+app.use('/api/players/search', playerSearchRoutes);
+```
+
+- [ ] **Step 3: Write a test for the search endpoint**
+
+Create `backend/src/routes/playerSearch.test.js`:
+
+```js
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const Database = require('better-sqlite3');
+const express = require('express');
+const http = require('http');
+
+// Use in-memory DB for tests
+process.env.DB_PATH = ':memory:';
+const { db, initialize } = require('../db/db');
+
+describe('GET /api/players/search', () => {
+  let server;
+  let port;
+
+  before(() => {
+    initialize();
+    // Seed test data
+    db.prepare("INSERT INTO players (name, vorname, nickname, nachname) VALUES (?, ?, ?, ?)")
+      .run('Martin "Ace" Hofmann', 'Martin', 'Ace', 'Hofmann');
+    db.prepare("INSERT INTO players (name, vorname, nickname, nachname) VALUES (?, ?, ?, ?)")
+      .run('Julia "Blitz" Braun', 'Julia', 'Blitz', 'Braun');
+
+    const app = express();
+    const router = require('./playerSearch');
+    app.use('/', router);
+    server = http.createServer(app);
+    server.listen(0);
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('returns 400 for query shorter than 2 chars', async () => {
+    const res = await fetch(`http://localhost:${port}/?q=a`);
+    assert.equal(res.status, 400);
+  });
+
+  it('finds player by nickname', async () => {
+    const res = await fetch(`http://localhost:${port}/?q=ace`);
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.length, 1);
+    assert.equal(data[0].nickname, 'Ace');
+  });
+
+  it('finds player by vorname', async () => {
+    const res = await fetch(`http://localhost:${port}/?q=julia`);
+    const data = await res.json();
+    assert.equal(data[0].nickname, 'Blitz');
+  });
+
+  it('returns has_walkon false when no walkon_file', async () => {
+    const res = await fetch(`http://localhost:${port}/?q=ace`);
+    const data = await res.json();
+    assert.equal(data[0].has_walkon, 0);
+  });
+
+  it('limits to 10 results', async () => {
+    // Insert 11 more players named "Test"
+    for (let i = 0; i < 11; i++) {
+      db.prepare("INSERT INTO players (name, vorname, nickname, nachname) VALUES (?, ?, ?, ?)")
+        .run(`Test${i} "T${i}" X`, `Test${i}`, `T${i}`, 'X');
+    }
+    const res = await fetch(`http://localhost:${port}/?q=test`);
+    const data = await res.json();
+    assert.ok(data.length <= 10);
+  });
+});
+```
+
+- [ ] **Step 4: Run the test — expect it to pass**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend
+node --test src/routes/playerSearch.test.js
+```
+
+Expected: all tests pass (✓)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/playerSearch.js backend/src/routes/playerSearch.test.js backend/src/app.js
+git commit -m "feat: add GET /api/players/search endpoint"
+```
+
+---
+
+### Task 3: Extend POST /api/tournaments/:id/players with player_id
+
+**Files:**
+- Modify: `backend/src/routes/players.js` (lines 30–98)
+
+- [ ] **Step 1: Replace `requireFields` middleware and add `player_id` path**
+
+Replace the route definition starting at line 30:
+
+```js
+router.post('/:id/players', requireFields(['vorname', 'nickname', 'nachname']), (req, res) => {
+```
+
+with (remove requireFields from this route, add inline validation):
+
+```js
+router.post('/:id/players', (req, res) => {
+  const tournament = db.prepare('SELECT * FROM tournaments WHERE id = ?').get(req.params.id);
+  if (!tournament) {
+    return res.status(404).json({ error: 'Turnier nicht gefunden' });
+  }
+  if (tournament.status !== 'open') {
+    return res.status(400).json({ error: 'Die Anmeldephase für dieses Turnier ist bereits geschlossen' });
+  }
+
+  // ── Path A: existing player by player_id ────────────────────
+  if (req.body.player_id) {
+    const pid = parseInt(req.body.player_id, 10);
+    if (!pid || pid <= 0) {
+      return res.status(400).json({ error: 'Ungültige player_id' });
+    }
+    const player = db.prepare('SELECT * FROM players WHERE id = ?').get(pid);
+    if (!player) {
+      return res.status(404).json({ error: 'Spieler nicht gefunden' });
+    }
+    const alreadyRegistered = db.prepare(
+      'SELECT id FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?'
+    ).get(pid, req.params.id);
+    if (alreadyRegistered) {
+      return res.status(409).json({ error: 'Spieler ist bereits in diesem Turnier angemeldet' });
+    }
+    const cancelToken = crypto.randomBytes(32).toString('hex');
+    db.prepare(
+      'INSERT INTO tournament_registrations (player_id, tournament_id, seed, cancel_token) VALUES (?, ?, ?, ?)'
+    ).run(pid, req.params.id, req.body.seed || null, cancelToken);
+    auditLog(req, 'player', 'REGISTER', `Spieler "${player.name}" (bestehend) in Turnier "${tournament.name}" angemeldet`, pid);
+    return res.status(201).json({ ...player, cancel_token: cancelToken });
+  }
+
+  // ── Path B: new or existing player by name fields ────────────
+  const { vorname, nickname, nachname, seed } = req.body;
+  if (!vorname || !nickname || !nachname) {
+    return res.status(400).json({ error: 'vorname, nickname und nachname sind Pflichtfelder' });
+  }
+```
+
+Then close with the existing logic (the code from `const vn = vorname.trim()` onward stays unchanged). The closing brace of the route handler stays the same.
+
+- [ ] **Step 2: Verify the import of `crypto` is present at the top of `players.js`**
+
+Line 1 of `players.js` should already have `const crypto = require('crypto');` — verify it's there.
+
+- [ ] **Step 3: Write a test for the player_id path**
+
+Add to `backend/src/routes/playerSearch.test.js` or create `backend/src/routes/players.test.js`:
+
+```js
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.DB_PATH = ':memory:';
+const { db, initialize } = require('../db/db');
+
+describe('POST /api/tournaments/:id/players with player_id', () => {
+  before(() => {
+    initialize();
+    db.prepare("INSERT INTO tournaments (name, format, checkout, status) VALUES (?, ?, ?, ?)").run('Test', '501', 'double_out', 'open');
+    db.prepare("INSERT INTO players (name, vorname, nickname, nachname) VALUES (?, ?, ?, ?)").run('Ace Hofmann', 'Martin', 'Ace', 'Hofmann');
+  });
+
+  it('registers existing player by player_id', () => {
+    const tournament = db.prepare('SELECT id FROM tournaments LIMIT 1').get();
+    const player = db.prepare('SELECT id FROM players LIMIT 1').get();
+    // Simulate the DB operation directly (route logic)
+    const cancelToken = 'testtoken123';
+    db.prepare('INSERT INTO tournament_registrations (player_id, tournament_id, seed, cancel_token) VALUES (?, ?, ?, ?)')
+      .run(player.id, tournament.id, null, cancelToken);
+    const reg = db.prepare('SELECT * FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?').get(player.id, tournament.id);
+    assert.ok(reg);
+    assert.equal(reg.player_id, player.id);
+  });
+
+  it('duplicate check: same player cannot register twice', () => {
+    const tournament = db.prepare('SELECT id FROM tournaments LIMIT 1').get();
+    const player = db.prepare('SELECT id FROM players LIMIT 1').get();
+    const existing = db.prepare('SELECT id FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?').get(player.id, tournament.id);
+    assert.ok(existing, 'Should already be registered from previous test');
+  });
+});
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend
+node --test src/routes/players.test.js
+```
+
+Expected: all pass (✓)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/players.js backend/src/routes/players.test.js
+git commit -m "feat: extend POST /tournaments/:id/players to accept player_id for existing players"
+```
+
+---
+
+### Task 4: Fix Walk-On DELETE to clear new metadata columns
+
+**Files:**
+- Modify: `backend/src/routes/walkon.js` (DELETE handler, ~line 230)
+
+- [ ] **Step 1: Update the UPDATE statement in the DELETE handler**
+
+Find the existing UPDATE in the DELETE handler (around line 231):
+
+```js
+db.prepare(
+  'UPDATE players SET walkon_file = NULL, walkon_youtube = NULL, walkon_start = NULL, walkon_duration = NULL WHERE id = ?'
+).run(playerId);
+```
+
+Replace with:
+
+```js
+db.prepare(
+  'UPDATE players SET walkon_file = NULL, walkon_youtube = NULL, walkon_start = NULL, walkon_duration = NULL, walkon_title = NULL, walkon_artist = NULL WHERE id = ?'
+).run(playerId);
+```
+
+- [ ] **Step 2: Verify — run a quick node check**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend
+node -e "
+const { db, initialize } = require('./src/db/db');
+initialize();
+db.prepare('INSERT OR IGNORE INTO players (id, name, walkon_title, walkon_artist) VALUES (999, \"test\", \"Title\", \"Artist\")').run();
+db.prepare('UPDATE players SET walkon_file = NULL, walkon_youtube = NULL, walkon_start = NULL, walkon_duration = NULL, walkon_title = NULL, walkon_artist = NULL WHERE id = 999').run();
+const p = db.prepare('SELECT walkon_title, walkon_artist FROM players WHERE id = 999').get();
+console.log(p.walkon_title === null && p.walkon_artist === null ? 'OK' : 'FAIL');
+db.prepare('DELETE FROM players WHERE id = 999').run();
+"
+```
+
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/routes/walkon.js
+git commit -m "fix: clear walkon_title and walkon_artist on walk-on delete"
+```
+
+---
+
+### Task 5: Walk-On Metadata Extraction in downloadWalkon()
+
+**Files:**
+- Modify: `backend/src/routes/walkon.js` (downloadWalkon function, lines 13–99)
+
+- [ ] **Step 1: Add metadata extraction step after walkon_file update (step 4), before job status ready (step 8)**
+
+Find the block after `fs.unlinkSync(tempPath)` cleanup (around line 82) and before the `status = 'ready'` update (around line 88). Insert between them:
+
+```js
+    // 5. Metadaten extrahieren (artist, title) — unkritisch, kein Fehler bei Fehlschlag
+    try {
+      const currentJob = db.prepare('SELECT id FROM walkon_jobs WHERE player_id = ? ORDER BY id DESC LIMIT 1').get(playerId);
+      if (currentJob && currentJob.id === jobId) {
+        const meta = await new Promise((resolve) => {
+          const dlpMeta = spawn('yt-dlp', [
+            '--no-playlist',
+            '--print', '%(artist,uploader)s',
+            '--print', 'title',
+            url
+          ]);
+          let out = '';
+          dlpMeta.stdout.on('data', (d) => { out += d.toString(); });
+          dlpMeta.on('close', () => resolve(out));
+          dlpMeta.on('error', () => resolve(''));
+        });
+        const lines = meta.trim().split(/\r?\n/).map(l => l.trim());
+        const artist = (lines[0] && lines[0] !== 'NA') ? lines[0] : null;
+        const title  = (lines[1] && lines[1] !== 'NA') ? lines[1] : null;
+        db.prepare('UPDATE players SET walkon_artist = ?, walkon_title = ? WHERE id = ?').run(artist, title, playerId);
+      }
+    } catch (_) { /* stilles Fallback — kein Einfluss auf Download-Status */ }
+```
+
+The complete reordered sequence in the `try` block of `downloadWalkon` should be:
+1. yt-dlp spawn (download) → resolve/reject
+2. ffmpeg spawn (trim) → resolve/reject
+3. `fs.unlinkSync(tempPath)`
+4. `db.prepare('UPDATE players SET walkon_file = ?').run(finalPath, playerId)`
+5. **[NEW]** metadata extraction block (above)
+6. `db.prepare("UPDATE walkon_jobs SET status = 'ready'...").run(jobId)` ← unchanged, stays last
+
+- [ ] **Step 2: Verify the function compiles (syntax check)**
+
+```bash
+node --check /home/moritzwolf/dartsturnier/backend/src/routes/walkon.js
+```
+
+Expected: no output (clean)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/routes/walkon.js
+git commit -m "feat: extract walk-on artist/title metadata from yt-dlp after download"
+```
+
+---
+
+### Task 6: Enrich Player Responses with walkon_title, walkon_artist, has_walkon, walkon_status
+
+**Files:**
+- Modify: `backend/src/routes/players.js` (GET /, GET /:id/players)
+- Modify: `backend/src/routes/walkon.js` (GET /:playerId/status)
+
+The correlated subquery to reuse in all three places:
+
+```sql
+(SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+(p.walkon_file IS NOT NULL) AS has_walkon
+```
+
+- [ ] **Step 1: Update `GET /api/players` (all players, line ~150)**
+
+Find the SQL in `router.get('/', ...)`. Replace the SELECT columns:
+
+Current:
+```js
+SELECT
+  p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube, p.registered_at,
+  COUNT(DISTINCT tr.tournament_id) as tournaments_count,
+  COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) as wins,
+  COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = p.id OR g.player2_id = p.id) AND g.winner_id != p.id THEN 1 END) as losses
+```
+
+Replace with:
+```js
+SELECT
+  p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube,
+  p.walkon_title, p.walkon_artist,
+  (p.walkon_file IS NOT NULL) AS has_walkon,
+  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+  p.registered_at,
+  COUNT(DISTINCT tr.tournament_id) as tournaments_count,
+  COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) as wins,
+  COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = p.id OR g.player2_id = p.id) AND g.winner_id != p.id THEN 1 END) as losses
+```
+
+- [ ] **Step 2: Update `GET /api/tournaments/:id/players` (line ~17)**
+
+Current SELECT:
+```js
+SELECT p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube,
+       tr.seed, tr.registered_at, tr.id as registration_id
+```
+
+Replace with:
+```js
+SELECT p.id, p.name, p.vorname, p.nickname, p.nachname, p.walkon_youtube,
+       p.walkon_title, p.walkon_artist,
+       (p.walkon_file IS NOT NULL) AS has_walkon,
+       (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+       tr.seed, tr.registered_at, tr.id as registration_id
+```
+
+- [ ] **Step 3: Update `GET /api/walkon/:playerId/status` response (line ~152)**
+
+Find the `db.prepare('SELECT id, walkon_file, walkon_start, walkon_duration, walkon_youtube FROM players WHERE id = ?')`.
+
+Replace with:
+```js
+const player = db.prepare(
+  'SELECT id, walkon_file, walkon_start, walkon_duration, walkon_youtube, walkon_title, walkon_artist FROM players WHERE id = ?'
+).get(playerId);
+```
+
+And update the `res.json(...)` call to include the new fields:
+```js
+res.json({
+  player_id:       player.id,
+  walkon_file:     player.walkon_file,
+  walkon_start:    player.walkon_start,
+  walkon_duration: player.walkon_duration,
+  walkon_url:      player.walkon_youtube,
+  walkon_title:    player.walkon_title,
+  walkon_artist:   player.walkon_artist,
+  job:             job || null
+});
+```
+
+- [ ] **Step 4: Syntax-check both files**
+
+```bash
+node --check /home/moritzwolf/dartsturnier/backend/src/routes/players.js
+node --check /home/moritzwolf/dartsturnier/backend/src/routes/walkon.js
+```
+
+Expected: no output
+
+- [ ] **Step 5: Smoke-test the backend**
+
+```bash
+cd /home/moritzwolf/dartsturnier/backend && node src/app.js &
+sleep 2
+curl -s http://localhost:3001/api/players | node -e "const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); console.log(Array.isArray(d) && 'walkon_title' in d[0] ? 'OK' : d.length === 0 ? 'OK (empty)' : 'FAIL');"
+kill %1
+```
+
+Expected: `OK` or `OK (empty)`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/routes/players.js backend/src/routes/walkon.js
+git commit -m "feat: enrich player responses with walkon_title, walkon_artist, has_walkon, walkon_status"
+```
+
+---
+
+## Chunk 2: Frontend
+
+### Task 7: Walk-On Badge — Badge-Stil mit Artist/Titel
+
+**Files:**
+- Modify: `frontend/src/pages/AdminPage.jsx`
+  - `WalkonBadge` component (around line 305–320)
+  - Desktop player card walk-on display (around lines 583–604)
+  - Mobile player card walk-on display (around lines 668–670)
+
+- [ ] **Step 1: Rewrite the `WalkonBadge` component**
+
+Find the existing `WalkonBadge` function (around line 305) and replace it entirely:
+
+```jsx
+function WalkonBadge({ status, title, artist }) {
+  let bg, border, color, text;
+
+  if (status === 'ready') {
+    bg     = 'rgba(0,229,160,0.1)';
+    border = 'rgba(0,229,160,0.3)';
+    color  = 'var(--pe-success)';
+    const label = (artist && title) ? `${artist} — ${title}` : (title || artist || 'bereit');
+    text = `♪ ${label}`;
+  } else if (status === 'pending' || status === 'downloading') {
+    bg     = 'rgba(255,176,32,0.1)';
+    border = 'rgba(255,176,32,0.3)';
+    color  = 'var(--pe-warning)';
+    text   = '⏳ lädt…';
+  } else if (status === 'error') {
+    bg     = 'rgba(255,69,96,0.1)';
+    border = 'rgba(255,69,96,0.3)';
+    color  = 'var(--pe-danger)';
+    text   = '✗ Fehler';
+  } else {
+    // has_walkon but no known status yet (e.g. fresh row, no job recorded) — muted fallback
+    bg     = 'transparent';
+    border = 'transparent';
+    color  = 'var(--pe-text-muted)';
+    text   = '♪';
+  }
+
+  if (!text) return null;
+
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: '4px',
+      background: bg, border: `1px solid ${border}`,
+      borderRadius: '6px', padding: '2px 7px',
+      fontSize: '11px', color,
+      fontFamily: 'Verdana, Geneva, sans-serif',
+      maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    }}>
+      {text}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Update `loadPlayers` to use server-returned walkon_status directly**
+
+Find `loadPlayers` (around line 402). Currently it makes per-player `/walkon/:id/status` calls. Replace it with a simpler version that uses the server-side data:
+
+```jsx
+const loadPlayers = async () => {
+  const updated = await api.get(`/tournaments/${selectedTournament}/players`);
+  setPlayers(updated);
+  // Seed walkonStatuses from server-side walkon_status field (no per-player API calls needed)
+  const statuses = {};
+  for (const p of updated) {
+    if (p.has_walkon || p.walkon_youtube) {
+      statuses[p.id] = p.walkon_status || null;
+    }
+  }
+  setWalkonStatuses(statuses);
+};
+```
+
+- [ ] **Step 3: Update the desktop player card walk-on display**
+
+Find the block in the desktop grid (around lines 583–604) that computes `walkonText`/`walkonColor`:
+
+```jsx
+const hasWalkon = p.walkon_url || p.walkon_youtube;
+const walkonStatus = walkonStatuses[p.id];
+let walkonText = '♪ —';
+let walkonColor = 'var(--pe-text-muted)';
+if (hasWalkon) { ... }
+```
+
+Replace the entire block and the `<div style={{ fontSize: '10px', color: walkonColor ... }}>{walkonText}</div>` line with:
+
+```jsx
+const effectiveWalkonStatus = walkonStatuses[p.id] ?? p.walkon_status;
+```
+
+And replace the sub-line element:
+```jsx
+<div style={{ fontSize: '10px', color: walkonColor, marginTop: '2px' }}>{walkonText}</div>
+```
+with:
+```jsx
+{(p.has_walkon || p.walkon_youtube) && (
+  <WalkonBadge
+    status={effectiveWalkonStatus}
+    title={p.walkon_title}
+    artist={p.walkon_artist}
+  />
+)}
+```
+
+- [ ] **Step 4: Update the mobile player card walk-on display**
+
+Find around line 668:
+```jsx
+{(p.walkon_url || p.walkon_youtube) && (
+  <WalkonBadge status={walkonStatuses[p.id]} />
+)}
+```
+
+Replace with:
+```jsx
+{(p.has_walkon || p.walkon_youtube) && (
+  <WalkonBadge
+    status={walkonStatuses[p.id] ?? p.walkon_status}
+    title={p.walkon_title}
+    artist={p.walkon_artist}
+  />
+)}
+```
+
+- [ ] **Step 5: Verify no build errors**
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend
+npm run build 2>&1 | tail -5
+```
+
+Expected: `built in Xs` with no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/AdminPage.jsx
+git commit -m "feat: walk-on badge shows artist and title in player cards"
+```
+
+---
+
+### Task 8: Player Search Flow — Replace Add-Player Form
+
+**Files:**
+- Modify: `frontend/src/pages/AdminPage.jsx`
+  - `PlayersTab` component state and JSX (lines 321–700)
+
+This task replaces the `showForm` state + `handleCreate` form with a 2-mode search-first flow.
+
+- [ ] **Step 1: Replace state declarations for the add-player flow**
+
+In `PlayersTab`, find:
+```jsx
+const [showForm, setShowForm] = useState(false);
+```
+
+Replace with:
+```jsx
+const [addMode, setAddMode] = useState(null); // null | 'search' | 'new'
+const [searchQuery, setSearchQuery] = useState('');
+const [searchResults, setSearchResults] = useState([]);
+const [searchLoading, setSearchLoading] = useState(false);
+const [confirmPlayer, setConfirmPlayer] = useState(null); // player object to confirm
+const [confirmSeed, setConfirmSeed] = useState('');
+```
+
+- [ ] **Step 2: Add debounced search effect**
+
+After the `loadPlayers` function definition, add:
+
+```jsx
+useEffect(() => {
+  if (!searchQuery || searchQuery.trim().length < 2) {
+    setSearchResults([]);
+    setConfirmPlayer(null);
+    return;
+  }
+  const timer = setTimeout(async () => {
+    setSearchLoading(true);
+    try {
+      const results = await api.get(
+        `/players/search?q=${encodeURIComponent(searchQuery.trim())}&tournament_id=${selectedTournament}`
+      );
+      setSearchResults(results);
+    } catch {
+      setSearchResults([]);
+    } finally {
+      setSearchLoading(false);
+    }
+  }, 300);
+  return () => clearTimeout(timer);
+}, [searchQuery, selectedTournament]);
+```
+
+- [ ] **Step 3: Add `handleRegisterExisting` handler**
+
+After the debounced search effect, add:
+
+```jsx
+const handleRegisterExisting = async () => {
+  if (!confirmPlayer || !selectedTournament) return;
+  try {
+    await api.post(`/tournaments/${selectedTournament}/players`, {
+      player_id: confirmPlayer.id,
+      seed: confirmSeed ? parseInt(confirmSeed, 10) : undefined,
+    });
+    setAddMode(null);
+    setSearchQuery('');
+    setSearchResults([]);
+    setConfirmPlayer(null);
+    setConfirmSeed('');
+    await loadPlayers();
+    addToast({ type: 'success', message: `${confirmPlayer.name} angemeldet` });
+  } catch (err) {
+    addToast({ type: 'error', message: err.message || 'Anmeldung fehlgeschlagen' });
+  }
+};
+```
+
+- [ ] **Step 4: Update `handleCreate` to reset addMode instead of showForm**
+
+Find in `handleCreate`:
+```jsx
+setShowForm(false);
+```
+Replace with:
+```jsx
+setAddMode(null);
+setSearchQuery('');
+setSearchResults([]);
+```
+
+Also update the form reset:
+```jsx
+setForm({ vorname: '', nickname: '', nachname: '', walk_on_song: '', walkon_start: 0, walkon_duration: 30 });
+```
+(keep as-is, just make sure it also clears after new player creation)
+
+- [ ] **Step 5: Update the header button — "+ Neu" triggers search mode**
+
+Find the header button:
+```jsx
+<button onClick={() => setShowForm(!showForm)} ...>
+  {showForm ? 'Abbrechen' : '+ Neu'}
+</button>
+```
+
+Replace with:
+```jsx
+<button
+  onClick={() => { setAddMode(addMode ? null : 'search'); setSearchQuery(''); setSearchResults([]); setConfirmPlayer(null); }}
+  className="px-4 py-2 rounded-lg text-sm font-bold"
+  style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'Verdana, Geneva, sans-serif' }}
+>
+  {addMode ? 'Abbrechen' : '+ Spieler'}
+</button>
+```
+
+- [ ] **Step 6: Replace the old form JSX with the new search UI**
+
+Find the `{showForm && !isActive && (<form onSubmit={handleCreate} ...>` block (lines 503–538) and replace the entire block with:
+
+```jsx
+{addMode && !isActive && (
+  <div className="p-4 rounded-xl mb-6" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
+
+    {/* Mode: search */}
+    {addMode === 'search' && !confirmPlayer && (
+      <>
+        <input
+          type="text"
+          autoFocus
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Name oder Nickname suchen…"
+          className="w-full p-3 rounded-lg outline-none mb-3"
+          style={inputStyle}
+        />
+        {searchLoading && (
+          <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)', textAlign: 'center', padding: '8px' }}>Suche…</p>
+        )}
+        {!searchLoading && searchQuery.trim().length >= 2 && searchResults.length === 0 && (
+          <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)', textAlign: 'center', padding: '8px' }}>
+            Keine Spieler gefunden.
+          </p>
+        )}
+        {searchResults.map((p) => (
+          <div
+            key={p.id}
+            onClick={() => { setConfirmPlayer(p); setConfirmSeed(''); }}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '10px',
+              background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)',
+              borderRadius: '8px', padding: '10px 12px', marginBottom: '6px', cursor: 'pointer',
+            }}
+            className="pe-card-interactive"
+          >
+            <div style={{
+              width: '36px', height: '36px', borderRadius: '8px', flexShrink: 0,
+              background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: '11px', fontWeight: 'bold', color: 'var(--pe-cyan-bright)',
+            }}>
+              {((p.vorname?.[0] || '') + (p.nachname?.[0] || '')).toUpperCase() || '?'}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: '13px', fontWeight: 'bold', color: 'var(--pe-text)' }}>{p.name}</div>
+              <div style={{ fontSize: '11px', color: 'var(--pe-text-muted)', marginTop: '2px' }}>
+                {p.tournaments_count} Turnier{p.tournaments_count !== 1 ? 'e' : ''} · {p.wins}S / {p.losses}N
+                {p.has_walkon ? <span style={{ marginLeft: '6px', color: 'var(--pe-success)' }}>♪</span> : null}
+              </div>
+            </div>
+          </div>
+        ))}
+        <button
+          onClick={() => setAddMode('new')}
+          style={{
+            width: '100%', marginTop: '6px', padding: '10px',
+            border: '1px dashed var(--pe-border)', borderRadius: '8px',
+            background: 'none', color: 'var(--pe-cyan-bright)',
+            fontSize: '12px', cursor: 'pointer', fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          + Neuen Spieler anlegen{searchQuery.trim() ? ` "${searchQuery.trim()}"` : ''}
+        </button>
+      </>
+    )}
+
+    {/* Confirm panel after selecting a player */}
+    {addMode === 'search' && confirmPlayer && (
+      <div>
+        <button
+          onClick={() => setConfirmPlayer(null)}
+          style={{ fontSize: '11px', color: 'var(--pe-text-muted)', background: 'none', border: 'none', cursor: 'pointer', marginBottom: '12px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+        >
+          ← Zurück zur Suche
+        </button>
+        <div style={{ background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-cyan-bright)', borderRadius: '10px', padding: '14px', marginBottom: '12px' }}>
+          <div style={{ fontSize: '10px', color: 'var(--pe-cyan-bright)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '6px' }}>Gefundener Spieler</div>
+          <div style={{ fontSize: '15px', fontWeight: 'bold', color: 'var(--pe-text)', marginBottom: '4px' }}>{confirmPlayer.name}</div>
+          <div style={{ fontSize: '11px', color: 'var(--pe-text-sub)', marginBottom: '8px' }}>
+            {confirmPlayer.tournaments_count} Turnier{confirmPlayer.tournaments_count !== 1 ? 'e' : ''} · {confirmPlayer.wins} Siege / {confirmPlayer.losses} Niederlagen
+          </div>
+          {confirmPlayer.has_walkon && (
+            <WalkonBadge
+              status={confirmPlayer.walkon_status}
+              title={confirmPlayer.walkon_title}
+              artist={confirmPlayer.walkon_artist}
+            />
+          )}
+        </div>
+        <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Setzung (optional)</label>
+        <input
+          type="number"
+          min="1"
+          value={confirmSeed}
+          onChange={(e) => setConfirmSeed(e.target.value)}
+          placeholder="z.B. 1"
+          className="w-full p-3 rounded-lg outline-none mb-3"
+          style={inputStyle}
+        />
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            onClick={handleRegisterExisting}
+            className="flex-1 py-3 rounded-lg font-bold"
+            style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+          >
+            Anmelden
+          </button>
+          <button
+            onClick={() => setConfirmPlayer(null)}
+            className="px-4 py-3 rounded-lg"
+            style={{ background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif' }}
+          >
+            Abbrechen
+          </button>
+        </div>
+      </div>
+    )}
+
+    {/* Mode: new player form */}
+    {addMode === 'new' && (
+      <form onSubmit={handleCreate} className="space-y-3">
+        <button
+          type="button"
+          onClick={() => setAddMode('search')}
+          style={{ fontSize: '11px', color: 'var(--pe-text-muted)', background: 'none', border: 'none', cursor: 'pointer', marginBottom: '4px', fontFamily: 'Verdana, Geneva, sans-serif' }}
+        >
+          ← Zurück zur Suche
+        </button>
+        <input type="text" value={form.vorname} onChange={(e) => setForm({ ...form, vorname: e.target.value })} placeholder="Vorname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+        <input
+          type="text"
+          value={form.nickname}
+          onChange={(e) => setForm({ ...form, nickname: e.target.value })}
+          placeholder="Nickname *"
+          required
+          className="w-full p-3 rounded-lg outline-none"
+          style={inputStyle}
+        />
+        <input type="text" value={form.nachname} onChange={(e) => setForm({ ...form, nachname: e.target.value })} placeholder="Nachname *" required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+        <input type="url" value={form.walk_on_song} onChange={(e) => setForm({ ...form, walk_on_song: e.target.value })} placeholder="Walk-On Song URL (optional)" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+        {form.walk_on_song && (
+          <div className="flex gap-2">
+            <div style={{ flex: 1 }}>
+              <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Startzeit (Sek.)</label>
+              <input type="number" min="0" value={form.walkon_start} onChange={(e) => setForm({ ...form, walkon_start: e.target.value })} required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <label style={{ fontSize: '11px', color: 'var(--pe-text-muted)', display: 'block', marginBottom: '4px' }}>Länge (Sek.)</label>
+              <input type="number" min="5" max="120" value={form.walkon_duration} onChange={(e) => setForm({ ...form, walkon_duration: e.target.value })} required className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
+            </div>
+          </div>
+        )}
+        {form.vorname && form.nickname && form.nachname && (
+          <p style={{ fontSize: '12px', color: 'var(--pe-text-muted)' }}>
+            Angezeigt als: <strong style={{ color: 'var(--pe-text)' }}>{form.vorname.trim()} &ldquo;{form.nickname.trim()}&rdquo; {form.nachname.trim()}</strong>
+          </p>
+        )}
+        <button type="submit" disabled={!form.vorname.trim() || !form.nickname.trim() || !form.nachname.trim()} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+          Spieler anlegen & anmelden
+        </button>
+      </form>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 7: Pre-fill nickname in "new" mode when coming from search**
+
+In the `handleCreate` — no change needed since the form is initialized empty. But when "+ Neuen Spieler anlegen" button is clicked, pre-fill the nickname from `searchQuery`. Update the button's `onClick`:
+
+```jsx
+onClick={() => {
+  setForm({ vorname: '', nickname: searchQuery.trim(), nachname: '', walk_on_song: '', walkon_start: 0, walkon_duration: 30 });
+  setAddMode('new');
+}}
+```
+
+- [ ] **Step 8: Apply all state-change steps atomically, then build**
+
+> **Important:** Steps 1, 4, and 5 of this task all touch `showForm`/`setShowForm`. The JSX references in the button (Step 5) and form guard (Step 6 replaces the old `{showForm && ...}` block) must all be replaced before running a build — a partial application leaves dangling `showForm` references that will cause a runtime warning. Complete all steps in order before running the build check below.
+
+```bash
+cd /home/moritzwolf/dartsturnier/frontend
+npm run build 2>&1 | tail -10
+```
+
+Expected: clean build, no errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/pages/AdminPage.jsx
+git commit -m "feat: replace add-player form with search-first flow (existing player lookup)"
+```
+
+---
+
+### Task 9: Create PR and Cleanup
+
+- [ ] **Step 1: Create feature branch from dev and push**
+
+```bash
+git checkout dev && git pull origin dev
+git checkout -b feat/persistent-player-lookup-walkon-metadata
+git cherry-pick <all commits from tasks 1-8>
+git push origin feat/persistent-player-lookup-walkon-metadata
+```
+
+Actually — if work was done directly on `dev`, create the branch properly:
+```bash
+# If working on a feature branch already:
+git push origin feat/persistent-player-lookup-walkon-metadata
+gh pr create --base dev --head feat/persistent-player-lookup-walkon-metadata \
+  --title "feat: persistent player lookup and walk-on metadata" \
+  --body "$(cat <<'EOF'
+## Summary
+- Admin can search existing player profiles when adding to a tournament (search-first flow)
+- Walk-on artist/title automatically extracted from YouTube via yt-dlp after download
+- Player cards show artist/title as badge instead of plain text status
+- New `GET /api/players/search` endpoint (own route file, avoids double-mount issue)
+- `POST /api/tournaments/:id/players` accepts optional `player_id` for direct registration
+- `walkon_title`, `walkon_artist` columns added to players table
+
+## Test plan
+- [ ] Search for an existing player by name/nickname → results appear
+- [ ] Select player → confirm panel shows stats + walk-on badge
+- [ ] Register existing player → appears in player list
+- [ ] "+ Neuen Spieler anlegen" → form opens with nickname pre-filled
+- [ ] New player creation still works as before
+- [ ] Walk-on badge shows artist/title after download completes
+- [ ] Deleting a walk-on clears title/artist from DB
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+**Plan complete.** 9 tasks, ~25 steps total. All backend tasks (1–6) are independent and can run in sequence. Frontend tasks (7–8) depend on backend being done first (new fields in responses).

--- a/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
+++ b/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
@@ -1,0 +1,183 @@
+# Design: Persistente Spieler — Turnier-Lookup & Walk-On Metadaten
+
+**Date:** 2026-03-16
+**Status:** Approved
+**Scope:** Backend + Frontend
+
+---
+
+## Problem
+
+Spielerprofile sind bereits persistent (eigene `players` Tabelle, losgelöst von Turnieren). Dennoch gibt es beim Hinzufügen eines Spielers zu einem Turnier nur ein leeres Formular — bestehende Spieler können nicht gesucht oder wiederverwendet werden.
+
+Zusätzlich fehlen zwei UX-Verbesserungen in der Spielerliste:
+1. Walk-On Metadaten (Interpret, Titel) werden von yt-dlp nicht extrahiert und nicht angezeigt.
+2. Die Walk-On Anzeige in der Spieler-Karte ist zu klein und informationsarm.
+
+---
+
+## Ziele
+
+1. Admin kann beim Turnier-Spieler-Management bestehende Spielerprofile suchen und direkt anmelden.
+2. Beim Walk-On Download werden Interpret und Titel automatisch per yt-dlp extrahiert und gespeichert.
+3. Die Spieler-Karte zeigt Walk-On als lesbaren Badge mit Interpret und Titel.
+
+---
+
+## Nicht im Scope
+
+- Spielerprofil-Detailseite / History (eigenes Feature #76)
+- Walk-On Audio Player im Admin (bereits vorhanden)
+- Öffentliche Spielersuche / Public API
+
+---
+
+## Architektur
+
+### Datenbank
+
+Zwei neue Spalten in `players`:
+
+```sql
+ALTER TABLE players ADD COLUMN walkon_title  TEXT;
+ALTER TABLE players ADD COLUMN walkon_artist TEXT;
+```
+
+Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pattern (SQLite: try/catch auf ALTER).
+
+---
+
+### Backend
+
+#### 1. `GET /api/players/search?q=<term>&tournament_id=<id>`
+
+- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE, case-insensitive)
+- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus
+- Gibt max. 10 Treffer zurück
+- Response pro Spieler:
+  ```json
+  {
+    "id": 1,
+    "name": "Martin \"Ace\" Hofmann",
+    "vorname": "Martin",
+    "nickname": "Ace",
+    "nachname": "Hofmann",
+    "walkon_title": "Seven Nation Army",
+    "walkon_artist": "The White Stripes",
+    "walkon_file": "/path/or/null",
+    "tournaments_count": 3,
+    "wins": 12,
+    "losses": 4
+  }
+  ```
+- Kein Auth erforderlich (öffentliche Spielerdaten)
+
+#### 2. `POST /api/tournaments/:id/players` — Erweiterung
+
+Neuer optionaler Body-Parameter: `player_id` (Integer).
+
+- Wenn `player_id` gesetzt: Spieler muss existieren → direkt `tournament_registrations` Eintrag anlegen, kein neues Profil erstellen
+- Wenn `player_id` nicht gesetzt: bisheriges Verhalten (Profil per Nickname suchen oder neu anlegen)
+- Duplikat-Check bleibt: gleicher Spieler darf nicht zweimal im selben Turnier angemeldet sein
+
+#### 3. Walk-On Route — Metadaten-Extraktion
+
+Nach erfolgreichem yt-dlp Audio-Download:
+
+```bash
+yt-dlp --no-playlist --print title --print uploader <url>
+```
+
+Gibt zwei Zeilen aus: Zeile 1 = Titel, Zeile 2 = Uploader/Artist.
+
+```js
+db.prepare('UPDATE players SET walkon_title = ?, walkon_artist = ? WHERE id = ?')
+  .run(title, artist, playerId);
+```
+
+Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `ready`, Felder bleiben `NULL`.
+
+#### 4. Player-Responses erweitern
+
+`walkon_title` und `walkon_artist` in allen bestehenden Player-Responses ergänzen:
+- `GET /api/players`
+- `GET /api/tournaments/:id/players`
+- `GET /api/walkon/:playerId/status`
+
+---
+
+### Frontend
+
+#### Spieler-Karte (Badge-Stil)
+
+Wenn Walk-On vorhanden (`walkon_youtube` gesetzt) und Status bekannt:
+
+| Status | Badge |
+|--------|-------|
+| `ready` | `♪ Artist — Titel` (grüner Badge) |
+| `pending` / `downloading` | `⏳ lädt…` (gelber Badge) |
+| `error` | `✗ Fehler` (roter Badge) |
+| kein Walk-On | kein Badge |
+
+Badge-Stil:
+```css
+background: rgba(0,229,160,0.1);
+border: 1px solid rgba(0,229,160,0.3);
+border-radius: 6px;
+padding: 2px 7px;
+font-size: 11px;
+color: var(--pe-success);
+```
+
+Wenn `walkon_title` / `walkon_artist` vorhanden: `♪ {artist} — {title}` anzeigen.
+Wenn nicht vorhanden aber ready: `♪ bereit` anzeigen.
+
+#### Spieler hinzufügen — Suchflow
+
+Das bestehende Formular (Vorname / Nickname / Nachname) wird durch einen 2-Modus-Flow ersetzt:
+
+**Modus 1: Suche (Standard)**
+
+1. Suchfeld (Debounce 300ms) → `GET /api/players/search?q=...&tournament_id=...`
+2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge
+3. Klick auf Spieler → Confirm-Panel erscheint:
+   - Spielerinfo (Name, Stats, Walk-On)
+   - Optionales Setzungs-Feld
+   - "Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
+4. Unten: "+ Neuen Spieler anlegen" → wechselt zu Modus 2
+
+**Modus 2: Neuer Spieler**
+
+- Bisheriges Formular (Vorname / Nickname / Nachname / Walk-On URL / Start / Dauer)
+- "Zurück zur Suche" Link oben
+- Nickname wird aus dem Suchbegriff vorausgefüllt wenn vorhanden
+
+---
+
+## Fehlerbehandlung
+
+- Suchfeld leer oder < 2 Zeichen: keine API-Anfrage, keine Ergebnisliste
+- Keine Treffer: leerer Zustand mit "+ Neuen Spieler anlegen" CTA
+- `player_id` nicht gefunden: Backend gibt `404` zurück
+- Spieler bereits im Turnier: Backend gibt `409` zurück mit erklärender Meldung
+- yt-dlp Metadaten-Fehler: stilles Fallback, kein Einfluss auf Download-Status
+
+---
+
+## Implementierungsreihenfolge
+
+1. DB-Migration (walkon_title, walkon_artist)
+2. Backend: Search-Endpunkt
+3. Backend: POST players mit player_id
+4. Backend: Walk-On Metadaten-Extraktion
+5. Backend: Player-Responses erweitern
+6. Frontend: Spieler-Karte Badge
+7. Frontend: Suchflow
+
+---
+
+## Nicht geändert
+
+- Walk-On ist und bleibt am `players`-Profil gebunden (nicht an `tournament_registrations`)
+- `cancel_token` Mechanismus bleibt unverändert
+- Spielerprofil-Daten (Name, Nickname) bleiben editierbar im bestehenden Edit-Dialog

--- a/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
+++ b/docs/superpowers/specs/2026-03-16-persistent-players-walkon-metadata-design.md
@@ -43,7 +43,7 @@ ALTER TABLE players ADD COLUMN walkon_title  TEXT;
 ALTER TABLE players ADD COLUMN walkon_artist TEXT;
 ```
 
-Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pattern (SQLite: try/catch auf ALTER).
+Migration in `db.js` via try/catch auf ALTER TABLE (identisches Pattern zu bestehenden `vorname`/`nickname`/`nachname` Migrationen).
 
 ---
 
@@ -51,58 +51,171 @@ Migration läuft beim Server-Start in `db.js` via `ALTER TABLE IF NOT EXISTS`-Pa
 
 #### 1. `GET /api/players/search?q=<term>&tournament_id=<id>`
 
-- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE, case-insensitive)
-- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus
+**Routing — wichtig:** `players.js` ist in `app.js` an **zwei** Pfaden gemountet: `/api/tournaments` und `/api/players`. Eine neue Route in `players.js` würde also auch unter `/api/tournaments/search` erreichbar sein. Um diese Kollision zu vermeiden, wird der Search-Endpoint in einer **eigenen Datei** `backend/src/routes/playerSearch.js` implementiert und in `app.js` ausschließlich unter `/api/players/search` gemountet:
+
+```js
+// app.js
+const playerSearchRoutes = require('./routes/playerSearch');
+app.use('/api/players/search', playerSearchRoutes);
+```
+
+- Kein Auth erforderlich (konsistent mit bestehendem `GET /api/players`; beide Endpunkte sind interne Admin-Tools ohne Zugriff von außen via CORS)
+- Nur ausgeführt wenn `q` mindestens 2 Zeichen lang ist, sonst `400`
+- Sucht in `name`, `nickname`, `vorname`, `nachname` (LIKE `%q%`, case-insensitive via `LOWER()`)
+- Optionaler Parameter `tournament_id`: filtert Spieler die bereits in diesem Turnier angemeldet sind heraus (Subquery auf `tournament_registrations`)
 - Gibt max. 10 Treffer zurück
-- Response pro Spieler:
-  ```json
-  {
-    "id": 1,
-    "name": "Martin \"Ace\" Hofmann",
-    "vorname": "Martin",
-    "nickname": "Ace",
-    "nachname": "Hofmann",
-    "walkon_title": "Seven Nation Army",
-    "walkon_artist": "The White Stripes",
-    "walkon_file": "/path/or/null",
-    "tournaments_count": 3,
-    "wins": 12,
-    "losses": 4
-  }
-  ```
-- Kein Auth erforderlich (öffentliche Spielerdaten)
+
+SQL-Grundstruktur:
+```sql
+SELECT
+  p.id, p.name, p.vorname, p.nickname, p.nachname,
+  p.walkon_title, p.walkon_artist,
+  (p.walkon_file IS NOT NULL) AS has_walkon,
+  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+  COUNT(DISTINCT tr.tournament_id) AS tournaments_count,
+  COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) AS wins,
+  COUNT(CASE WHEN g.status = 'finished'
+        AND (g.player1_id = p.id OR g.player2_id = p.id)
+        AND g.winner_id != p.id THEN 1 END) AS losses
+FROM players p
+LEFT JOIN tournament_registrations tr ON tr.player_id = p.id
+LEFT JOIN games g ON (g.player1_id = p.id OR g.player2_id = p.id) AND g.status = 'finished'
+WHERE (
+  LOWER(p.name) LIKE LOWER(?)
+  OR LOWER(p.nickname) LIKE LOWER(?)
+  OR LOWER(p.vorname) LIKE LOWER(?)
+  OR LOWER(p.nachname) LIKE LOWER(?)
+)
+AND (? IS NULL OR p.id NOT IN (
+  SELECT player_id FROM tournament_registrations WHERE tournament_id = ?
+))
+GROUP BY p.id
+ORDER BY p.name ASC
+LIMIT 10
+```
+
+Die correlated Subquery für `walkon_status` steht im SELECT-List (nicht im WHERE/JOIN) — kein Einfluss auf GROUP BY.
+
+Response pro Spieler:
+```json
+{
+  "id": 1,
+  "name": "Martin \"Ace\" Hofmann",
+  "vorname": "Martin",
+  "nickname": "Ace",
+  "nachname": "Hofmann",
+  "walkon_title": "Seven Nation Army",
+  "walkon_artist": "The White Stripes",
+  "has_walkon": true,
+  "walkon_status": "ready",
+  "tournaments_count": 3,
+  "wins": 12,
+  "losses": 4
+}
+```
 
 #### 2. `POST /api/tournaments/:id/players` — Erweiterung
 
 Neuer optionaler Body-Parameter: `player_id` (Integer).
 
-- Wenn `player_id` gesetzt: Spieler muss existieren → direkt `tournament_registrations` Eintrag anlegen, kein neues Profil erstellen
-- Wenn `player_id` nicht gesetzt: bisheriges Verhalten (Profil per Nickname suchen oder neu anlegen)
-- Duplikat-Check bleibt: gleicher Spieler darf nicht zweimal im selben Turnier angemeldet sein
+**Wenn `player_id` gesetzt:**
+- Bestehende `requireFields(['vorname', 'nickname', 'nachname'])` Middleware wird durch **inline konditionelle Validierung** ersetzt (Middleware komplett entfernen, Validierung in den Route-Handler verlagern):
+  ```js
+  if (req.body.player_id) {
+    const pid = parseInt(req.body.player_id, 10);
+    if (!pid || pid <= 0) return res.status(400).json({ error: 'Ungültige player_id' });
+  } else {
+    if (!req.body.vorname || !req.body.nickname || !req.body.nachname) {
+      return res.status(400).json({ error: 'vorname, nickname und nachname sind Pflichtfelder' });
+    }
+  }
+  ```
+- Tournament-Status-Prüfung (`status !== 'open'` → 400) gilt **auch** für den `player_id`-Pfad
+- Spieler muss in `players` existieren → 404 wenn nicht gefunden
+- Expliziter Duplikat-Check: `SELECT id FROM tournament_registrations WHERE player_id = ? AND tournament_id = ?` → 409 mit Meldung `"Spieler ist bereits in diesem Turnier angemeldet"`
+- Direkt `tournament_registrations` Eintrag anlegen ohne Profil anzulegen
+- `walkon_youtube` aus dem Body wird bei `player_id`-Pfad ignoriert
+- `seed`: optionaler Integer (kein Eindeutigkeits-Check — konsistent mit bestehendem Verhalten)
+
+**Wenn `player_id` nicht gesetzt:**
+- Bisheriges Verhalten vollständig erhalten (Profil per Nickname suchen oder neu anlegen, `walkon_youtube` aus Body verarbeiten)
 
 #### 3. Walk-On Route — Metadaten-Extraktion
 
-Nach erfolgreichem yt-dlp Audio-Download:
+Metadaten-Extraktion läuft **vor** dem finalen `status = 'ready'` Update.
 
-```bash
-yt-dlp --no-playlist --print title --print uploader <url>
+Reihenfolge in `downloadWalkon()`:
+
+```
+1. yt-dlp download → tempPath
+2. ffmpeg trim → finalPath
+3. tempPath löschen
+4. walkon_file in players aktualisieren
+5. [NEU] yt-dlp --print metadata → walkon_artist/walkon_title extrahieren (try/catch, jobId-Check)
+6. [NEU] walkon_title + walkon_artist in players aktualisieren
+7. Job status → 'ready'
 ```
 
-Gibt zwei Zeilen aus: Zeile 1 = Titel, Zeile 2 = Uploader/Artist.
+Metadaten-Extraktion (Schritt 5):
 
 ```js
-db.prepare('UPDATE players SET walkon_title = ?, walkon_artist = ? WHERE id = ?')
-  .run(title, artist, playerId);
+try {
+  // Prüfen ob dieser Job noch der aktuelle ist (Race-Condition-Schutz)
+  const currentJob = db.prepare('SELECT id FROM walkon_jobs WHERE player_id = ? ORDER BY id DESC LIMIT 1').get(playerId);
+  if (currentJob && currentJob.id === jobId) {
+    const meta = await new Promise((resolve) => {
+      const dlp = spawn('yt-dlp', [
+        '--no-playlist',
+        '--print', '%(artist,uploader)s',
+        '--print', 'title',
+        url
+      ]);
+      let out = '';
+      dlp.stdout.on('data', (d) => { out += d.toString(); });
+      dlp.on('close', () => resolve(out));
+      dlp.on('error', () => resolve(''));
+    });
+    const lines = meta.trim().split(/\r?\n/).map(l => l.trim());
+    const artist = (lines[0] && lines[0] !== 'NA') ? lines[0] : null;
+    const title  = (lines[1] && lines[1] !== 'NA') ? lines[1] : null;
+    db.prepare('UPDATE players SET walkon_artist = ?, walkon_title = ? WHERE id = ?').run(artist, title, playerId);
+  }
+} catch (_) { /* stilles Fallback */ }
 ```
 
-Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `ready`, Felder bleiben `NULL`.
+**DELETE `/api/walkon/:playerId`:** Bestehender Handler muss `walkon_title` und `walkon_artist` ebenfalls auf NULL zurücksetzen:
+```sql
+UPDATE players SET walkon_file = NULL, walkon_youtube = NULL,
+  walkon_start = NULL, walkon_duration = NULL,
+  walkon_title = NULL, walkon_artist = NULL
+WHERE id = ?
+```
+
+Wenn `has_walkon = false` (nach DELETE), ist `walkon_status` aus der Subquery NULL — kein Badge wird angezeigt. Der Fall "kein Badge" greift sobald `has_walkon` falsy ist, unabhängig von `walkon_status`.
 
 #### 4. Player-Responses erweitern
 
-`walkon_title` und `walkon_artist` in allen bestehenden Player-Responses ergänzen:
-- `GET /api/players`
-- `GET /api/tournaments/:id/players`
-- `GET /api/walkon/:playerId/status`
+`walkon_title`, `walkon_artist`, `has_walkon` und `walkon_status` in folgenden Responses ergänzen:
+
+- **`GET /api/players`** — `walkon_title`, `walkon_artist`, `has_walkon`, `walkon_status` (correlated Subquery im SELECT-List, nicht als JOIN — bestehende GROUP BY-Aggregation bleibt erhalten)
+- **`GET /api/tournaments/:id/players`** — `walkon_title`, `walkon_artist`, `walkon_status`, `has_walkon` via correlated Subquery ergänzen:
+  ```sql
+  (SELECT status FROM walkon_jobs WHERE player_id = p.id ORDER BY id DESC LIMIT 1) AS walkon_status,
+  (p.walkon_file IS NOT NULL) AS has_walkon
+  ```
+- **`GET /api/walkon/:playerId/status`** — Response um `walkon_title`, `walkon_artist` erweitern:
+  ```json
+  {
+    "player_id": 1,
+    "walkon_file": "/abs/path",
+    "walkon_start": 30,
+    "walkon_duration": 20,
+    "walkon_url": "https://...",
+    "walkon_title": "Seven Nation Army",
+    "walkon_artist": "The White Stripes",
+    "job": { "status": "ready", "id": 5 }
+  }
+  ```
 
 ---
 
@@ -110,74 +223,78 @@ Fehler bei der Metadaten-Extraktion sind unkritisch — Download-Status bleibt `
 
 #### Spieler-Karte (Badge-Stil)
 
-Wenn Walk-On vorhanden (`walkon_youtube` gesetzt) und Status bekannt:
+Badge liest `walkon_status` direkt aus dem Player-Objekt (kein separater Polling-Call beim initialen Laden). Polling für laufende Downloads läuft weiterhin via `GET /api/walkon/:playerId/status`.
 
-| Status | Badge |
-|--------|-------|
-| `ready` | `♪ Artist — Titel` (grüner Badge) |
+| Bedingung | Badge |
+|-----------|-------|
+| `has_walkon` + `ready` + Metadaten vorhanden | `♪ {artist} — {title}` (grüner Badge) |
+| `has_walkon` + `ready` + keine Metadaten | `♪ bereit` (grüner Badge) |
 | `pending` / `downloading` | `⏳ lädt…` (gelber Badge) |
 | `error` | `✗ Fehler` (roter Badge) |
-| kein Walk-On | kein Badge |
+| `!has_walkon` | kein Badge |
 
-Badge-Stil:
+Badge-CSS (PE-Tokens):
 ```css
-background: rgba(0,229,160,0.1);
-border: 1px solid rgba(0,229,160,0.3);
-border-radius: 6px;
-padding: 2px 7px;
-font-size: 11px;
-color: var(--pe-success);
+/* ready */  background: rgba(0,229,160,0.1); border: 1px solid rgba(0,229,160,0.3); color: var(--pe-success);
+/* warning */ background: rgba(255,176,32,0.1); border: 1px solid rgba(255,176,32,0.3); color: var(--pe-warning);
+/* error */  background: rgba(255,69,96,0.1);  border: 1px solid rgba(255,69,96,0.3);  color: var(--pe-danger);
+/* shared */ border-radius: 6px; padding: 2px 7px; font-size: 11px; display: inline-flex; align-items: center; gap: 4px;
 ```
-
-Wenn `walkon_title` / `walkon_artist` vorhanden: `♪ {artist} — {title}` anzeigen.
-Wenn nicht vorhanden aber ready: `♪ bereit` anzeigen.
 
 #### Spieler hinzufügen — Suchflow
 
-Das bestehende Formular (Vorname / Nickname / Nachname) wird durch einen 2-Modus-Flow ersetzt:
+Das bestehende Formular wird durch einen 2-Modus-Flow ersetzt:
 
 **Modus 1: Suche (Standard)**
 
-1. Suchfeld (Debounce 300ms) → `GET /api/players/search?q=...&tournament_id=...`
-2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge
-3. Klick auf Spieler → Confirm-Panel erscheint:
-   - Spielerinfo (Name, Stats, Walk-On)
-   - Optionales Setzungs-Feld
-   - "Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
-4. Unten: "+ Neuen Spieler anlegen" → wechselt zu Modus 2
+1. Suchfeld — Debounce 300ms, min. 2 Zeichen → `GET /api/players/search?q=...&tournament_id=...`
+2. Ergebnisliste: Avatar (Initialen), Name, Stats, Walk-On Badge wenn `has_walkon`
+3. 0 Treffer → Leer-Zustand + `+ Neuen Spieler anlegen "{Suchbegriff}"` CTA
+4. Klick auf Spieler → Confirm-Panel:
+   - Name, Stats, Walk-On Badge
+   - Optionales Setzungs-Feld (positive Integer)
+   - „Anmelden" → `POST /api/tournaments/:id/players` mit `{ player_id, seed }`
+   - „Abbrechen" → zurück zur Liste
+5. Unten: `+ Neuen Spieler anlegen` → Modus 2
 
 **Modus 2: Neuer Spieler**
 
 - Bisheriges Formular (Vorname / Nickname / Nachname / Walk-On URL / Start / Dauer)
-- "Zurück zur Suche" Link oben
-- Nickname wird aus dem Suchbegriff vorausgefüllt wenn vorhanden
+- Nickname vorausgefüllt aus Suchbegriff (falls aus Modus 1 gewechselt)
+- `← Zurück zur Suche` Link oben
 
 ---
 
 ## Fehlerbehandlung
 
-- Suchfeld leer oder < 2 Zeichen: keine API-Anfrage, keine Ergebnisliste
-- Keine Treffer: leerer Zustand mit "+ Neuen Spieler anlegen" CTA
-- `player_id` nicht gefunden: Backend gibt `404` zurück
-- Spieler bereits im Turnier: Backend gibt `409` zurück mit erklärender Meldung
-- yt-dlp Metadaten-Fehler: stilles Fallback, kein Einfluss auf Download-Status
+| Szenario | Verhalten |
+|----------|-----------|
+| `q` < 2 Zeichen | Keine API-Anfrage |
+| 0 Suchergebnisse | Leer-Zustand + CTA |
+| `player_id` nicht gefunden | 404 → Toast |
+| Spieler bereits im Turnier | 409 → Toast |
+| Turnier nicht `open` | 400 → Toast |
+| yt-dlp Metadaten-Fehler | Stilles Fallback, Status bleibt `ready` |
+| Zweiter Download während Metadaten-Extraktion | jobId-Check verhindert falschen Metadaten-Write |
 
 ---
 
 ## Implementierungsreihenfolge
 
-1. DB-Migration (walkon_title, walkon_artist)
-2. Backend: Search-Endpunkt
-3. Backend: POST players mit player_id
-4. Backend: Walk-On Metadaten-Extraktion
-5. Backend: Player-Responses erweitern
-6. Frontend: Spieler-Karte Badge
-7. Frontend: Suchflow
+1. DB-Migration (`walkon_title`, `walkon_artist` in `db.js`)
+2. Backend: `playerSearch.js` neu anlegen + in `app.js` mounten
+3. Backend: `POST /api/tournaments/:id/players` um `player_id` erweitern
+4. Backend: Walk-On `DELETE` Handler um neue Felder erweitern
+5. Backend: Walk-On Metadaten-Extraktion in `downloadWalkon()` (inkl. jobId-Check)
+6. Backend: Player-Responses um neue Felder erweitern
+7. Frontend: Walk-On Badge in Spieler-Karte
+8. Frontend: Suchflow (Modus 1 + Modus 2)
 
 ---
 
 ## Nicht geändert
 
-- Walk-On ist und bleibt am `players`-Profil gebunden (nicht an `tournament_registrations`)
-- `cancel_token` Mechanismus bleibt unverändert
-- Spielerprofil-Daten (Name, Nickname) bleiben editierbar im bestehenden Edit-Dialog
+- Walk-On bleibt am `players`-Profil gebunden
+- `cancel_token` Mechanismus unverändert
+- Edit-Dialog für Spielerprofil-Daten unverändert
+- Audio-Streaming via `GET /api/walkon/:playerId/audio` unverändert

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,10 @@ const RefereePage = lazy(() => import('./pages/RefereePage'));
 const GastronomyPage = lazy(() => import('./pages/GastronomyPage'));
 const CancelRegistrationPage = lazy(() => import('./pages/CancelRegistrationPage'));
 const RefereeEntryPage = lazy(() => import('./pages/RefereeEntryPage'));
+const TournamentHistoryPage = lazy(() => import('./pages/TournamentHistoryPage'));
+const TournamentDetailPage = lazy(() => import('./pages/TournamentDetailPage'));
+const PlayerProfilePage = lazy(() => import('./pages/PlayerProfilePage'));
+const AdminReportsPage = lazy(() => import('./pages/AdminReportsPage'));
 
 // NEU: Protected Route mit Rollenprüfung
 function ProtectedRoute({ element, roles }) {
@@ -89,6 +93,10 @@ export default function App() {
             <Route path="/admin" element={<AdminPage />} />
             {/* /admin/users → redirect to /admin?tab=users */}
             <Route path="/admin/users" element={<Navigate to="/admin?tab=users" replace />} />
+            <Route path="/admin/reports" element={<ProtectedRoute element={<AdminReportsPage />} roles={['admin', 'gastronomy']} />} />
+            <Route path="/history" element={<TournamentHistoryPage />} />
+            <Route path="/history/:id" element={<TournamentDetailPage />} />
+            <Route path="/players/:id" element={<PlayerProfilePage />} />
           </Route>
 
           {/* ── Standalone routes: no shell ── */}

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -7,8 +7,14 @@ import TopNav from './TopNav';
 function useSubPage() {
   const registerMatch = useMatch('/tournament/:id/register');
   const tournamentMatch = useMatch('/tournament/:id');
+  const historyDetailMatch = useMatch('/history/:id');
+  const playerProfileMatch = useMatch('/players/:id');
+  const adminReportsMatch = useMatch('/admin/reports');
   if (registerMatch) return { isSubPage: true, title: 'Anmelden' };
   if (tournamentMatch) return { isSubPage: true, title: 'Turnier-Detail' };
+  if (historyDetailMatch) return { isSubPage: true, title: 'Tournament Detail' };
+  if (playerProfileMatch) return { isSubPage: true, title: 'Player Profile' };
+  if (adminReportsMatch) return { isSubPage: true, title: 'Gastro Reports' };
   return { isSubPage: false, title: '' };
 }
 

--- a/frontend/src/components/BottomNav.jsx
+++ b/frontend/src/components/BottomNav.jsx
@@ -4,8 +4,9 @@ import { useStore } from '../store';
 
 const TABS = {
   public: [
-    { icon: '🏠', label: 'Home',       path: '/',       exact: true },
-    { icon: '👤', label: 'Anmelden',   path: '/login',  exact: false },
+    { icon: '🏠', label: 'Home',       path: '/',        exact: true },
+    { icon: '📜', label: 'Archiv',     path: '/history', exact: false },
+    { icon: '👤', label: 'Anmelden',   path: '/login',   exact: false },
   ],
   referee: [
     { icon: '📋', label: 'Boards',     path: '/referee',             exact: false },

--- a/frontend/src/components/TopNav.jsx
+++ b/frontend/src/components/TopNav.jsx
@@ -5,6 +5,7 @@ import { useStore } from '../store';
 const TABS = {
   public: [
     { icon: '🏠', label: 'Home',          path: '/',                        exact: true },
+    { icon: '📜', label: 'Archiv',        path: '/history',                 exact: false },
     { icon: '👤', label: 'Anmelden',      path: '/login',                   exact: false },
   ],
   referee: [
@@ -29,6 +30,8 @@ const TABS = {
     { icon: '📧', label: 'Mailing',       path: '/admin?tab=mailing',       exact: false },
     { icon: '⚙️', label: 'Settings',      path: '/admin?tab=settings',      exact: false },
     { icon: '📋', label: 'System-Log',    path: '/admin?tab=log',           exact: false },
+    { icon: '📈', label: 'Reports',       path: '/admin/reports',           exact: false },
+    { icon: '📜', label: 'Archiv',        path: '/history',                 exact: false },
     { icon: '❓', label: 'Hilfe',          path: '/admin?tab=help',          exact: false },
   ],
   director: [
@@ -37,6 +40,7 @@ const TABS = {
     { icon: '👥', label: 'Spieler',       path: '/admin?tab=players',       exact: false },
     { icon: '🎯', label: 'Boards',        path: '/admin?tab=boards',        exact: false },
     { icon: '📋', label: 'System-Log',    path: '/admin?tab=log',           exact: false },
+    { icon: '📜', label: 'Archiv',        path: '/history',                 exact: false },
   ],
 };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,8 +18,8 @@
   --pe-success: #00E5A0;
   --pe-warning: #FFB020;
   --pe-danger: #FF4560;
-  --pe-font-body: Verdana, Geneva, sans-serif;
-  --pe-font-display: Verdana, Geneva, sans-serif;
+  --pe-font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --pe-font-display: 'Barlow Condensed', 'Inter', sans-serif;
 }
 
 /* Display font utility — used for stats, numbers, headings */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,13 @@
   --pe-success: #00E5A0;
   --pe-warning: #FFB020;
   --pe-danger: #FF4560;
+  --pe-font-body: Verdana, Geneva, sans-serif;
+  --pe-font-display: Verdana, Geneva, sans-serif;
+}
+
+/* Display font utility — used for stats, numbers, headings */
+.pe-font-display {
+  font-family: var(--pe-font-display);
 }
 
 html {

--- a/frontend/src/pages/AdminReportsPage.jsx
+++ b/frontend/src/pages/AdminReportsPage.jsx
@@ -1,0 +1,268 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api/client';
+import BackButton from '../components/BackButton';
+
+export default function AdminReportsPage() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    api.get('/admin/reports/gastro')
+      .then(setData)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p style={{ color: 'var(--pe-text-sub)' }}>Loading reports...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen p-4">
+        <BackButton to="/admin" label="Admin" />
+        <p style={{ color: 'var(--pe-danger)', textAlign: 'center', marginTop: 24 }}>
+          {error}
+        </p>
+      </div>
+    );
+  }
+
+  const { revenue, top_products, orders_per_guest, by_category, settlements } = data || {};
+
+  return (
+    <div className="pe-page-enter" style={{ fontFamily: 'var(--pe-font-body)' }}>
+      <div style={{ maxWidth: 800, margin: '0 auto', padding: '16px 12px 100px' }}>
+        <BackButton to="/admin" label="Admin" />
+
+        <h1
+          className="pe-font-display"
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            background: 'var(--pe-gradient)',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+            margin: '12px 0 20px',
+          }}
+        >
+          Gastro Reports
+        </h1>
+
+        {/* Revenue overview */}
+        {revenue && (
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+            gap: 10,
+            marginBottom: 24,
+          }}>
+            <RevenueCard label="Total Revenue" value={formatCurrency(revenue.total)} color="var(--pe-success)" />
+            <RevenueCard label="Open Orders" value={formatCurrency(revenue.open)} color="var(--pe-warning)" />
+            <RevenueCard label="Settled" value={formatCurrency(revenue.settled)} />
+            <RevenueCard label="Total Orders" value={revenue.order_count ?? 0} />
+          </div>
+        )}
+
+        {/* Category breakdown */}
+        {by_category && by_category.length > 0 && (
+          <Section title="Revenue by Category">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {by_category.map((cat) => (
+                <div
+                  key={cat.category}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: '12px 14px',
+                    borderRadius: 10,
+                    background: 'var(--pe-bg-card)',
+                    border: '1px solid var(--pe-border)',
+                  }}
+                >
+                  <span style={{ fontSize: 14, fontWeight: 'bold', color: 'var(--pe-text)', textTransform: 'capitalize' }}>
+                    {cat.category}
+                  </span>
+                  <span className="pe-font-display" style={{ fontSize: 16, fontWeight: 700, color: 'var(--pe-cyan-bright)' }}>
+                    {formatCurrency(cat.total)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {/* Top products */}
+        {top_products && top_products.length > 0 && (
+          <Section title="Top Products">
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  {['Product', 'Sold', 'Revenue'].map((h) => (
+                    <th
+                      key={h}
+                      style={{
+                        textAlign: h === 'Product' ? 'left' : 'right',
+                        padding: '8px 10px',
+                        fontSize: 11,
+                        color: 'var(--pe-text-muted)',
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.5,
+                        borderBottom: '1px solid var(--pe-border)',
+                      }}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {top_products.map((p, i) => (
+                  <tr key={i} style={{ borderBottom: '1px solid var(--pe-border)' }}>
+                    <td style={{ padding: '10px', fontSize: 14, color: 'var(--pe-text)', fontWeight: 'bold' }}>
+                      {p.name}
+                    </td>
+                    <td className="pe-font-display" style={{ padding: '10px', fontSize: 14, fontWeight: 700, color: 'var(--pe-text)', textAlign: 'right' }}>
+                      {p.quantity_sold}
+                    </td>
+                    <td className="pe-font-display" style={{ padding: '10px', fontSize: 14, fontWeight: 700, color: 'var(--pe-cyan-bright)', textAlign: 'right' }}>
+                      {formatCurrency(p.revenue)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Section>
+        )}
+
+        {/* Orders per guest */}
+        {orders_per_guest && orders_per_guest.length > 0 && (
+          <Section title="Orders per Guest">
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  {['Guest', 'Orders', 'Total'].map((h) => (
+                    <th
+                      key={h}
+                      style={{
+                        textAlign: h === 'Guest' ? 'left' : 'right',
+                        padding: '8px 10px',
+                        fontSize: 11,
+                        color: 'var(--pe-text-muted)',
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.5,
+                        borderBottom: '1px solid var(--pe-border)',
+                      }}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {orders_per_guest.map((g, i) => (
+                  <tr key={i} style={{ borderBottom: '1px solid var(--pe-border)' }}>
+                    <td style={{ padding: '10px', fontSize: 14, color: 'var(--pe-text)', fontWeight: 'bold' }}>
+                      {g.guest_name || 'Guest'}
+                    </td>
+                    <td className="pe-font-display" style={{ padding: '10px', fontSize: 14, fontWeight: 700, color: 'var(--pe-text)', textAlign: 'right' }}>
+                      {g.order_count}
+                    </td>
+                    <td className="pe-font-display" style={{ padding: '10px', fontSize: 14, fontWeight: 700, color: 'var(--pe-cyan-bright)', textAlign: 'right' }}>
+                      {formatCurrency(g.total)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Section>
+        )}
+
+        {/* Settlements */}
+        {settlements && settlements.length > 0 && (
+          <Section title="Recent Settlements">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {settlements.map((s, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: '10px 14px',
+                    borderRadius: 10,
+                    background: 'var(--pe-bg-card)',
+                    border: '1px solid var(--pe-border)',
+                  }}
+                >
+                  <div>
+                    <span style={{ fontSize: 14, fontWeight: 'bold', color: 'var(--pe-text)' }}>
+                      {s.guest_name || 'Guest'}
+                    </span>
+                    <span style={{ fontSize: 12, color: 'var(--pe-text-muted)', marginLeft: 8 }}>
+                      {s.settled_at}
+                    </span>
+                  </div>
+                  <span className="pe-font-display" style={{ fontSize: 15, fontWeight: 700, color: 'var(--pe-success)' }}>
+                    {formatCurrency(s.total)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <h2 style={{ fontSize: 14, fontWeight: 'bold', color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1, margin: '0 0 10px' }}>
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+function RevenueCard({ label, value, color }) {
+  return (
+    <div style={{
+      background: 'var(--pe-bg-card)',
+      borderRadius: 12,
+      border: '1px solid var(--pe-border)',
+      padding: 14,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 4,
+    }}>
+      <span
+        className="pe-font-display"
+        style={{
+          fontSize: 22,
+          fontWeight: 700,
+          color: color || 'var(--pe-text)',
+          letterSpacing: '0.01em',
+        }}
+      >
+        {value}
+      </span>
+      <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function formatCurrency(val) {
+  if (val == null) return '—';
+  return `${parseFloat(val).toFixed(2)} EUR`;
+}

--- a/frontend/src/pages/AdminReportsPage.jsx
+++ b/frontend/src/pages/AdminReportsPage.jsx
@@ -255,7 +255,7 @@ function RevenueCard({ label, value, color }) {
       >
         {value}
       </span>
-      <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+      <span style={{ fontSize: 11, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
         {label}
       </span>
     </div>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -110,7 +110,30 @@ export default function HomePage() {
         {loading ? (
           <p style={{ color: 'var(--pe-text-sub)', textAlign: 'center' }}>Lade Turniere...</p>
         ) : !activeTournament ? (
-          <p style={{ color: 'var(--pe-text-sub)', textAlign: 'center' }}>Keine Turniere vorhanden.</p>
+          <div style={{ textAlign: 'center' }}>
+            <p style={{ color: 'var(--pe-text-sub)', marginBottom: 24 }}>Keine Turniere vorhanden.</p>
+            <Link
+              to="/history"
+              className="pe-card-interactive"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '16px 24px',
+                borderRadius: 12,
+                background: 'var(--pe-bg-card)',
+                border: '1px solid var(--pe-border)',
+                textDecoration: 'none',
+                minHeight: 64,
+                color: 'var(--pe-text)',
+                fontSize: 15,
+                fontWeight: 'bold',
+              }}
+            >
+              <span style={{ fontSize: 22 }}>📜</span>
+              Turnier-Archiv
+            </Link>
+          </div>
         ) : (
           <>
             {/* NEU: Aktuelles Turnier Card */}
@@ -355,6 +378,39 @@ export default function HomePage() {
                   ))}
               </div>
             )}
+
+            {/* NEU: Turnier-Archiv Link */}
+            <div style={{ marginTop: 24 }}>
+              <h3 style={styles.sectionTitle}>Archiv</h3>
+              <Link
+                to="/history"
+                className="pe-card-interactive"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '16px 18px',
+                  borderRadius: 12,
+                  background: 'var(--pe-bg-card)',
+                  border: '1px solid var(--pe-border)',
+                  textDecoration: 'none',
+                  minHeight: 64,
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <span style={{ fontSize: 22 }}>📜</span>
+                  <div>
+                    <span style={{ fontSize: 15, fontWeight: 'bold', color: 'var(--pe-text)', display: 'block' }}>
+                      Turnier-Archiv
+                    </span>
+                    <span style={{ fontSize: 12, color: 'var(--pe-text-sub)' }}>
+                      Vergangene Turniere &amp; Statistiken
+                    </span>
+                  </div>
+                </div>
+                <span style={{ fontSize: 18, color: 'var(--pe-text-muted)' }}>›</span>
+              </Link>
+            </div>
           </>
         )}
       </div>

--- a/frontend/src/pages/PlayerProfilePage.jsx
+++ b/frontend/src/pages/PlayerProfilePage.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api } from '../api/client';
+import BackButton from '../components/BackButton';
+
+export default function PlayerProfilePage() {
+  const { id } = useParams();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    api.get(`/players/${id}/stats`)
+      .then(setData)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p style={{ color: 'var(--pe-text-sub)' }}>Loading player profile...</p>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen p-4">
+        <BackButton to="/" label="Back" />
+        <p style={{ color: 'var(--pe-danger)', textAlign: 'center', marginTop: 24 }}>
+          {error || 'Player not found.'}
+        </p>
+      </div>
+    );
+  }
+
+  const { player, career, tournament_history } = data;
+
+  return (
+    <div className="pe-page-enter" style={{ fontFamily: 'var(--pe-font-body)' }}>
+      <div style={{ maxWidth: 700, margin: '0 auto', padding: '16px 12px 100px' }}>
+        <BackButton to="/history" label="History" />
+
+        {/* Player header */}
+        <div style={{ marginTop: 12, marginBottom: 20 }}>
+          <h1
+            className="pe-font-display"
+            style={{
+              fontSize: 26,
+              fontWeight: 700,
+              background: 'var(--pe-gradient)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              margin: 0,
+            }}
+          >
+            {player.name}
+          </h1>
+          {player.nickname && (
+            <p style={{ fontSize: 13, color: 'var(--pe-text-sub)', margin: '4px 0 0' }}>
+              "{player.nickname}"
+            </p>
+          )}
+        </div>
+
+        {/* Career stats grid */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
+          gap: 10,
+          marginBottom: 24,
+        }}>
+          <StatCard label="Tournaments" value={career.tournaments_played} />
+          <StatCard label="Tournament Wins" value={career.tournament_wins} color="var(--pe-success)" />
+          <StatCard label="Record" value={`${career.wins}W / ${career.losses}L`} />
+          <StatCard label="Win Rate" value={career.win_rate != null ? `${career.win_rate.toFixed(0)}%` : '—'} />
+          <StatCard label="3-Dart Avg" value={career.three_dart_avg != null ? career.three_dart_avg.toFixed(1) : '—'} color="var(--pe-cyan-bright)" />
+          <StatCard label="180s" value={career.one_eighties ?? '—'} color="var(--pe-cyan-bright)" />
+          <StatCard label="Checkout %" value={career.checkout_pct != null ? `${career.checkout_pct.toFixed(0)}%` : '—'} />
+          <StatCard label="Best Checkout" value={career.highest_checkout ?? '—'} color="var(--pe-warning)" />
+          <StatCard label="Best Leg" value={career.best_leg ?? '—'} />
+        </div>
+
+        {/* Tournament history */}
+        <h2 style={{ fontSize: 14, fontWeight: 'bold', color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1, margin: '0 0 10px' }}>
+          Tournament History
+        </h2>
+
+        {(!tournament_history || tournament_history.length === 0) ? (
+          <p style={{ color: 'var(--pe-text-muted)', textAlign: 'center', padding: '16px 0' }}>
+            No tournament history yet.
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {tournament_history.map((t) => (
+              <Link
+                key={t.tournament_id}
+                to={`/history/${t.tournament_id}`}
+                className="pe-card-interactive"
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  padding: '12px 14px',
+                  borderRadius: 12,
+                  background: 'var(--pe-bg-card)',
+                  border: '1px solid var(--pe-border)',
+                  textDecoration: 'none',
+                }}
+              >
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <span style={{ fontSize: 14, fontWeight: 'bold', color: 'var(--pe-text)', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {t.tournament_name}
+                  </span>
+                  <span style={{ fontSize: 12, color: 'var(--pe-text-sub)' }}>
+                    {t.date} &middot; {t.format}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', gap: 16, flexShrink: 0, alignItems: 'center' }}>
+                  <div style={{ textAlign: 'center' }}>
+                    <span className="pe-font-display" style={{ fontSize: 14, fontWeight: 700, color: 'var(--pe-text)' }}>
+                      {t.wins}W/{t.losses}L
+                    </span>
+                  </div>
+                  {t.is_winner && (
+                    <span style={{
+                      fontSize: 11,
+                      fontWeight: 'bold',
+                      padding: '3px 8px',
+                      borderRadius: 16,
+                      border: '1px solid var(--pe-success)',
+                      color: 'var(--pe-success)',
+                    }}>
+                      Winner
+                    </span>
+                  )}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, color }) {
+  return (
+    <div style={{
+      background: 'var(--pe-bg-card)',
+      borderRadius: 12,
+      border: '1px solid var(--pe-border)',
+      padding: 14,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 4,
+    }}>
+      <span
+        className="pe-font-display"
+        style={{
+          fontSize: 20,
+          fontWeight: 700,
+          color: color || 'var(--pe-text)',
+          letterSpacing: '0.01em',
+        }}
+      >
+        {value}
+      </span>
+      <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/PlayerProfilePage.jsx
+++ b/frontend/src/pages/PlayerProfilePage.jsx
@@ -103,6 +103,7 @@ export default function PlayerProfilePage() {
                   justifyContent: 'space-between',
                   alignItems: 'center',
                   padding: '12px 14px',
+                  minHeight: 64,
                   borderRadius: 12,
                   background: 'var(--pe-bg-card)',
                   border: '1px solid var(--pe-border)',
@@ -167,7 +168,7 @@ function StatCard({ label, value, color }) {
       >
         {value}
       </span>
-      <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+      <span style={{ fontSize: 11, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
         {label}
       </span>
     </div>

--- a/frontend/src/pages/TournamentDetailPage.jsx
+++ b/frontend/src/pages/TournamentDetailPage.jsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api } from '../api/client';
+import BackButton from '../components/BackButton';
+import Bracket from '../components/tournament/Bracket';
+
+export default function TournamentDetailPage() {
+  const { id } = useParams();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [activeTab, setActiveTab] = useState('stats');
+
+  useEffect(() => {
+    api.get(`/history/${id}`)
+      .then(setData)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p style={{ color: 'var(--pe-text-sub)' }}>Loading tournament...</p>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen p-4">
+        <BackButton to="/history" label="History" />
+        <p style={{ color: 'var(--pe-danger)', textAlign: 'center', marginTop: 24 }}>
+          {error || 'Tournament not found.'}
+        </p>
+      </div>
+    );
+  }
+
+  const { tournament, players, games } = data;
+
+  return (
+    <div className="pe-page-enter" style={{ fontFamily: 'var(--pe-font-body)' }}>
+      <div style={{ maxWidth: 800, margin: '0 auto', padding: '16px 12px 100px' }}>
+        <BackButton to="/history" label="History" />
+
+        <div style={{ marginTop: 12 }}>
+          <h1
+            className="pe-font-display"
+            style={{
+              fontSize: 22,
+              fontWeight: 700,
+              background: 'var(--pe-gradient)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              margin: 0,
+            }}
+          >
+            {tournament.name}
+          </h1>
+          <p style={{ fontSize: 12, color: 'var(--pe-text-sub)', margin: '4px 0 0' }}>
+            {tournament.date} &middot; {tournament.format} &middot;{' '}
+            {tournament.checkout === 'double_out' ? 'Double Out' : 'Single Out'}
+          </p>
+        </div>
+
+        {/* Tab bar */}
+        <div style={{ display: 'flex', gap: 6, marginTop: 16, marginBottom: 12, overflowX: 'auto', scrollbarWidth: 'none' }}>
+          {[
+            { id: 'stats', label: 'Player Stats' },
+            { id: 'bracket', label: 'Bracket' },
+          ].map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              style={{
+                padding: '0 18px',
+                borderRadius: 10,
+                border: '1px solid',
+                borderColor: activeTab === tab.id ? 'var(--pe-blue-deep)' : 'var(--pe-border)',
+                background: activeTab === tab.id ? 'var(--pe-blue-deep)' : 'var(--pe-bg-card)',
+                color: activeTab === tab.id ? 'var(--pe-text)' : 'var(--pe-text-sub)',
+                fontFamily: 'var(--pe-font-body)',
+                fontSize: 14,
+                fontWeight: 'bold',
+                cursor: 'pointer',
+                minHeight: 64,
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Player stats table */}
+        {activeTab === 'stats' && (
+          <div style={{ overflowX: 'auto' }}>
+            {players.length === 0 ? (
+              <p style={{ color: 'var(--pe-text-muted)', textAlign: 'center', padding: '24px 0' }}>
+                No player data available.
+              </p>
+            ) : (
+              <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 580 }}>
+                <thead>
+                  <tr>
+                    {['Player', 'W', 'L', 'Avg', '180s', 'CO%', 'Best CO', 'Best Leg'].map((h) => (
+                      <th
+                        key={h}
+                        style={{
+                          textAlign: h === 'Player' ? 'left' : 'center',
+                          padding: '8px 10px',
+                          fontSize: 11,
+                          color: 'var(--pe-text-muted)',
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.5,
+                          borderBottom: '1px solid var(--pe-border)',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {players.map((p) => (
+                    <tr key={p.id} style={{ borderBottom: '1px solid var(--pe-border)' }}>
+                      <td style={{ padding: '10px' }}>
+                        <Link
+                          to={`/players/${p.id}`}
+                          style={{
+                            color: 'var(--pe-cyan-bright)',
+                            textDecoration: 'none',
+                            fontWeight: 'bold',
+                            fontSize: 14,
+                          }}
+                        >
+                          {p.name}
+                        </Link>
+                      </td>
+                      <StatCell value={p.wins} color="var(--pe-success)" />
+                      <StatCell value={p.losses} color="var(--pe-danger)" />
+                      <StatCell value={p.three_dart_avg != null ? p.three_dart_avg.toFixed(1) : '—'} />
+                      <StatCell value={p.one_eighties ?? '—'} />
+                      <StatCell value={p.checkout_pct != null ? `${p.checkout_pct.toFixed(0)}%` : '—'} />
+                      <StatCell value={p.highest_checkout ?? '—'} />
+                      <StatCell value={p.best_leg ?? '—'} />
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+
+        {/* Bracket */}
+        {activeTab === 'bracket' && (
+          <div style={{ marginTop: 8 }}>
+            {games && games.length > 0 ? (
+              <Bracket games={games} />
+            ) : (
+              <p style={{ color: 'var(--pe-text-muted)', textAlign: 'center', padding: '24px 0' }}>
+                No bracket data available.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCell({ value, color }) {
+  return (
+    <td
+      className="pe-font-display"
+      style={{
+        textAlign: 'center',
+        padding: '10px',
+        fontSize: 14,
+        fontWeight: 700,
+        color: color || 'var(--pe-text)',
+      }}
+    >
+      {value}
+    </td>
+  );
+}

--- a/frontend/src/pages/TournamentDetailPage.jsx
+++ b/frontend/src/pages/TournamentDetailPage.jsx
@@ -127,10 +127,14 @@ export default function TournamentDetailPage() {
                 <tbody>
                   {players.map((p) => (
                     <tr key={p.id} style={{ borderBottom: '1px solid var(--pe-border)' }}>
-                      <td style={{ padding: '10px' }}>
+                      <td style={{ padding: 0 }}>
                         <Link
                           to={`/players/${p.id}`}
                           style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            minHeight: 48,
+                            padding: '6px 10px',
                             color: 'var(--pe-cyan-bright)',
                             textDecoration: 'none',
                             fontWeight: 'bold',

--- a/frontend/src/pages/TournamentHistoryPage.jsx
+++ b/frontend/src/pages/TournamentHistoryPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../api/client';
+import BackButton from '../components/BackButton';
 
 export default function TournamentHistoryPage() {
   const [tournaments, setTournaments] = useState([]);
@@ -33,6 +34,8 @@ export default function TournamentHistoryPage() {
   return (
     <div className="pe-page-enter" style={{ fontFamily: 'var(--pe-font-body)' }}>
       <div style={{ maxWidth: 700, margin: '0 auto', padding: '16px 12px 100px' }}>
+        <BackButton to="/" label="Home" />
+
         <h1
           className="pe-font-display"
           style={{
@@ -41,7 +44,7 @@ export default function TournamentHistoryPage() {
             background: 'var(--pe-gradient)',
             WebkitBackgroundClip: 'text',
             WebkitTextFillColor: 'transparent',
-            margin: '0 0 16px',
+            margin: '12px 0 16px',
           }}
         >
           Tournament History
@@ -64,6 +67,7 @@ export default function TournamentHistoryPage() {
                   borderRadius: 14,
                   border: '1px solid var(--pe-border)',
                   padding: 16,
+                  minHeight: 64,
                   textDecoration: 'none',
                 }}
               >
@@ -108,7 +112,7 @@ export default function TournamentHistoryPage() {
                       <span className="pe-font-display" style={{ fontSize: 15, fontWeight: 700, color: 'var(--pe-success)' }}>
                         {t.winner_name}
                       </span>
-                      <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+                      <span style={{ fontSize: 11, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
                         Winner
                       </span>
                     </div>
@@ -117,7 +121,7 @@ export default function TournamentHistoryPage() {
                     <span className="pe-font-display" style={{ fontSize: 15, fontWeight: 700, color: 'var(--pe-cyan-bright)' }}>
                       {t.player_count}
                     </span>
-                    <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+                    <span style={{ fontSize: 11, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
                       Players
                     </span>
                   </div>
@@ -125,7 +129,7 @@ export default function TournamentHistoryPage() {
                     <span className="pe-font-display" style={{ fontSize: 15, fontWeight: 700, color: 'var(--pe-cyan-bright)' }}>
                       {t.games_played}
                     </span>
-                    <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+                    <span style={{ fontSize: 11, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
                       Games
                     </span>
                   </div>

--- a/frontend/src/pages/TournamentHistoryPage.jsx
+++ b/frontend/src/pages/TournamentHistoryPage.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api } from '../api/client';
+
+export default function TournamentHistoryPage() {
+  const [tournaments, setTournaments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    api.get('/history')
+      .then(setTournaments)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p style={{ color: 'var(--pe-text-sub)' }}>Loading tournament history...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p style={{ color: 'var(--pe-danger)' }}>Error: {error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pe-page-enter" style={{ fontFamily: 'var(--pe-font-body)' }}>
+      <div style={{ maxWidth: 700, margin: '0 auto', padding: '16px 12px 100px' }}>
+        <h1
+          className="pe-font-display"
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            background: 'var(--pe-gradient)',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+            margin: '0 0 16px',
+          }}
+        >
+          Tournament History
+        </h1>
+
+        {tournaments.length === 0 ? (
+          <p style={{ color: 'var(--pe-text-muted)', textAlign: 'center', padding: '32px 0' }}>
+            No finished tournaments yet.
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {tournaments.map((t) => (
+              <Link
+                key={t.id}
+                to={`/history/${t.id}`}
+                className="pe-card-interactive"
+                style={{
+                  display: 'block',
+                  background: 'var(--pe-bg-card)',
+                  borderRadius: 14,
+                  border: '1px solid var(--pe-border)',
+                  padding: 16,
+                  textDecoration: 'none',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
+                  <div style={{ minWidth: 0, flex: 1 }}>
+                    <h2
+                      className="pe-font-display"
+                      style={{
+                        fontSize: 17,
+                        fontWeight: 700,
+                        color: 'var(--pe-text)',
+                        margin: 0,
+                        lineHeight: 1.3,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {t.name}
+                    </h2>
+                    <p style={{ fontSize: 12, color: 'var(--pe-text-sub)', margin: '4px 0 0' }}>
+                      {t.date} &middot; {t.format} &middot; {t.checkout === 'double_out' ? 'Double Out' : 'Single Out'}
+                    </p>
+                  </div>
+                  <span style={{
+                    fontSize: 11,
+                    fontWeight: 'bold',
+                    padding: '4px 10px',
+                    borderRadius: 20,
+                    border: '1px solid var(--pe-text-muted)',
+                    color: 'var(--pe-text-muted)',
+                    whiteSpace: 'nowrap',
+                    flexShrink: 0,
+                  }}>
+                    Finished
+                  </span>
+                </div>
+
+                <div style={{ display: 'flex', gap: 20, marginTop: 12 }}>
+                  {t.winner_name && (
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                      <span className="pe-font-display" style={{ fontSize: 15, fontWeight: 700, color: 'var(--pe-success)' }}>
+                        {t.winner_name}
+                      </span>
+                      <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+                        Winner
+                      </span>
+                    </div>
+                  )}
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <span className="pe-font-display" style={{ fontSize: 15, fontWeight: 700, color: 'var(--pe-cyan-bright)' }}>
+                      {t.player_count}
+                    </span>
+                    <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+                      Players
+                    </span>
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <span className="pe-font-display" style={{ fontSize: 15, fontWeight: 700, color: 'var(--pe-cyan-bright)' }}>
+                      {t.games_played}
+                    </span>
+                    <span style={{ fontSize: 10, color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>
+                      Games
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add missing navigation links for `/history` (BottomNav, TopNav, HomePage) and `/admin/reports` (TopNav admin)
- Fix font tokens in `index.css`: `--pe-font-body` → Inter, `--pe-font-display` → Barlow Condensed (was incorrectly set to Verdana)
- Design audit fixes: touch targets, BackButton on HistoryPage, label font sizes

## Commits
- `4118d60` — DAU design audit fixes (touch targets, BackButton, labels)
- `a25a123` — font token correction (Inter/Barlow Condensed)
- `3144f9e` — navigation links for /history and /admin/reports

## Follows
PR #90 (stats pages) — these commits were added after the squash merge.