### PR TITLE
feat: gastro section rework — tablet-first station-split (#70)

### DIFF
--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -218,7 +218,8 @@ router.get('/by-guest', requireAuth, (req, res) => {
         g.id as guest_id,
         g.name as guest_name,
         COUNT(o.id) as open_orders,
-        COALESCE(SUM(o.quantity * p.price), 0) as total
+        COALESCE(SUM(o.quantity * p.price), 0) as total,
+        MIN(o.ordered_at) as oldest_order_at
       FROM guests g
       JOIN orders o ON o.guest_id = g.id AND o.status = 'open'
       JOIN products p ON o.product_id = p.id

--- a/frontend/src/components/gastro/GastronomyLogin.jsx
+++ b/frontend/src/components/gastro/GastronomyLogin.jsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { api } from '../../api/client';
+
+// GastronomyLogin — shown when no gastronomy token is present
+// Props: onLogin(token: string) => void
+export default function GastronomyLogin({ onLogin }) {
+  const [form, setForm] = useState({ username: '', password: '' });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const data = await api.post('/auth/login', form);
+      if (!['admin', 'gastronomy'].includes(data.user?.role)) {
+        setError('Keine Berechtigung für die Gastronomie.');
+        return;
+      }
+      onLogin(data.token);
+    } catch (err) {
+      setError(err.message || 'Login fehlgeschlagen');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const inp = {
+    background: 'var(--pe-bg-card)',
+    border: '1px solid var(--pe-border)',
+    color: 'var(--pe-text)',
+    fontFamily: 'Verdana, Geneva, sans-serif',
+    minHeight: '64px',
+    borderRadius: '12px',
+    padding: '0 16px',
+    width: '100%',
+    outline: 'none',
+    fontSize: '16px',
+    boxSizing: 'border-box',
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '16px',
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}
+    >
+      <div style={{ width: '100%', maxWidth: '380px' }}>
+        <div style={{ textAlign: 'center', marginBottom: '32px' }}>
+          <img src="/logo.png" alt="DartEvent" style={{ height: '64px', marginBottom: '16px' }} />
+          <h1
+            style={{
+              background: 'var(--pe-gradient)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              fontWeight: 'bold',
+              fontSize: '20px',
+              margin: 0,
+            }}
+          >
+            Gastronomie
+          </h1>
+        </div>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <input
+            type="text"
+            value={form.username}
+            onChange={(e) => setForm({ ...form, username: e.target.value })}
+            placeholder="Benutzername"
+            style={inp}
+            autoComplete="username"
+          />
+          <input
+            type="password"
+            value={form.password}
+            onChange={(e) => setForm({ ...form, password: e.target.value })}
+            placeholder="Passwort"
+            style={inp}
+            autoComplete="current-password"
+          />
+          {error && (
+            <p style={{ color: 'var(--pe-danger)', fontSize: '14px', textAlign: 'center', margin: 0 }}>
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={loading || !form.username || !form.password}
+            style={{
+              background: 'var(--pe-gradient)',
+              color: 'var(--pe-text)',
+              border: 'none',
+              borderRadius: '12px',
+              padding: '16px',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              fontWeight: 'bold',
+              fontSize: '16px',
+              cursor: loading ? 'not-allowed' : 'pointer',
+              minHeight: '64px',
+              opacity: loading ? 0.6 : 1,
+            }}
+          >
+            {loading ? 'Anmelden...' : 'Anmelden'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/GuestHeader.jsx
+++ b/frontend/src/components/gastro/GuestHeader.jsx
@@ -1,0 +1,131 @@
+// GuestHeader — shows the current guest's info, status badge, close button, lock/unlock and optional settle button
+const btnStyle = {
+  fontFamily: 'Verdana, Geneva, sans-serif',
+  borderRadius: '12px',
+  fontWeight: 'bold',
+  border: '1px solid var(--pe-border)',
+  cursor: 'pointer',
+};
+
+export default function GuestHeader({ guest, isBlocked, onClose, onToggleLock, lockLoading, onSettle }) {
+  return (
+    <div
+      className="mb-4 p-3 rounded-xl"
+      style={{
+        background: 'var(--pe-bg-card)',
+        border: `1px solid ${isBlocked ? 'var(--pe-danger)' : 'var(--pe-border)'}`,
+      }}
+    >
+      {/* Row 1: Name + Badge + Close */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '10px',
+          marginBottom: '10px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flex: 1, minWidth: 0 }}>
+          <div>
+            <p style={{ fontWeight: 'bold', color: 'var(--pe-text)', margin: 0, fontSize: '15px' }}>
+              {guest.name || 'Gast'}
+            </p>
+            <p style={{ fontSize: '11px', color: 'var(--pe-text-muted)', margin: '2px 0 0' }}>#{guest.id}</p>
+          </div>
+          {/* Status badge */}
+          <span
+            style={{
+              flexShrink: 0,
+              padding: '4px 12px',
+              borderRadius: '20px',
+              fontSize: '12px',
+              fontWeight: 'bold',
+              color: isBlocked ? 'var(--pe-danger)' : 'var(--pe-success)',
+              border: `1px solid ${isBlocked ? 'var(--pe-danger)' : 'var(--pe-success)'}`,
+              background: isBlocked ? 'rgba(255,69,96,0.12)' : 'rgba(0,229,160,0.10)',
+            }}
+          >
+            {isBlocked ? 'Gesperrt' : 'Aktiv'}
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            ...btnStyle,
+            minHeight: '64px',
+            padding: '0 16px',
+            background: 'var(--pe-bg-elevated)',
+            color: 'var(--pe-text-sub)',
+            border: '1px solid var(--pe-border)',
+            flexShrink: 0,
+          }}
+        >
+          ✕ Schließen
+        </button>
+      </div>
+
+      {/* Row 2: Lock / Unlock */}
+      <button
+        onClick={onToggleLock}
+        disabled={lockLoading}
+        style={{
+          ...btnStyle,
+          width: '100%',
+          minHeight: '64px',
+          background: isBlocked ? 'rgba(0,229,160,0.12)' : 'rgba(255,69,96,0.12)',
+          color: isBlocked ? 'var(--pe-success)' : 'var(--pe-danger)',
+          border: `1px solid ${isBlocked ? 'var(--pe-success)' : 'var(--pe-danger)'}`,
+          fontSize: '13px',
+          opacity: lockLoading ? 0.6 : 1,
+        }}
+      >
+        {lockLoading
+          ? isBlocked
+            ? 'Wird entsperrt...'
+            : 'Wird gesperrt...'
+          : isBlocked
+          ? 'Armband entsperren'
+          : 'Armband sperren'}
+      </button>
+
+      {/* Hint when blocked */}
+      {isBlocked && (
+        <p
+          style={{
+            margin: '8px 0 0',
+            fontSize: '13px',
+            color: 'var(--pe-danger)',
+            fontWeight: 'bold',
+            textAlign: 'center',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          Armband gesperrt — keine Bestellungen möglich
+        </p>
+      )}
+
+      {/* Optional: Settle button */}
+      {onSettle && !isBlocked && (
+        <button
+          onClick={onSettle}
+          style={{
+            width: '100%',
+            minHeight: '64px',
+            marginTop: '10px',
+            borderRadius: '12px',
+            background: 'rgba(0,229,160,0.12)',
+            color: 'var(--pe-success)',
+            border: '1px solid var(--pe-success)',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+            fontWeight: 'bold',
+            fontSize: '14px',
+            cursor: 'pointer',
+          }}
+        >
+          Abrechnen
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/GuestSearchInput.jsx
+++ b/frontend/src/components/gastro/GuestSearchInput.jsx
@@ -1,0 +1,54 @@
+export default function GuestSearchInput({
+  value,
+  onChange,
+  placeholder = 'Name suchen…',
+  onCreateNew,
+  createLabel = '+ Neu',
+  disabled = false,
+}) {
+  return (
+    <div style={{ display: 'flex', gap: '8px' }}>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        style={{
+          flex: 1,
+          minHeight: '64px',
+          background: 'var(--pe-bg-card)',
+          border: '1px solid var(--pe-border)',
+          color: 'var(--pe-text)',
+          fontFamily: 'Verdana, Geneva, sans-serif',
+          borderRadius: '12px',
+          padding: '0 16px',
+          fontSize: '16px',
+          outline: 'none',
+          width: '100%',
+        }}
+      />
+      {onCreateNew && (
+        <button
+          type="button"
+          onClick={onCreateNew}
+          disabled={disabled}
+          style={{
+            minHeight: '64px',
+            padding: '0 20px',
+            background: 'var(--pe-blue-mid)',
+            color: 'var(--pe-text)',
+            border: 'none',
+            borderRadius: '12px',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+            fontWeight: 'bold',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {createLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/GuestSelector.jsx
+++ b/frontend/src/components/gastro/GuestSelector.jsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import NFCScanner from '../nfc/NFCScanner';
+import GuestSearchInput from './GuestSearchInput';
+
+/**
+ * GuestSelector — NFC tap-to-start with manual accordion fallback.
+ *
+ * Props:
+ *   guests           — array of all guest objects
+ *   onGuestSelect    — called with the guest object when a guest is selected
+ *   onCreateGuest    — called with a name string when user clicks "+ Neu"
+ *   nfcAvailable     — boolean: 'NDEFReader' in window
+ *   onRequestNfcScan — called with the raw NFC UID when NFCScanner fires onScan
+ *   scanning         — boolean: true while NFC scan is being processed
+ */
+export default function GuestSelector({
+  guests,
+  onGuestSelect,
+  onCreateGuest,
+  nfcAvailable,
+  onRequestNfcScan,
+  scanning,
+}) {
+  const [manualOpen, setManualOpen] = useState(!nfcAvailable);
+  const [search, setSearch] = useState('');
+
+  const filteredGuests = guests.filter(
+    (g) => !search || g.name?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div style={{ fontFamily: 'Verdana, Geneva, sans-serif' }}>
+      {/* NFC section — only when NFC is available */}
+      {nfcAvailable && (
+        <NFCScanner onScan={onRequestNfcScan} scanning={scanning} />
+      )}
+
+      {/* Manual toggle — only shown when NFC is available */}
+      {nfcAvailable && (
+        <button
+          type="button"
+          onClick={() => setManualOpen((o) => !o)}
+          style={{
+            minHeight: '48px',
+            background: 'var(--pe-bg-elevated)',
+            border: '1px solid var(--pe-border)',
+            borderRadius: '12px',
+            color: 'var(--pe-text-sub)',
+            fontWeight: 'bold',
+            fontSize: '13px',
+            cursor: 'pointer',
+            width: '100%',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+            marginTop: '12px',
+          }}
+        >
+          {manualOpen ? '▲ Manuelle Auswahl schließen' : '▼ Oder manuell auswählen'}
+        </button>
+      )}
+
+      {/* Manual section — always visible when NFC unavailable, toggleable otherwise */}
+      {(manualOpen || !nfcAvailable) && (
+        <div style={{ marginTop: '8px' }}>
+          <GuestSearchInput
+            value={search}
+            onChange={setSearch}
+            onCreateNew={() => onCreateGuest(search.trim() || 'Neuer Gast')}
+          />
+
+          <div
+            style={{
+              maxHeight: '320px',
+              overflowY: 'auto',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '6px',
+              marginTop: '8px',
+            }}
+          >
+            {filteredGuests.map((g) => {
+              const gBlocked = g.active === 0 || g.active === false;
+              return (
+                <button
+                  key={g.id}
+                  type="button"
+                  onClick={() => onGuestSelect(g)}
+                  style={{
+                    minHeight: '64px',
+                    width: '100%',
+                    background: 'var(--pe-bg-card)',
+                    border: `1px solid ${gBlocked ? 'var(--pe-danger)' : 'var(--pe-border)'}`,
+                    borderRadius: '12px',
+                    padding: '0 16px',
+                    textAlign: 'left',
+                    cursor: 'pointer',
+                    color: 'var(--pe-text)',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                    fontSize: '15px',
+                    fontWeight: 'bold',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  <span>{g.name || 'Gast'}</span>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                    {gBlocked && (
+                      <span
+                        style={{
+                          fontSize: '11px',
+                          fontWeight: 'bold',
+                          color: 'var(--pe-danger)',
+                          border: '1px solid var(--pe-danger)',
+                          borderRadius: '20px',
+                          padding: '2px 8px',
+                        }}
+                      >
+                        Gesperrt
+                      </span>
+                    )}
+                    <span style={{ color: 'var(--pe-text-muted)', fontSize: '12px' }}>
+                      #{g.id}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+
+            {filteredGuests.length === 0 && (
+              <p
+                style={{
+                  color: 'var(--pe-text-muted)',
+                  textAlign: 'center',
+                  padding: '16px',
+                  fontSize: '13px',
+                }}
+              >
+                {guests.length === 0
+                  ? 'Noch keine Gäste. Mit "+ Neu" ersten Gast anlegen.'
+                  : 'Kein Gast gefunden.'}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/KitchenView.jsx
+++ b/frontend/src/components/gastro/KitchenView.jsx
@@ -1,0 +1,219 @@
+import { useState, useEffect } from 'react';
+import { api } from '../../api/client.js';
+
+function timeAgo(isoString) {
+  const mins = Math.floor((Date.now() - new Date(isoString)) / 60000);
+  if (mins < 1) return 'gerade eben';
+  if (mins === 1) return 'vor 1 Minute';
+  return `vor ${mins} Minuten`;
+}
+
+export default function KitchenView() {
+  const [orders, setOrders] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [lastRefresh, setLastRefresh] = useState(null);
+
+  async function fetchKitchenOrders() {
+    try {
+      const data = await api.get('/orders/by-guest');
+      // Filter to guests that have at least one food item; also filter items to food only
+      const foodGuests = data
+        .map((guest) => ({
+          ...guest,
+          items: (guest.items || []).filter((item) => item.category === 'food'),
+        }))
+        .filter((guest) => guest.items.length > 0);
+      setOrders(foodGuests);
+      setLastRefresh(new Date());
+    } catch {
+      // Silently ignore polling errors — stale data remains visible
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchKitchenOrders();
+    const interval = setInterval(fetchKitchenOrders, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const refreshLabel = lastRefresh
+    ? `Aktualisiert: ${lastRefresh.getHours().toString().padStart(2, '0')}:${lastRefresh.getMinutes().toString().padStart(2, '0')}`
+    : '…';
+
+  return (
+    <div
+      style={{
+        maxWidth: 1200,
+        margin: '0 auto',
+        padding: 16,
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}
+    >
+      {/* Header bar */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 20,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <h2
+            style={{
+              color: 'var(--pe-text)',
+              fontWeight: 'bold',
+              fontSize: 20,
+              margin: 0,
+              fontFamily: 'Verdana, Geneva, sans-serif',
+            }}
+          >
+            Offene Küchen-Bestellungen
+          </h2>
+          <span
+            style={{
+              background: 'var(--pe-warning)',
+              color: '#000',
+              borderRadius: 20,
+              padding: '2px 10px',
+              fontWeight: 'bold',
+              marginLeft: 10,
+              fontFamily: 'Verdana, Geneva, sans-serif',
+            }}
+          >
+            {orders.length}
+          </span>
+        </div>
+        <span
+          style={{
+            color: 'var(--pe-text-muted)',
+            fontSize: 12,
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          {refreshLabel}
+        </span>
+      </div>
+
+      {/* Loading state */}
+      {loading && orders.length === 0 && (
+        <p style={{ textAlign: 'center', color: 'var(--pe-text-sub)', padding: 32 }}>
+          Lade Bestellungen…
+        </p>
+      )}
+
+      {/* Empty state */}
+      {!loading && orders.length === 0 && (
+        <div style={{ textAlign: 'center', padding: '64px 0' }}>
+          <div style={{ fontSize: 64, color: 'var(--pe-success)' }}>✓</div>
+          <p
+            style={{
+              color: 'var(--pe-text-sub)',
+              fontSize: 16,
+              fontFamily: 'Verdana, Geneva, sans-serif',
+            }}
+          >
+            Keine offenen Küchen-Bestellungen
+          </p>
+        </div>
+      )}
+
+      {/* Ticket grid */}
+      {orders.length > 0 && (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+            gap: 16,
+          }}
+        >
+          {orders.map((guest) => (
+            <div
+              key={guest.guest_id ?? guest.id}
+              style={{
+                background: 'var(--pe-bg-card)',
+                border: '1px solid var(--pe-border)',
+                borderRadius: 16,
+                overflow: 'hidden',
+              }}
+            >
+              {/* Card header */}
+              <div
+                style={{
+                  background: 'var(--pe-bg-elevated)',
+                  padding: '12px 16px',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <span
+                  style={{
+                    fontWeight: 'bold',
+                    color: 'var(--pe-text)',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                  }}
+                >
+                  {guest.guest_name ?? guest.name ?? 'Gast'}
+                </span>
+                <span
+                  style={{
+                    background: 'rgba(255,176,32,0.15)',
+                    color: 'var(--pe-warning)',
+                    borderRadius: 20,
+                    padding: '4px 10px',
+                    fontSize: 12,
+                    fontWeight: 'bold',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                  }}
+                >
+                  {timeAgo(guest.oldest_order_at ?? guest.items[0]?.ordered_at)}
+                </span>
+              </div>
+
+              {/* Card body */}
+              <div style={{ padding: '12px 16px' }}>
+                {guest.items.map((item, idx) => (
+                  <div
+                    key={item.order_id ?? idx}
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      padding: '6px 0',
+                      borderBottom:
+                        idx < guest.items.length - 1
+                          ? '1px solid var(--pe-border)'
+                          : 'none',
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontSize: 15,
+                        color: 'var(--pe-text)',
+                        fontFamily: 'Verdana, Geneva, sans-serif',
+                      }}
+                    >
+                      {item.product_name}
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 15,
+                        color: 'var(--pe-text-muted)',
+                        fontWeight: 'bold',
+                        fontFamily: 'Verdana, Geneva, sans-serif',
+                      }}
+                    >
+                      ×{item.quantity}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/KitchenView.jsx
+++ b/frontend/src/components/gastro/KitchenView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { api } from '../../api/client.js';
 
 function timeAgo(isoString) {
@@ -13,7 +13,7 @@ export default function KitchenView() {
   const [loading, setLoading] = useState(true);
   const [lastRefresh, setLastRefresh] = useState(null);
 
-  async function fetchKitchenOrders() {
+  const fetchKitchenOrders = useCallback(async () => {
     try {
       const data = await api.get('/orders/by-guest');
       // Filter to guests that have at least one food item; also filter items to food only
@@ -30,13 +30,13 @@ export default function KitchenView() {
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
 
   useEffect(() => {
     fetchKitchenOrders();
     const interval = setInterval(fetchKitchenOrders, 5000);
     return () => clearInterval(interval);
-  }, []);
+  }, [fetchKitchenOrders]);
 
   const refreshLabel = lastRefresh
     ? `Aktualisiert: ${lastRefresh.getHours().toString().padStart(2, '0')}:${lastRefresh.getMinutes().toString().padStart(2, '0')}`

--- a/frontend/src/components/gastro/OpenOrdersPanel.jsx
+++ b/frontend/src/components/gastro/OpenOrdersPanel.jsx
@@ -1,0 +1,163 @@
+import { useState } from 'react';
+
+// Accordion panel showing a guest's currently open (unpaid) orders.
+// Props:
+//   items  — Array<{ product_name, quantity, total }>
+//   total  — number (sum of all open items)
+export default function OpenOrdersPanel({ items, total }) {
+  const [open, setOpen] = useState(items.length <= 3);
+
+  return (
+    <div style={{ marginBottom: '16px', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+      {/* Header — always visible, clickable to toggle */}
+      <div
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          background: 'var(--pe-bg-elevated)',
+          border: '1px solid var(--pe-border)',
+          borderRadius: open ? '12px 12px 0 0' : '12px',
+          padding: '0 16px',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          color: 'var(--pe-text-sub)',
+          fontWeight: 'bold',
+          fontSize: '13px',
+          fontFamily: 'Verdana, Geneva, sans-serif',
+          minHeight: '48px',
+          cursor: 'pointer',
+          userSelect: 'none',
+        }}
+      >
+        <span>
+          {items.length} offene Artikel — {parseFloat(total || 0).toFixed(2)} €
+        </span>
+        <span style={{ marginLeft: '8px', fontSize: '14px' }}>{open ? '▾' : '▸'}</span>
+      </div>
+
+      {/* Body — visible when expanded */}
+      {open && (
+        <div
+          style={{
+            background: 'var(--pe-bg-elevated)',
+            border: '1px solid var(--pe-border)',
+            borderTop: 'none',
+            borderRadius: '0 0 12px 12px',
+            overflow: 'hidden',
+          }}
+        >
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '4px 8px',
+                    fontSize: '11px',
+                    color: 'var(--pe-text-muted)',
+                    textTransform: 'uppercase',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                  }}
+                >
+                  Artikel
+                </th>
+                <th
+                  style={{
+                    textAlign: 'center',
+                    padding: '4px 8px',
+                    fontSize: '11px',
+                    color: 'var(--pe-text-muted)',
+                    textTransform: 'uppercase',
+                    width: '48px',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                  }}
+                >
+                  Menge
+                </th>
+                <th
+                  style={{
+                    textAlign: 'right',
+                    padding: '4px 8px',
+                    fontSize: '11px',
+                    color: 'var(--pe-text-muted)',
+                    textTransform: 'uppercase',
+                    width: '80px',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                  }}
+                >
+                  Preis
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, i) => (
+                <tr key={i} style={{ borderTop: '1px solid var(--pe-border)' }}>
+                  <td
+                    style={{
+                      padding: '7px 8px',
+                      fontSize: '13px',
+                      color: 'var(--pe-text)',
+                      fontFamily: 'Verdana, Geneva, sans-serif',
+                    }}
+                  >
+                    {item.product_name}
+                  </td>
+                  <td
+                    style={{
+                      padding: '7px 8px',
+                      fontSize: '13px',
+                      color: 'var(--pe-text)',
+                      textAlign: 'center',
+                      fontFamily: 'Verdana, Geneva, sans-serif',
+                    }}
+                  >
+                    {item.quantity}
+                  </td>
+                  <td
+                    style={{
+                      padding: '7px 8px',
+                      fontSize: '13px',
+                      color: 'var(--pe-text-sub)',
+                      textAlign: 'right',
+                      fontFamily: 'Verdana, Geneva, sans-serif',
+                    }}
+                  >
+                    {parseFloat(item.total).toFixed(2)} €
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr style={{ borderTop: '2px solid var(--pe-border)' }}>
+                <td
+                  colSpan="2"
+                  style={{
+                    padding: '7px 8px',
+                    fontSize: '13px',
+                    fontWeight: 'bold',
+                    color: 'var(--pe-text-sub)',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                  }}
+                >
+                  Gesamt offen
+                </td>
+                <td
+                  style={{
+                    padding: '7px 8px',
+                    fontSize: '14px',
+                    fontWeight: 'bold',
+                    color: 'var(--pe-cyan-bright)',
+                    textAlign: 'right',
+                    fontFamily: 'Verdana, Geneva, sans-serif',
+                  }}
+                >
+                  {parseFloat(total || 0).toFixed(2)} €
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/OrderCart.jsx
+++ b/frontend/src/components/gastro/OrderCart.jsx
@@ -1,0 +1,191 @@
+import OrderCartItem from './OrderCartItem';
+
+const OrderCart = ({
+  items,
+  onAdd,
+  onRemove,
+  onSubmit,
+  submitting,
+  isBlocked,
+  guestName,
+  orderSuccess,
+}) => {
+  const totalQty = items.reduce((s, i) => s + i.quantity, 0);
+  const total = items.reduce((s, i) => s + i.price * i.quantity, 0);
+
+  const submitButtonStyle = {
+    width: '100%',
+    minHeight: 72,
+    borderRadius: 16,
+    fontWeight: 'bold',
+    fontSize: 18,
+    fontFamily: 'Verdana, Geneva, sans-serif',
+    border: 'none',
+    cursor: isBlocked ? 'not-allowed' : 'pointer',
+    marginTop: 12,
+    ...(isBlocked
+      ? {
+          background: 'var(--pe-bg-elevated)',
+          color: 'var(--pe-danger)',
+          border: '1px solid var(--pe-danger)',
+        }
+      : submitting
+      ? {
+          background: 'var(--pe-gradient)',
+          color: 'var(--pe-text)',
+          opacity: 0.6,
+        }
+      : {
+          background: 'var(--pe-gradient)',
+          color: 'var(--pe-text)',
+        }),
+  };
+
+  const submitLabel = isBlocked
+    ? 'Armband gesperrt'
+    : submitting
+    ? 'Wird gespeichert\u2026'
+    : 'Bestellen';
+
+  const dividerStyle = {
+    borderTop: '1px solid var(--pe-border)',
+    margin: '8px 0',
+  };
+
+  // Inlined cart content — shared between tablet and mobile layouts
+  const cartContent = (
+    <>
+      <div
+        style={{
+          fontWeight: 'bold',
+          fontSize: 16,
+          color: 'var(--pe-text)',
+          marginBottom: 12,
+          fontFamily: 'Verdana, Geneva, sans-serif',
+        }}
+      >
+        Warenkorb ({totalQty})
+      </div>
+
+      <div style={dividerStyle} />
+
+      {items.map((item) => (
+        <OrderCartItem
+          key={item.product_id}
+          item={item}
+          onAdd={onAdd}
+          onRemove={onRemove}
+        />
+      ))}
+
+      <div style={dividerStyle} />
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginTop: 8,
+        }}
+      >
+        <span
+          style={{
+            color: 'var(--pe-text)',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          Gesamt
+        </span>
+        <span
+          style={{
+            color: 'var(--pe-cyan-bright)',
+            fontWeight: 'bold',
+            fontSize: 20,
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          {total.toFixed(2)} &euro;
+        </span>
+      </div>
+
+      <button
+        onClick={onSubmit}
+        disabled={isBlocked || submitting}
+        style={submitButtonStyle}
+      >
+        {submitLabel}
+      </button>
+
+      {orderSuccess && items.length === 0 && (
+        <p
+          style={{
+            color: 'var(--pe-success)',
+            fontWeight: 'bold',
+            textAlign: 'center',
+            marginTop: 12,
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          &#10003; Bestellung gespeichert!
+        </p>
+      )}
+    </>
+  );
+
+  return (
+    <>
+      {/* Tablet sidebar (md and up) */}
+      <div className="hidden md:block">
+        <div
+          style={{
+            position: 'sticky',
+            top: 16,
+            maxHeight: 'calc(100vh - 32px)',
+            overflowY: 'auto',
+            background: 'var(--pe-bg-card)',
+            border: '1px solid var(--pe-border)',
+            borderRadius: 16,
+            padding: 16,
+          }}
+        >
+          {cartContent}
+        </div>
+      </div>
+
+      {/* Mobile bottom sheet (below md) */}
+      <div className="md:hidden">
+        {items.length > 0 && (
+          <div
+            style={{
+              position: 'fixed',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              zIndex: 50,
+              background: 'var(--pe-bg-elevated)',
+              borderTop: '1px solid var(--pe-border)',
+              borderRadius: '20px 20px 0 0',
+              padding: 16,
+              maxHeight: '50vh',
+              overflowY: 'auto',
+            }}
+          >
+            {/* Drag handle */}
+            <div
+              style={{
+                width: 40,
+                height: 4,
+                background: 'var(--pe-border)',
+                borderRadius: 2,
+                margin: '0 auto 12px',
+              }}
+            />
+            {cartContent}
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default OrderCart;

--- a/frontend/src/components/gastro/OrderCartItem.jsx
+++ b/frontend/src/components/gastro/OrderCartItem.jsx
@@ -1,0 +1,99 @@
+const OrderCartItem = ({ item, onAdd, onRemove }) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 8,
+        padding: '8px 0',
+      }}
+    >
+      <div style={{ flex: 1 }}>
+        <div
+          style={{
+            color: 'var(--pe-text)',
+            fontWeight: 'bold',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          {item.name}
+        </div>
+        <div
+          style={{
+            color: 'var(--pe-text-muted)',
+            fontSize: 12,
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          {item.price.toFixed(2)} € / Stk.
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button
+          onClick={() => onRemove(item.product_id)}
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: 12,
+            border: 'none',
+            cursor: 'pointer',
+            fontWeight: 'bold',
+            fontSize: 20,
+            background: 'var(--pe-bg-elevated)',
+            color: 'var(--pe-danger)',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          −
+        </button>
+
+        <div
+          style={{
+            minWidth: 32,
+            textAlign: 'center',
+            color: 'var(--pe-text)',
+            fontWeight: 'bold',
+            fontSize: 16,
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          {item.quantity}
+        </div>
+
+        <button
+          onClick={() => onAdd(item.product_id)}
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: 12,
+            border: 'none',
+            cursor: 'pointer',
+            fontWeight: 'bold',
+            fontSize: 20,
+            background: 'var(--pe-bg-elevated)',
+            color: 'var(--pe-success)',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          +
+        </button>
+
+        <div
+          style={{
+            color: 'var(--pe-cyan-bright)',
+            fontWeight: 'bold',
+            minWidth: 56,
+            textAlign: 'right',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}
+        >
+          {(item.quantity * item.price).toFixed(2)} €
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OrderCartItem;

--- a/frontend/src/components/gastro/OrderCartItem.jsx
+++ b/frontend/src/components/gastro/OrderCartItem.jsx
@@ -63,7 +63,7 @@ const OrderCartItem = ({ item, onAdd, onRemove }) => {
         </div>
 
         <button
-          onClick={() => onAdd(item.product_id)}
+          onClick={() => onAdd(item)}
           style={{
             width: 64,
             height: 64,

--- a/frontend/src/components/gastro/ProductGrid.jsx
+++ b/frontend/src/components/gastro/ProductGrid.jsx
@@ -1,0 +1,77 @@
+// ProductGrid — category filter bar + responsive product button grid
+export default function ProductGrid({ products, onAddToCart, isBlocked, categoryFilter, onCategoryChange }) {
+  const categories = [
+    { id: 'all', label: 'Alle' },
+    { id: 'drink', label: 'Getränke' },
+    { id: 'food', label: 'Speisen' },
+  ];
+
+  const filtered = categoryFilter !== 'all'
+    ? products.filter((p) => p.category === categoryFilter)
+    : products;
+
+  const gridContent = (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+      {filtered.map((product) => (
+        <button
+          key={product.id}
+          onClick={() => onAddToCart(product)}
+          style={{
+            minHeight: '96px',
+            borderRadius: '12px',
+            border: '1px solid var(--pe-border)',
+            background: 'var(--pe-bg-card)',
+            color: 'var(--pe-text)',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+            cursor: 'pointer',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '12px',
+            gap: '6px',
+            width: '100%',
+          }}
+        >
+          <span style={{ fontWeight: 'bold', fontSize: '14px' }}>{product.name}</span>
+          <span style={{ fontSize: '13px', color: 'var(--pe-cyan-bright)' }}>
+            {parseFloat(product.price).toFixed(2)} €
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <div>
+      {/* Category filter bar */}
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+        {categories.map((cat) => (
+          <button
+            key={cat.id}
+            onClick={() => onCategoryChange(cat.id)}
+            style={{
+              flex: 1,
+              minHeight: '64px',
+              borderRadius: '12px',
+              border: '1px solid var(--pe-border)',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              fontWeight: 'bold',
+              fontSize: '15px',
+              cursor: 'pointer',
+              background: categoryFilter === cat.id ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)',
+              color: categoryFilter === cat.id ? 'var(--pe-text)' : 'var(--pe-text-sub)',
+            }}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Product grid — dimmed and non-interactive when blocked */}
+      {isBlocked ? (
+        <div style={{ opacity: 0.4, pointerEvents: 'none' }}>{gridContent}</div>
+      ) : gridContent}
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/RegisterGuestCard.jsx
+++ b/frontend/src/components/gastro/RegisterGuestCard.jsx
@@ -37,7 +37,7 @@ export default function RegisterGuestCard({ guest, isSettled, onSettle, submitti
       {/* Item table */}
       <table style={{ width: '100%', borderCollapse: 'collapse' }}>
         <thead>
-          <tr style={{ background: 'rgba(255,255,255,0.03)' }}>
+          <tr style={{ background: 'var(--pe-bg-elevated)' }}>
             <th
               style={{
                 textAlign: 'left',

--- a/frontend/src/components/gastro/RegisterGuestCard.jsx
+++ b/frontend/src/components/gastro/RegisterGuestCard.jsx
@@ -1,0 +1,139 @@
+// RegisterGuestCard — individual guest card for the Kasse (register) view
+export default function RegisterGuestCard({ guest, isSettled, onSettle, submitting }) {
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{
+        background: isSettled ? 'rgba(0,229,160,0.08)' : 'var(--pe-bg-card)',
+        border: isSettled ? '1px solid var(--pe-success)' : '1px solid var(--pe-border)',
+        transition: 'all 0.3s',
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}
+    >
+      {/* Guest header */}
+      <div
+        style={{
+          padding: '12px 16px',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          borderBottom: '1px solid var(--pe-border)',
+        }}
+      >
+        <span style={{ fontWeight: 'bold', fontSize: '16px', color: 'var(--pe-text)' }}>
+          {guest.guest_name || 'Gast'}
+        </span>
+        <span
+          style={{
+            fontWeight: 'bold',
+            fontSize: '20px',
+            color: isSettled ? 'var(--pe-success)' : 'var(--pe-cyan-bright)',
+          }}
+        >
+          {isSettled ? '✓ Abgerechnet' : `${parseFloat(guest.total || 0).toFixed(2)} €`}
+        </span>
+      </div>
+
+      {/* Item table */}
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr style={{ background: 'rgba(255,255,255,0.03)' }}>
+            <th
+              style={{
+                textAlign: 'left',
+                padding: '8px 16px',
+                fontSize: '11px',
+                color: 'var(--pe-text-muted)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+              }}
+            >
+              Artikel
+            </th>
+            <th
+              style={{
+                textAlign: 'center',
+                padding: '8px 16px',
+                fontSize: '11px',
+                color: 'var(--pe-text-muted)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                width: '64px',
+              }}
+            >
+              Menge
+            </th>
+            <th
+              style={{
+                textAlign: 'right',
+                padding: '8px 16px',
+                fontSize: '11px',
+                color: 'var(--pe-text-muted)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                width: '96px',
+              }}
+            >
+              Preis
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {(guest.items || []).map((item, i) => (
+            <tr key={i} style={{ borderTop: '1px solid var(--pe-border)' }}>
+              <td style={{ padding: '10px 16px', fontSize: '14px', color: 'var(--pe-text)' }}>
+                {item.product_name}
+              </td>
+              <td
+                style={{
+                  padding: '10px 16px',
+                  fontSize: '14px',
+                  color: 'var(--pe-text)',
+                  textAlign: 'center',
+                }}
+              >
+                {item.quantity}
+              </td>
+              <td
+                style={{
+                  padding: '10px 16px',
+                  fontSize: '14px',
+                  color: 'var(--pe-text-sub)',
+                  textAlign: 'right',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {parseFloat(item.total).toFixed(2)} €
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Settle button */}
+      {!isSettled && (
+        <div style={{ padding: '12px 16px' }}>
+          <button
+            onClick={onSettle}
+            disabled={submitting}
+            style={{
+              width: '100%',
+              minHeight: '64px',
+              borderRadius: '12px',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              fontWeight: 'bold',
+              border: 'none',
+              cursor: submitting ? 'not-allowed' : 'pointer',
+              background: 'var(--pe-success)',
+              color: '#000',
+              fontSize: '15px',
+              opacity: submitting ? 0.6 : 1,
+            }}
+          >
+            Jetzt abrechnen
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/RegisterView.jsx
+++ b/frontend/src/components/gastro/RegisterView.jsx
@@ -1,0 +1,58 @@
+// RegisterView — Kasse (register) tab: shows all guests with open orders + settle actions
+import { useState } from 'react';
+import GuestSearchInput from './GuestSearchInput';
+import RegisterGuestCard from './RegisterGuestCard';
+
+export default function RegisterView({ guestOrders, settledIds, onSettle, loading }) {
+  const [search, setSearch] = useState('');
+
+  const filtered = guestOrders.filter(
+    (g) => !search || g.guest_name?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div style={{ fontFamily: 'Verdana, Geneva, sans-serif' }}>
+      {/* Search input */}
+      <div style={{ marginBottom: '16px' }}>
+        <GuestSearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Gast suchen…"
+        />
+      </div>
+
+      {/* Loading state */}
+      {loading && guestOrders.length === 0 && (
+        <p style={{ color: 'var(--pe-text-sub)', textAlign: 'center' }}>
+          Lade Bestellungen…
+        </p>
+      )}
+
+      {/* Empty state */}
+      {!loading && guestOrders.length === 0 && (
+        <p
+          style={{
+            color: 'var(--pe-text-muted)',
+            padding: '32px 0',
+            textAlign: 'center',
+          }}
+        >
+          Keine offenen Bestellungen
+        </p>
+      )}
+
+      {/* Guest cards */}
+      <div className="space-y-3">
+        {filtered.map((g) => (
+          <RegisterGuestCard
+            key={g.guest_id}
+            guest={g}
+            isSettled={settledIds.has(g.guest_id)}
+            onSettle={() => onSettle(g)}
+            submitting={false}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/RegisterView.jsx
+++ b/frontend/src/components/gastro/RegisterView.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import GuestSearchInput from './GuestSearchInput';
 import RegisterGuestCard from './RegisterGuestCard';
 
-export default function RegisterView({ guestOrders, settledIds, onSettle, loading }) {
+export default function RegisterView({ guestOrders, settledIds, onSettle, loading, submitting }) {
   const [search, setSearch] = useState('');
 
   const filtered = guestOrders.filter(
@@ -49,7 +49,7 @@ export default function RegisterView({ guestOrders, settledIds, onSettle, loadin
             guest={g}
             isSettled={settledIds.has(g.guest_id)}
             onSettle={() => onSettle(g)}
-            submitting={false}
+            submitting={submitting}
           />
         ))}
       </div>

--- a/frontend/src/components/gastro/SettleDialog.jsx
+++ b/frontend/src/components/gastro/SettleDialog.jsx
@@ -1,0 +1,91 @@
+// Extracted from GastronomyPage — shared settle confirmation dialog
+// Props: guest, total, onConfirm, onCancel
+
+export default function SettleDialog({ guest, total, onConfirm, onCancel }) {
+  return (
+    <div
+      onClick={onCancel}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.75)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+        padding: '16px',
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: 'var(--pe-bg-card)',
+          border: '1px solid var(--pe-border)',
+          borderRadius: '16px',
+          padding: '24px',
+          width: 'min(480px, 90vw)',
+          fontFamily: 'Verdana, Geneva, sans-serif',
+        }}
+      >
+        <h3 style={{ color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '18px', margin: '0 0 8px' }}>
+          Abrechnung bestätigen
+        </h3>
+        <p style={{ color: 'var(--pe-text-sub)', fontSize: '14px', margin: '0 0 20px' }}>
+          Gast <strong style={{ color: 'var(--pe-text)' }}>{guest.guest_name || guest.name || 'Gast'}</strong> jetzt abrechnen?
+        </p>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '12px 0',
+            borderTop: '1px solid var(--pe-border)',
+            borderBottom: '1px solid var(--pe-border)',
+            marginBottom: '20px',
+          }}
+        >
+          <span style={{ color: 'var(--pe-text-sub)', fontSize: '14px' }}>Gesamtbetrag</span>
+          <span style={{ color: 'var(--pe-success)', fontWeight: 'bold', fontSize: '22px' }}>
+            {parseFloat(total || 0).toFixed(2)} EUR
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: '10px' }}>
+          <button
+            onClick={onCancel}
+            style={{
+              flex: 1,
+              minHeight: '64px',
+              borderRadius: '12px',
+              border: '1px solid var(--pe-border)',
+              background: 'var(--pe-bg-elevated)',
+              color: 'var(--pe-text)',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              fontWeight: 'bold',
+              fontSize: '15px',
+              cursor: 'pointer',
+            }}
+          >
+            Abbrechen
+          </button>
+          <button
+            onClick={onConfirm}
+            style={{
+              flex: 1,
+              minHeight: '64px',
+              borderRadius: '12px',
+              border: 'none',
+              background: 'var(--pe-success)',
+              color: '#000',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              fontWeight: 'bold',
+              fontSize: '15px',
+              cursor: 'pointer',
+            }}
+          >
+            Abrechnen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/gastro/StationSelector.jsx
+++ b/frontend/src/components/gastro/StationSelector.jsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+
+const stations = [
+  {
+    id: 'bar',
+    emoji: '🍺',
+    label: 'Bar',
+    description: 'Bestellungen aufnehmen',
+    accent: 'var(--pe-cyan-bright)',
+  },
+  {
+    id: 'kitchen',
+    emoji: '🍳',
+    label: 'Küche',
+    description: 'Küchen-Tickets verwalten',
+    accent: 'var(--pe-warning)',
+  },
+  {
+    id: 'register',
+    emoji: '💳',
+    label: 'Kasse',
+    description: 'Gäste abrechnen',
+    accent: 'var(--pe-success)',
+  },
+];
+
+export default function StationSelector({ onSelect }) {
+  const [hovered, setHovered] = useState(null);
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        background: 'var(--pe-bg)',
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}
+    >
+      {/* Header */}
+      <img src="/logo.png" alt="Logo" style={{ height: 56, marginBottom: 16 }} />
+      <h1
+        style={{
+          color: 'var(--pe-text)',
+          fontSize: 22,
+          fontWeight: 'bold',
+          margin: 0,
+        }}
+      >
+        Station wählen
+      </h1>
+      <p
+        style={{
+          color: 'var(--pe-text-sub)',
+          fontSize: 14,
+          margin: '8px 0 0',
+        }}
+      >
+        Wähle deine Station für diese Schicht
+      </p>
+
+      {/* Responsive grid via style tag */}
+      <style>{`
+        .station-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: 16px;
+          width: 100%;
+          max-width: 480px;
+          margin-top: 32px;
+        }
+        @media (min-width: 768px) {
+          .station-grid {
+            grid-template-columns: repeat(3, 1fr);
+            max-width: 720px;
+          }
+        }
+      `}</style>
+
+      <div className="station-grid">
+        {stations.map((station) => {
+          const isHovered = hovered === station.id;
+          return (
+            <button
+              key={station.id}
+              onClick={() => onSelect(station.id)}
+              onMouseEnter={() => setHovered(station.id)}
+              onMouseLeave={() => setHovered(null)}
+              style={{
+                minHeight: 140,
+                borderRadius: 16,
+                border: `1px solid ${isHovered ? station.accent : 'var(--pe-border)'}`,
+                background: isHovered ? 'var(--pe-bg-elevated)' : 'var(--pe-bg-card)',
+                color: 'var(--pe-text)',
+                fontFamily: 'Verdana, Geneva, sans-serif',
+                cursor: 'pointer',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 12,
+                padding: 20,
+                width: '100%',
+                transition: 'background 0.2s, border-color 0.2s',
+              }}
+            >
+              <span style={{ fontSize: 40, lineHeight: 1 }}>{station.emoji}</span>
+              <span style={{ fontSize: 18, fontWeight: 'bold' }}>{station.label}</span>
+              <span style={{ fontSize: 12, color: 'var(--pe-text-sub)' }}>
+                {station.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/nfc/NFCScanner.jsx
+++ b/frontend/src/components/nfc/NFCScanner.jsx
@@ -47,7 +47,7 @@ export default function NFCScanner({ onScan, scanning }) {
         <div>
           <button
             onClick={startNFC}
-            disabled={nfcStatus === 'reading' || scanning}
+            disabled={nfcStatus === 'reading' || nfcStatus === 'error' || scanning}
             style={{
               background: 'none',
               border: 'none',
@@ -120,8 +120,9 @@ export default function NFCScanner({ onScan, scanning }) {
 
       <style>{`
         @keyframes pulse {
-          0%, 100% { box-shadow: 0 0 0 0 rgba(0, 184, 255, 0.4); }
-          50% { box-shadow: 0 0 0 20px rgba(0, 184, 255, 0); }
+          0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--pe-cyan-bright) 40%, transparent); }
+          70% { box-shadow: 0 0 0 20px transparent; }
+          100% { box-shadow: 0 0 0 0 transparent; }
         }
       `}</style>
     </div>

--- a/frontend/src/components/nfc/NFCScanner.jsx
+++ b/frontend/src/components/nfc/NFCScanner.jsx
@@ -81,12 +81,15 @@ export default function NFCScanner({ onScan, scanning }) {
               onClick={() => setNfcStatus('idle')}
               style={{
                 marginTop: '1rem',
+                minHeight: '64px',
+                padding: '0 20px',
                 color: 'var(--pe-cyan-bright)',
-                background: 'none',
-                border: 'none',
+                background: 'var(--pe-bg-elevated)',
+                border: '1px solid var(--pe-cyan-bright)',
+                borderRadius: '12px',
                 cursor: 'pointer',
-                textDecoration: 'underline',
                 fontFamily: 'Verdana, Geneva, sans-serif',
+                fontWeight: 'bold',
                 fontSize: '0.875rem',
               }}
             >

--- a/frontend/src/components/nfc/NFCScanner.jsx
+++ b/frontend/src/components/nfc/NFCScanner.jsx
@@ -1,14 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export default function NFCScanner({ onScan, scanning }) {
   const [nfcSupported, setNfcSupported] = useState(false);
   const [nfcStatus, setNfcStatus] = useState('idle'); // 'idle' | 'reading' | 'error'
   const [errorMessage, setErrorMessage] = useState('');
+  const ndefRef = useRef(null);
+  const abortRef = useRef(null);
 
   useEffect(() => {
     if ('NDEFReader' in window) {
       setNfcSupported(true);
     }
+    return () => { abortRef.current?.abort(); };
   }, []);
 
   const startNFC = async () => {
@@ -16,13 +19,17 @@ export default function NFCScanner({ onScan, scanning }) {
     try {
       setNfcStatus('reading');
       setErrorMessage('');
+      abortRef.current?.abort(); // clean up any previous scan session
+      abortRef.current = new AbortController();
       const ndef = new window.NDEFReader();
-      await ndef.scan();
+      ndefRef.current = ndef;
+      await ndef.scan({ signal: abortRef.current.signal });
       ndef.addEventListener('reading', ({ serialNumber }) => {
         onScan(serialNumber);
         setNfcStatus('idle');
-      });
+      }, { signal: abortRef.current.signal }); // listener is removed automatically when aborted
     } catch (err) {
+      if (err.name === 'AbortError') return; // ignore clean aborts
       setNfcStatus('error');
       setErrorMessage(err?.message || 'NFC konnte nicht gestartet werden.');
     }

--- a/frontend/src/components/nfc/NFCScanner.jsx
+++ b/frontend/src/components/nfc/NFCScanner.jsx
@@ -2,58 +2,117 @@ import { useState, useEffect } from 'react';
 
 export default function NFCScanner({ onScan, scanning }) {
   const [nfcSupported, setNfcSupported] = useState(false);
-  const [nfcStatus, setNfcStatus] = useState('idle');
+  const [nfcStatus, setNfcStatus] = useState('idle'); // 'idle' | 'reading' | 'error'
+  const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
     if ('NDEFReader' in window) {
       setNfcSupported(true);
-      startNFC();
     }
   }, []);
 
   const startNFC = async () => {
+    if (nfcStatus !== 'idle') return;
     try {
       setNfcStatus('reading');
+      setErrorMessage('');
       const ndef = new window.NDEFReader();
       await ndef.scan();
       ndef.addEventListener('reading', ({ serialNumber }) => {
         onScan(serialNumber);
+        setNfcStatus('idle');
       });
-    } catch {
+    } catch (err) {
       setNfcStatus('error');
+      setErrorMessage(err?.message || 'NFC konnte nicht gestartet werden.');
     }
+  };
+
+  const statusText = () => {
+    if (scanning) return 'Wird verarbeitet...';
+    if (nfcStatus === 'reading') return 'NFC aktiv \u2013 Chip heranhalten';
+    if (nfcStatus === 'error') return errorMessage || 'Fehler beim NFC-Scan';
+    return 'Tippen zum Starten';
+  };
+
+  const circleColor = () => {
+    if (nfcStatus === 'error') return 'var(--pe-danger)';
+    if (nfcStatus === 'reading') return 'var(--pe-cyan-bright)';
+    return 'var(--pe-blue-mid)';
   };
 
   return (
     <div className="text-center">
       {nfcSupported ? (
         <div>
-          <div
-            className="w-32 h-32 mx-auto rounded-full flex items-center justify-center mb-6"
+          <button
+            onClick={startNFC}
+            disabled={nfcStatus === 'reading' || scanning}
             style={{
-              background: 'var(--pe-bg-elevated)',
-              border: '2px solid var(--pe-cyan-bright)',
-              animation: nfcStatus === 'reading' ? 'pulse 2s infinite' : 'none',
+              background: 'none',
+              border: 'none',
+              cursor: nfcStatus === 'idle' && !scanning ? 'pointer' : 'default',
+              padding: 0,
+              display: 'block',
+              margin: '0 auto 1.5rem',
             }}
+            aria-label={statusText()}
           >
-            <span className="text-4xl" style={{ color: 'var(--pe-cyan-bright)' }}>NFC</span>
-          </div>
-          <p style={{ color: 'var(--pe-text-sub)' }}>
-            {scanning ? 'Wird verarbeitet...' : 'Halte NFC-Tag ans Geraet'}
+            <div
+              className="w-32 h-32 rounded-full flex items-center justify-center"
+              style={{
+                width: '8rem',
+                height: '8rem',
+                minWidth: '64px',
+                minHeight: '64px',
+                background: 'var(--pe-bg-elevated)',
+                border: `2px solid ${circleColor()}`,
+                animation: nfcStatus === 'reading' ? 'pulse 2s infinite' : 'none',
+              }}
+            >
+              <span className="text-4xl" style={{ color: circleColor(), fontFamily: 'Verdana, Geneva, sans-serif' }}>NFC</span>
+            </div>
+          </button>
+          <p style={{ color: nfcStatus === 'error' ? 'var(--pe-danger)' : 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif' }}>
+            {statusText()}
           </p>
+          {nfcStatus === 'error' && (
+            <button
+              onClick={() => setNfcStatus('idle')}
+              style={{
+                marginTop: '1rem',
+                color: 'var(--pe-cyan-bright)',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                textDecoration: 'underline',
+                fontFamily: 'Verdana, Geneva, sans-serif',
+                fontSize: '0.875rem',
+              }}
+            >
+              Erneut versuchen
+            </button>
+          )}
         </div>
       ) : (
         <div>
           <div
             className="w-32 h-32 mx-auto rounded-full flex items-center justify-center mb-6"
-            style={{ background: 'var(--pe-bg-elevated)', border: '2px solid var(--pe-text-muted)' }}
+            style={{
+              width: '8rem',
+              height: '8rem',
+              minWidth: '64px',
+              minHeight: '64px',
+              background: 'var(--pe-bg-elevated)',
+              border: '2px solid var(--pe-text-muted)',
+            }}
           >
-            <span className="text-4xl" style={{ color: 'var(--pe-text-muted)' }}>QR</span>
+            <span className="text-4xl" style={{ color: 'var(--pe-text-muted)', fontFamily: 'Verdana, Geneva, sans-serif' }}>QR</span>
           </div>
-          <p className="mb-4" style={{ color: 'var(--pe-text-sub)' }}>
+          <p className="mb-4" style={{ color: 'var(--pe-text-sub)', fontFamily: 'Verdana, Geneva, sans-serif' }}>
             NFC nicht verfuegbar. Nutze einen QR-Code mit UID-Parameter.
           </p>
-          <p className="text-sm" style={{ color: 'var(--pe-text-muted)' }}>
+          <p className="text-sm" style={{ color: 'var(--pe-text-muted)', fontFamily: 'Verdana, Geneva, sans-serif' }}>
             URL-Format: /nfc?uid=DEIN_CODE
           </p>
         </div>

--- a/frontend/src/components/order/Cart.jsx
+++ b/frontend/src/components/order/Cart.jsx
@@ -22,7 +22,7 @@ export default function Cart({ items, onRemove, onSubmit }) {
               <button
                 onClick={() => onRemove(item.product_id)}
                 className="rounded-full flex items-center justify-center text-xs font-bold"
-                style={{ background: 'var(--pe-bg-card)', color: 'var(--pe-danger)', fontFamily: 'var(--pe-font-body)', width: '44px', height: '44px', minWidth: '44px', padding: '10px', boxSizing: 'content-box' }}
+                style={{ background: 'var(--pe-bg-card)', color: 'var(--pe-danger)', fontFamily: 'Verdana, Geneva, sans-serif', width: '64px', height: '64px', minWidth: '64px', borderRadius: '50%', border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '18px', fontWeight: 'bold' }}
               >
                 -
               </button>

--- a/frontend/src/components/order/ProductList.jsx
+++ b/frontend/src/components/order/ProductList.jsx
@@ -1,3 +1,4 @@
+// TODO: superseded by gastro/ProductGrid.jsx — remove after audit
 import { useState } from 'react';
 
 const categories = [

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -6,6 +6,7 @@ import NFCScanner from '../components/nfc/NFCScanner';
 import GuestHeader from '../components/gastro/GuestHeader';
 import OpenOrdersPanel from '../components/gastro/OpenOrdersPanel';
 import RegisterView from '../components/gastro/RegisterView';
+import ProductGrid from '../components/gastro/ProductGrid';
 import { useToastStore } from '../store/toasts';
 import { useStore } from '../store';
 
@@ -459,12 +460,10 @@ export default function GastronomyPage() {
   // Station-based category restriction: bar=drink, kueche=food, kasse=all
   const stationCategory = station === 'bar' ? 'drink' : station === 'kueche' ? 'food' : null;
 
-  const filteredProducts = products.filter((p) => {
+  // Station-level filtering only; ProductGrid handles the categoryFilter tab internally
+  const stationFilteredProducts = products.filter((p) => {
     if (!p.available) return false;
-    // Apply station restriction first
     if (stationCategory && p.category !== stationCategory) return false;
-    // Then apply manual tab filter (but only if it makes sense given the station)
-    if (productFilter !== 'all' && p.category !== productFilter) return false;
     return true;
   });
 
@@ -636,40 +635,14 @@ export default function GastronomyPage() {
                   <OpenOrdersPanel items={guestOpenOrders.items} total={guestOpenOrders.total} />
                 )}
 
-                {/* Kategorien-Tabs */}
-                <div className="flex gap-2 mb-3">
-                  {[{ id: 'all', label: 'Alle' }, { id: 'drink', label: 'Getränke' }, { id: 'food', label: 'Speisen' }].map((cat) => (
-                    <button
-                      key={cat.id}
-                      onClick={() => setProductFilter(cat.id)}
-                      style={{
-                        ...btnStyle,
-                        padding: '8px 16px',
-                        minHeight: '64px',
-                        background: productFilter === cat.id ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)',
-                        color: productFilter === cat.id ? 'var(--pe-text)' : 'var(--pe-text-sub)',
-                      }}
-                    >
-                      {cat.label}
-                    </button>
-                  ))}
-                </div>
-
-                {/* Produkt-Buttons */}
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-3" style={{ opacity: isBlocked ? 0.4 : 1, pointerEvents: isBlocked ? 'none' : undefined }}>
-                  {filteredProducts.map((product) => (
-                    <button
-                      key={product.id}
-                      onClick={() => addToCart(product)}
-                      disabled={isBlocked}
-                      className="flex flex-col items-center justify-center p-3"
-                      style={{ ...btnStyle, minHeight: '80px', background: 'var(--pe-bg-card)', color: 'var(--pe-text)' }}
-                    >
-                      <span className="text-sm font-bold mb-1">{product.name}</span>
-                      <span className="text-xs" style={{ color: 'var(--pe-cyan-bright)' }}>{parseFloat(product.price).toFixed(2)} €</span>
-                    </button>
-                  ))}
-                </div>
+                {/* Product grid with category filter */}
+                <ProductGrid
+                  products={stationFilteredProducts}
+                  onAddToCart={addToCart}
+                  isBlocked={isBlocked}
+                  categoryFilter={productFilter}
+                  onCategoryChange={setProductFilter}
+                />
               </div>
 
               {/* NEU: Rechte Seite — Warenkorb (nur Bestellen, kein Abrechnen) */}

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { api } from '../api/client';
 import NFCScanner from '../components/nfc/NFCScanner';
+import GuestHeader from '../components/gastro/GuestHeader';
 import { useToastStore } from '../store/toasts';
 import { useStore } from '../store';
 
@@ -619,64 +620,14 @@ export default function GastronomyPage() {
               {/* NEU: Linke Seite — Gast-Info + offene Bestellungen + Produkte */}
               <div className="flex-1">
                 {/* Gast-Header */}
-                {/* Gast-Header */}
-                <div className="mb-4 p-3 rounded-xl" style={{ background: 'var(--pe-bg-card)', border: `1px solid ${isBlocked ? 'var(--pe-danger)' : 'var(--pe-border)'}` }}>
-                      {/* Zeile 1: Name + Badge + Schließen */}
-                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px', marginBottom: '10px' }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flex: 1, minWidth: 0 }}>
-                          <div>
-                            <p style={{ fontWeight: 'bold', color: 'var(--pe-text)', margin: 0, fontSize: '15px' }}>{guest.name || 'Gast'}</p>
-                            <p style={{ fontSize: '11px', color: 'var(--pe-text-muted)', margin: '2px 0 0' }}>#{guest.id}</p>
-                          </div>
-                          {/* Status-Badge */}
-                          <span
-                            style={{
-                              flexShrink: 0,
-                              padding: '4px 12px',
-                              borderRadius: '20px',
-                              fontSize: '12px',
-                              fontWeight: 'bold',
-                              color: isBlocked ? 'var(--pe-danger)' : 'var(--pe-success)',
-                              border: `1px solid ${isBlocked ? 'var(--pe-danger)' : 'var(--pe-success)'}`,
-                              background: isBlocked ? 'rgba(255,69,96,0.12)' : 'rgba(0,229,160,0.10)',
-                            }}
-                          >
-                            {isBlocked ? 'Gesperrt' : 'Aktiv'}
-                          </span>
-                        </div>
-                        <button
-                          onClick={() => { setGuest(null); setCart([]); setGuestOpenOrders(null); }}
-                          style={{ ...btnStyle, minHeight: '64px', padding: '0 16px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-text-sub)', border: '1px solid var(--pe-border)', flexShrink: 0 }}
-                        >
-                          ✕ Schließen
-                        </button>
-                      </div>
-                      {/* Zeile 2: Sperren/Entsperren */}
-                      <button
-                        onClick={toggleGuestLock}
-                        disabled={lockLoading}
-                        style={{
-                          ...btnStyle,
-                          width: '100%',
-                          minHeight: '64px',
-                          background: isBlocked ? 'rgba(0,229,160,0.12)' : 'rgba(255,69,96,0.12)',
-                          color: isBlocked ? 'var(--pe-success)' : 'var(--pe-danger)',
-                          border: `1px solid ${isBlocked ? 'var(--pe-success)' : 'var(--pe-danger)'}`,
-                          fontSize: '13px',
-                          opacity: lockLoading ? 0.6 : 1,
-                        }}
-                      >
-                        {lockLoading
-                          ? (isBlocked ? 'Wird entsperrt...' : 'Wird gesperrt...')
-                          : (isBlocked ? 'Armband entsperren' : 'Armband sperren')}
-                      </button>
-                      {/* Hinweis wenn gesperrt */}
-                      {isBlocked && (
-                        <p style={{ margin: '8px 0 0', fontSize: '13px', color: 'var(--pe-danger)', fontWeight: 'bold', textAlign: 'center' }}>
-                          Armband gesperrt — keine Bestellungen möglich
-                        </p>
-                      )}
-                </div>
+                <GuestHeader
+                  guest={guest}
+                  isBlocked={isBlocked}
+                  onClose={() => { setGuest(null); setCart([]); }}
+                  onToggleLock={toggleGuestLock}
+                  lockLoading={lockLoading}
+                  onSettle={() => initSettle(guest)}
+                />
 
                 {/* Bereits offene Bestellungen dieses Gastes */}
                 {guestOpenOrders && guestOpenOrders.items?.length > 0 && (

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -1,236 +1,23 @@
-// NEU: Gastronomie-Seite — iPad/Tablet optimiert, NFC-Scan + Bestellung + Kassen-Ansicht
+// GastronomyPage — station-split architecture
+// Stations: 'bar' (drinks + ordering), 'kitchen' (food tickets), 'register' (settle)
 import { useEffect, useState, useCallback } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
 import { api } from '../api/client';
+import GastronomyLogin from '../components/gastro/GastronomyLogin';
+import StationSelector from '../components/gastro/StationSelector';
+import KitchenView from '../components/gastro/KitchenView';
+import RegisterView from '../components/gastro/RegisterView';
 import GuestSelector from '../components/gastro/GuestSelector';
 import GuestHeader from '../components/gastro/GuestHeader';
 import OpenOrdersPanel from '../components/gastro/OpenOrdersPanel';
-import RegisterView from '../components/gastro/RegisterView';
 import ProductGrid from '../components/gastro/ProductGrid';
+import OrderCart from '../components/gastro/OrderCart';
+import SettleDialog from '../components/gastro/SettleDialog';
 import { useToastStore } from '../store/toasts';
 import { useStore } from '../store';
-
-// NEU: Gastronomy Login (nur gastronomy + admin)
-function GastronomyLogin({ onLogin }) {
-  const [form, setForm] = useState({ username: '', password: '' });
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setLoading(true);
-    setError('');
-    try {
-      const data = await api.post('/auth/login', form);
-      if (!['admin', 'gastronomy'].includes(data.user?.role)) {
-        setError('Keine Berechtigung für die Gastronomie.');
-        return;
-      }
-      onLogin(data.token);
-    } catch (err) {
-      setError(err.message || 'Login fehlgeschlagen');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const inp = { background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)', minHeight: '64px', borderRadius: '12px', padding: '0 16px', width: '100%', outline: 'none', fontSize: '16px' };
-
-  return (
-    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '16px', fontFamily: 'var(--pe-font-body)' }}>
-      <div style={{ width: '100%', maxWidth: '380px' }}>
-        <div style={{ textAlign: 'center', marginBottom: '32px' }}>
-          <img src="/logo.jpeg" alt="DartEvent" style={{ height: '64px', marginBottom: '16px' }} />
-          <h1 style={{ background: 'var(--pe-gradient)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent', fontWeight: 'bold', fontSize: '20px' }}>Gastronomie</h1>
-        </div>
-        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-          <input type="text" value={form.username} onChange={e => setForm({...form, username: e.target.value})} placeholder="Benutzername" style={inp} />
-          <input type="password" value={form.password} onChange={e => setForm({...form, password: e.target.value})} placeholder="Passwort" style={inp} />
-          {error && <p style={{ color: 'var(--pe-danger)', fontSize: '14px', textAlign: 'center' }}>{error}</p>}
-          <button type="submit" disabled={loading || !form.username || !form.password} style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', border: 'none', borderRadius: '12px', padding: '16px', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '16px', cursor: 'pointer', minHeight: '64px', opacity: loading ? 0.6 : 1 }}>
-            {loading ? 'Anmelden...' : 'Anmelden'}
-          </button>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-// Bestätigungs-Dialog vor Abrechnung
-function SettleConfirmDialog({ guest, total, onConfirm, onCancel }) {
-  return (
-    <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.75)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100, padding: '16px' }}>
-      <div style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', borderRadius: '16px', padding: '24px', maxWidth: '380px', width: '100%', fontFamily: 'var(--pe-font-body)' }}>
-        <h3 style={{ color: 'var(--pe-text)', fontWeight: 'bold', fontSize: '18px', margin: '0 0 8px' }}>Abrechnung bestätigen</h3>
-        <p style={{ color: 'var(--pe-text-sub)', fontSize: '14px', margin: '0 0 20px' }}>
-          Gast <strong style={{ color: 'var(--pe-text)' }}>{guest.guest_name || guest.name || 'Gast'}</strong> jetzt abrechnen?
-        </p>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '12px 0', borderTop: '1px solid var(--pe-border)', borderBottom: '1px solid var(--pe-border)', marginBottom: '20px' }}>
-          <span style={{ color: 'var(--pe-text-sub)', fontSize: '14px' }}>Gesamtbetrag</span>
-          <span style={{ color: 'var(--pe-success)', fontWeight: 'bold', fontSize: '22px' }}>{parseFloat(total || 0).toFixed(2)} EUR</span>
-        </div>
-        <div style={{ display: 'flex', gap: '10px' }}>
-          <button onClick={onCancel} style={{ flex: 1, minHeight: '64px', borderRadius: '12px', border: '1px solid var(--pe-border)', background: 'var(--pe-bg-elevated)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '15px', cursor: 'pointer' }}>
-            Abbrechen
-          </button>
-          <button onClick={onConfirm} style={{ flex: 1, minHeight: '64px', borderRadius: '12px', border: 'none', background: 'var(--pe-success)', color: '#000', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', fontSize: '15px', cursor: 'pointer' }}>
-            Abrechnen
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const btnStyle = {
-  fontFamily: 'var(--pe-font-body)',
-  borderRadius: '12px',
-  fontWeight: 'bold',
-  border: '1px solid var(--pe-border)',
-  cursor: 'pointer',
-};
-
-// Station picker — shown when no station is selected yet
-function StationPicker({ onSelect }) {
-  const stations = [
-    {
-      id: 'bar',
-      label: 'Bar',
-      icon: '🍺',
-      description: 'Getränke',
-      accent: 'var(--pe-cyan-bright)',
-      accentBg: 'rgba(0,184,255,0.10)',
-      accentBorder: 'rgba(0,184,255,0.35)',
-    },
-    {
-      id: 'kueche',
-      label: 'Küche',
-      icon: '🍽️',
-      description: 'Speisen',
-      accent: 'var(--pe-warning)',
-      accentBg: 'rgba(255,176,32,0.10)',
-      accentBorder: 'rgba(255,176,32,0.35)',
-    },
-    {
-      id: 'kasse',
-      label: 'Kasse',
-      icon: '💳',
-      description: 'Alle Artikel',
-      accent: 'var(--pe-success)',
-      accentBg: 'rgba(0,229,160,0.10)',
-      accentBorder: 'rgba(0,229,160,0.35)',
-    },
-  ];
-
-  return (
-    <div
-      style={{
-        minHeight: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '24px 16px',
-        background: 'var(--pe-bg)',
-        fontFamily: 'Verdana, Geneva, sans-serif',
-      }}
-    >
-      <div style={{ marginBottom: '8px', fontSize: '28px', textAlign: 'center' }}>📍</div>
-      <h1
-        style={{
-          color: 'var(--pe-text)',
-          fontWeight: 'bold',
-          fontSize: '22px',
-          margin: '0 0 6px',
-          textAlign: 'center',
-          fontFamily: 'Verdana, Geneva, sans-serif',
-        }}
-      >
-        Station wählen
-      </h1>
-      <p
-        style={{
-          color: 'var(--pe-text-sub)',
-          fontSize: '14px',
-          margin: '0 0 32px',
-          textAlign: 'center',
-          fontFamily: 'Verdana, Geneva, sans-serif',
-        }}
-      >
-        Wähle deine Station
-      </p>
-
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '16px',
-          width: '100%',
-          maxWidth: '420px',
-        }}
-      >
-        {stations.map((s) => (
-          <button
-            key={s.id}
-            onClick={() => onSelect(s.id)}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '20px',
-              minHeight: '130px',
-              padding: '20px 24px',
-              borderRadius: '16px',
-              background: s.accentBg,
-              border: `2px solid ${s.accentBorder}`,
-              cursor: 'pointer',
-              textAlign: 'left',
-              fontFamily: 'Verdana, Geneva, sans-serif',
-              transition: 'transform 0.1s, border-color 0.1s',
-            }}
-            onMouseDown={(e) => { e.currentTarget.style.transform = 'scale(0.98)'; }}
-            onMouseUp={(e) => { e.currentTarget.style.transform = 'scale(1)'; }}
-            onTouchStart={(e) => { e.currentTarget.style.transform = 'scale(0.98)'; }}
-            onTouchEnd={(e) => { e.currentTarget.style.transform = 'scale(1)'; }}
-          >
-            <span style={{ fontSize: '42px', lineHeight: 1, flexShrink: 0 }}>{s.icon}</span>
-            <div>
-              <div
-                style={{
-                  color: s.accent,
-                  fontWeight: 'bold',
-                  fontSize: '22px',
-                  marginBottom: '4px',
-                  fontFamily: 'Verdana, Geneva, sans-serif',
-                }}
-              >
-                {s.label}
-              </div>
-              <div
-                style={{
-                  color: 'var(--pe-text-sub)',
-                  fontSize: '13px',
-                  fontFamily: 'Verdana, Geneva, sans-serif',
-                }}
-              >
-                {s.description}
-              </div>
-            </div>
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
 
 export default function GastronomyPage() {
   const { addToast } = useToastStore();
   const { token, setToken: storeSetToken } = useStore();
-  const [searchParams] = useSearchParams();
-  const tabParam = searchParams.get('tab');
-  // view state: initialized from URL, and kept in sync reactively via useEffect below
-  const [view, setView] = useState(
-    tabParam === 'kasse' ? 'register' : tabParam === 'products' ? 'products' : 'order'
-  );
 
   // Station state — persisted in sessionStorage
   const [station, setStation] = useState(() => {
@@ -247,51 +34,43 @@ export default function GastronomyPage() {
     try { sessionStorage.removeItem('gastro_station'); } catch { /* ignore */ }
   };
 
-  // Keep view in sync when user navigates between tabs (URL changes without unmount)
-  useEffect(() => {
-    setView(tabParam === 'kasse' ? 'register' : tabParam === 'products' ? 'products' : 'order');
-  }, [tabParam]);
-
-  // NEU: Bestellungs-Ansicht State
+  // Bar / ordering state
   const [guest, setGuest] = useState(null);
   const [products, setProducts] = useState([]);
   const [cart, setCart] = useState([]);
   const [productFilter, setProductFilter] = useState('all');
   const [scanning, setScanning] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  // Bereits bestellte offene Artikel des Gastes
   const [guestOpenOrders, setGuestOpenOrders] = useState(null);
   const [orderSuccess, setOrderSuccess] = useState(false);
-  // NEU: Armband sperren/entsperren
   const [lockLoading, setLockLoading] = useState(false);
-
   const [allGuests, setAllGuests] = useState([]);
 
   const isBlocked = guest != null && (guest.active === 0 || guest.active === false);
 
-  // NEU: Kassen-Ansicht State
+  // Register (Kasse) state
   const [guestOrders, setGuestOrders] = useState([]);
   const [registerLoading, setRegisterLoading] = useState(false);
-  // Bestätigungs-Dialog
-  const [settleTarget, setSettleTarget] = useState(null); // { guest_id, guest_name, total }
-  // Erfolgsmeldung nach Abrechnung
   const [settledIds, setSettledIds] = useState(new Set());
 
-  // NEU: Produkte + Gäste laden
+  // Settle dialog
+  const [settleTarget, setSettleTarget] = useState(null);
+
+  // Load products + all guests once token is available
   useEffect(() => {
     if (!token) return;
     api.get('/products').then(setProducts).catch(() => {});
     api.get('/nfc/guests').then(setAllGuests).catch(() => {});
   }, [token]);
 
-  // NEU: Offene Bestellungen des ausgewählten Gastes laden
+  // Load open orders for the currently selected guest
   useEffect(() => {
     if (!token) return;
     if (!guest) { setGuestOpenOrders(null); return; }
     api.get(`/orders/guest/${guest.id}`).then(setGuestOpenOrders).catch(() => setGuestOpenOrders(null));
   }, [token, guest]);
 
-  // NEU: NFC-Scan Handler
+  // NFC scan handler
   const handleNFCScan = async (uid) => {
     setScanning(true);
     try {
@@ -306,7 +85,7 @@ export default function GastronomyPage() {
     }
   };
 
-  // NEU: Produkt zum Warenkorb hinzufügen
+  // Cart helpers
   const addToCart = (product) => {
     setCart((prev) => {
       const existing = prev.find((item) => item.product_id === product.id);
@@ -319,7 +98,6 @@ export default function GastronomyPage() {
     });
   };
 
-  // NEU: Produkt aus Warenkorb entfernen
   const removeFromCart = (productId) => {
     setCart((prev) =>
       prev
@@ -328,7 +106,7 @@ export default function GastronomyPage() {
     );
   };
 
-  // NEU: Bestellung aufgeben
+  // Submit order
   const submitOrder = async () => {
     if (!guest || cart.length === 0) return;
     setSubmitting(true);
@@ -342,7 +120,6 @@ export default function GastronomyPage() {
       }
       setCart([]);
       setOrderSuccess(true);
-      // Offene Bestellungen neu laden
       const updated = await api.get(`/orders/guest/${guest.id}`);
       setGuestOpenOrders(updated);
       setTimeout(() => setOrderSuccess(false), 2000);
@@ -353,60 +130,11 @@ export default function GastronomyPage() {
     }
   };
 
-  // NEU: Abrechnung einleiten (Dialog öffnen)
+  // Settle flow
   const initSettle = (target) => {
     setSettleTarget(target);
   };
 
-  // NEU: Abrechnung durchführen
-  const confirmSettle = async () => {
-    if (!settleTarget) return;
-    setSubmitting(true);
-    const targetId = settleTarget.guest_id || settleTarget.id;
-    try {
-      await api.post(`/orders/settle/${targetId}`);
-      setSettleTarget(null);
-      if (view === 'register') {
-        setSettledIds(prev => new Set([...prev, targetId]));
-        // Kurz anzeigen, dann aus Liste entfernen und neu laden
-        setTimeout(() => {
-          setSettledIds(prev => { const s = new Set(prev); s.delete(targetId); return s; });
-          loadRegister();
-        }, 2000);
-        loadRegister();
-      } else {
-        // "Bestellung"-Ansicht: Gast zurücksetzen
-        setGuest(null);
-        setGuestOpenOrders(null);
-        setCart([]);
-      }
-    } catch (err) {
-      addToast({ type: 'error', message: err.message || 'Abrechnung fehlgeschlagen – bitte erneut versuchen' });
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  // NEU: Armband sperren / entsperren
-  const toggleGuestLock = async () => {
-    if (!guest) return;
-    const isBlocked = guest.active === 0 || guest.active === false;
-    const endpoint = isBlocked ? `/nfc/${guest.nfc_uid}/activate` : `/nfc/${guest.nfc_uid}/deactivate`;
-    setLockLoading(true);
-    try {
-      const updated = await api.put(endpoint);
-      // Merge updated fields back into guest state
-      setGuest((prev) => ({ ...prev, ...updated }));
-      // Also update allGuests list
-      setAllGuests((prev) => prev.map((g) => g.id === guest.id ? { ...g, ...updated } : g));
-    } catch (err) {
-      addToast({ type: 'error', message: err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen' });
-    } finally {
-      setLockLoading(false);
-    }
-  };
-
-  // NEU: Kassen-Daten laden
   const loadRegister = useCallback(async () => {
     setRegisterLoading(true);
     try {
@@ -419,47 +147,102 @@ export default function GastronomyPage() {
     }
   }, []);
 
-  // NEU: Auto-Refresh Kassen-Ansicht alle 10 Sekunden
+  const confirmSettle = async () => {
+    if (!settleTarget) return;
+    setSubmitting(true);
+    const targetId = settleTarget.guest_id || settleTarget.id;
+    try {
+      await api.post(`/orders/settle/${targetId}`);
+      setSettleTarget(null);
+      if (station === 'register') {
+        setSettledIds((prev) => new Set([...prev, targetId]));
+        setTimeout(() => {
+          setSettledIds((prev) => { const s = new Set(prev); s.delete(targetId); return s; });
+          loadRegister();
+        }, 2000);
+        loadRegister();
+      } else {
+        // Bar station: reset guest after settling
+        setGuest(null);
+        setGuestOpenOrders(null);
+        setCart([]);
+      }
+    } catch (err) {
+      addToast({ type: 'error', message: err.message || 'Abrechnung fehlgeschlagen – bitte erneut versuchen' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Lock / unlock guest armband
+  const toggleGuestLock = async () => {
+    if (!guest) return;
+    const blocked = guest.active === 0 || guest.active === false;
+    const endpoint = blocked ? `/nfc/${guest.nfc_uid}/activate` : `/nfc/${guest.nfc_uid}/deactivate`;
+    setLockLoading(true);
+    try {
+      const updated = await api.put(endpoint);
+      setGuest((prev) => ({ ...prev, ...updated }));
+      setAllGuests((prev) => prev.map((g) => g.id === guest.id ? { ...g, ...updated } : g));
+    } catch (err) {
+      addToast({ type: 'error', message: err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen' });
+    } finally {
+      setLockLoading(false);
+    }
+  };
+
+  // Auto-refresh register view every 10 seconds
   useEffect(() => {
     if (!token) return;
-    if (view !== 'register') return;
+    if (station !== 'register') return;
     loadRegister();
     const interval = setInterval(loadRegister, 10000);
     return () => clearInterval(interval);
-  }, [token, view, loadRegister]);
+  }, [token, station, loadRegister]);
 
+  // Login gate
   const handleLogin = (newToken) => {
-    storeSetToken(newToken);    // Zustand: updates role + localStorage → AppShell nav re-renders with correct tabs
+    storeSetToken(newToken);
   };
 
-  if (!token) return (
-    <div style={{
-      position: 'fixed', inset: 0, zIndex: 500,
-      background: 'var(--pe-bg)',
-      display: 'flex', flexDirection: 'column',
-      overflow: 'auto',
-    }}>
-      <GastronomyLogin onLogin={handleLogin} />
-    </div>
-  );
+  if (!token) {
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          zIndex: 500,
+          background: 'var(--pe-bg)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'auto',
+        }}
+      >
+        <GastronomyLogin onLogin={handleLogin} />
+      </div>
+    );
+  }
 
-  // Show station picker if no station selected yet
-  if (station === null) return (
-    <div style={{
-      position: 'fixed', inset: 0, zIndex: 400,
-      background: 'var(--pe-bg)',
-      overflow: 'auto',
-    }}>
-      <StationPicker onSelect={selectStation} />
-    </div>
-  );
+  // Station gate
+  if (!station) {
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          zIndex: 400,
+          background: 'var(--pe-bg)',
+          overflow: 'auto',
+        }}
+      >
+        <StationSelector onSelect={selectStation} />
+      </div>
+    );
+  }
 
-  const cartTotal = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
-
-  // Station-based category restriction: bar=drink, kueche=food, kasse=all
-  const stationCategory = station === 'bar' ? 'drink' : station === 'kueche' ? 'food' : null;
-
-  // Station-level filtering only; ProductGrid handles the categoryFilter tab internally
+  // Station-level product filtering
+  // 'bar' shows drinks only, 'kitchen' and 'register' show all available
+  const stationCategory = station === 'bar' ? 'drink' : null;
   const stationFilteredProducts = products.filter((p) => {
     if (!p.available) return false;
     if (stationCategory && p.category !== stationCategory) return false;
@@ -467,18 +250,18 @@ export default function GastronomyPage() {
   });
 
   // Station badge config
-  const stationBadgeConfig = {
-    bar:    { label: 'Bar',   icon: '🍺', accent: 'var(--pe-cyan-bright)', accentBg: 'rgba(0,184,255,0.12)', accentBorder: 'rgba(0,184,255,0.35)' },
-    kueche: { label: 'Küche', icon: '🍽️', accent: 'var(--pe-warning)',    accentBg: 'rgba(255,176,32,0.12)', accentBorder: 'rgba(255,176,32,0.35)' },
-    kasse:  { label: 'Kasse', icon: '💳', accent: 'var(--pe-success)',    accentBg: 'rgba(0,229,160,0.12)', accentBorder: 'rgba(0,229,160,0.35)' },
+  const badgeConfig = {
+    bar:      { label: 'Bar',   icon: '🍺', accent: 'var(--pe-cyan-bright)', accentBg: 'rgba(0,184,255,0.12)', accentBorder: 'rgba(0,184,255,0.35)' },
+    kitchen:  { label: 'Küche', icon: '🍳', accent: 'var(--pe-warning)',     accentBg: 'rgba(255,176,32,0.12)',  accentBorder: 'rgba(255,176,32,0.35)' },
+    register: { label: 'Kasse', icon: '💳', accent: 'var(--pe-success)',     accentBg: 'rgba(0,229,160,0.12)',  accentBorder: 'rgba(0,229,160,0.35)' },
   };
-  const currentBadge = stationBadgeConfig[station];
+  const badge = badgeConfig[station];
 
   return (
-    <div className="min-h-screen p-4" style={{ fontFamily: 'Verdana, Geneva, sans-serif' }}>
-      {/* Bestätigungs-Dialog */}
+    <div className="min-h-screen" style={{ fontFamily: 'Verdana, Geneva, sans-serif' }}>
+      {/* Settle confirmation dialog — rendered at top level so it works from any station */}
       {settleTarget && (
-        <SettleConfirmDialog
+        <SettleDialog
           guest={settleTarget}
           total={settleTarget.total}
           onConfirm={confirmSettle}
@@ -486,9 +269,19 @@ export default function GastronomyPage() {
         />
       )}
 
-      {/* Station badge */}
-      {currentBadge && (
-        <div className="max-w-5xl mx-auto mb-4" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+      {/* Station header bar: badge + switch button */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '8px 16px',
+          marginBottom: 4,
+          maxWidth: 1200,
+          margin: '0 auto',
+        }}
+      >
+        {badge && (
           <div
             style={{
               display: 'inline-flex',
@@ -496,86 +289,57 @@ export default function GastronomyPage() {
               gap: '8px',
               padding: '8px 14px',
               borderRadius: '20px',
-              background: currentBadge.accentBg,
-              border: `1px solid ${currentBadge.accentBorder}`,
-              fontFamily: 'Verdana, Geneva, sans-serif',
+              background: badge.accentBg,
+              border: `1px solid ${badge.accentBorder}`,
             }}
           >
-            <span style={{ fontSize: '16px' }}>{currentBadge.icon}</span>
-            <span style={{ color: currentBadge.accent, fontWeight: 'bold', fontSize: '14px' }}>
-              {currentBadge.label}
+            <span style={{ fontSize: '16px' }}>{badge.icon}</span>
+            <span style={{ color: badge.accent, fontWeight: 'bold', fontSize: '14px' }}>
+              {badge.label}
             </span>
           </div>
-          <button
-            onClick={clearStation}
-            style={{
-              padding: '8px 14px',
-              borderRadius: '20px',
-              border: '1px solid var(--pe-border)',
-              background: 'var(--pe-bg-elevated)',
-              color: 'var(--pe-text-sub)',
-              fontFamily: 'Verdana, Geneva, sans-serif',
-              fontSize: '12px',
-              cursor: 'pointer',
-              minHeight: '64px',
-            }}
-          >
-            Station wechseln
-          </button>
-        </div>
-      )}
-
-      {/* NEU: View-Toggle — Bestellung | Kasse */}
-      <div className="flex gap-2 mb-6 max-w-5xl mx-auto">
+        )}
         <button
-          onClick={() => setView('order')}
+          onClick={clearStation}
           style={{
-            ...btnStyle,
-            flex: 1,
-            minHeight: '64px',
-            fontSize: '16px',
-            background: view === 'order' ? 'var(--pe-blue-deep)' : 'var(--pe-bg-card)',
-            color: view === 'order' ? 'var(--pe-text)' : 'var(--pe-text-sub)',
+            minHeight: 64,
+            padding: '0 20px',
+            background: 'var(--pe-bg-elevated)',
+            border: '1px solid var(--pe-border)',
+            borderRadius: 12,
+            color: 'var(--pe-text-sub)',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+            fontSize: 14,
+            fontWeight: 'bold',
+            cursor: 'pointer',
           }}
         >
-          Bestellung
-        </button>
-        <button
-          onClick={() => setView('register')}
-          style={{
-            ...btnStyle,
-            flex: 1,
-            minHeight: '64px',
-            fontSize: '16px',
-            background: view === 'register' ? 'var(--pe-blue-deep)' : 'var(--pe-bg-card)',
-            color: view === 'register' ? 'var(--pe-text)' : 'var(--pe-text-sub)',
-          }}
-        >
-          Kasse
+          ⇄ Station wechseln
         </button>
       </div>
 
-      {/* ===== BESTELLUNGS-ANSICHT (Servicekraft) ===== */}
-      {view === 'order' && (
-        <div className="max-w-5xl mx-auto">
-          {!guest && (
-            <GuestSelector
-              guests={allGuests}
-              onGuestSelect={(g) => { setGuest(g); setCart([]); setOrderSuccess(false); }}
-              onCreateGuest={(name) => api.post('/nfc/create-manual', { name })
-                .then((g) => { setGuest(g); setCart([]); setAllGuests((prev) => [...prev, g]); })
-                .catch((err) => addToast({ type: 'error', message: err.message }))}
-              nfcAvailable={'NDEFReader' in window}
-              onRequestNfcScan={handleNFCScan}
-              scanning={scanning}
-            />
-          )}
+      {/* ===== BAR STATION ===== */}
+      {station === 'bar' && (
+        <div className="flex flex-col md:flex-row gap-4 max-w-5xl mx-auto p-4">
+          {/* Left column: guest selector or guest detail + products */}
+          <div className="flex-1 min-w-0">
+            {!guest && (
+              <GuestSelector
+                guests={allGuests}
+                onGuestSelect={(g) => { setGuest(g); setCart([]); setOrderSuccess(false); }}
+                onCreateGuest={(name) =>
+                  api.post('/nfc/create-manual', { name })
+                    .then((g) => { setGuest(g); setCart([]); setAllGuests((prev) => [...prev, g]); })
+                    .catch((err) => addToast({ type: 'error', message: err.message }))
+                }
+                nfcAvailable={'NDEFReader' in window}
+                onRequestNfcScan={handleNFCScan}
+                scanning={scanning}
+              />
+            )}
 
-          {guest && (
-            <div className="flex flex-col lg:flex-row gap-4">
-              {/* NEU: Linke Seite — Gast-Info + offene Bestellungen + Produkte */}
-              <div className="flex-1">
-                {/* Gast-Header */}
+            {guest && (
+              <>
                 <GuestHeader
                   guest={guest}
                   isBlocked={isBlocked}
@@ -585,12 +349,10 @@ export default function GastronomyPage() {
                   onSettle={() => initSettle(guest)}
                 />
 
-                {/* Bereits offene Bestellungen dieses Gastes */}
                 {guestOpenOrders?.items?.length > 0 && (
                   <OpenOrdersPanel items={guestOpenOrders.items} total={guestOpenOrders.total} />
                 )}
 
-                {/* Product grid with category filter */}
                 <ProductGrid
                   products={stationFilteredProducts}
                   onAddToCart={addToCart}
@@ -598,68 +360,36 @@ export default function GastronomyPage() {
                   categoryFilter={productFilter}
                   onCategoryChange={setProductFilter}
                 />
-              </div>
+              </>
+            )}
+          </div>
 
-              {/* NEU: Rechte Seite — Warenkorb (nur Bestellen, kein Abrechnen) */}
-              <div className="lg:w-80">
-                <div className="p-4 rounded-xl" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
-                  <h3 className="text-sm font-bold mb-3" style={{ color: 'var(--pe-text-sub)' }}>
-                    Warenkorb ({cart.reduce((s, i) => s + i.quantity, 0)})
-                  </h3>
-
-                  {cart.length === 0 && (
-                    <p className="text-sm py-4 text-center" style={{ color: 'var(--pe-text-muted)' }}>
-                      {orderSuccess ? '✓ Bestellung gespeichert' : 'Leer — Artikel tippen zum Hinzufügen'}
-                    </p>
-                  )}
-
-                  <div className="space-y-2 max-h-64 overflow-y-auto mb-4">
-                    {cart.map((item) => (
-                      <div key={item.product_id} className="flex justify-between items-center text-sm">
-                        <span style={{ color: 'var(--pe-text)' }}>{item.name} x{item.quantity}</span>
-                        <div className="flex items-center gap-2">
-                          <span style={{ color: 'var(--pe-text-sub)' }}>{(item.price * item.quantity).toFixed(2)} €</span>
-                          <button
-                            onClick={() => removeFromCart(item.product_id)}
-                            className="rounded-full flex items-center justify-center text-xs font-bold"
-                            style={{ background: 'var(--pe-bg-elevated)', color: 'var(--pe-danger)', fontFamily: 'var(--pe-font-body)', width: '44px', height: '44px', minWidth: '44px', padding: '10px', boxSizing: 'content-box' }}
-                          >
-                            -
-                          </button>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-
-                  {cart.length > 0 && (
-                    <div className="flex justify-between items-center mb-4 pt-3" style={{ borderTop: '1px solid var(--pe-border)' }}>
-                      <span className="font-bold" style={{ color: 'var(--pe-text)' }}>Summe:</span>
-                      <span className="font-bold text-lg" style={{ color: 'var(--pe-cyan-bright)' }}>{cartTotal.toFixed(2)} €</span>
-                    </div>
-                  )}
-
-                  <button
-                    onClick={submitOrder}
-                    disabled={cart.length === 0 || submitting || isBlocked}
-                    className="w-full py-4 rounded-xl font-bold text-lg disabled:opacity-50"
-                    style={{ background: isBlocked ? 'var(--pe-bg-elevated)' : 'var(--pe-gradient)', color: isBlocked ? 'var(--pe-danger)' : 'var(--pe-text)', minHeight: '64px', fontFamily: 'var(--pe-font-body)', border: isBlocked ? '1px solid var(--pe-danger)' : 'none', cursor: isBlocked ? 'not-allowed' : 'pointer' }}
-                  >
-                    {isBlocked ? 'Armband gesperrt' : submitting ? 'Wird gespeichert...' : 'Bestellen'}
-                  </button>
-
-                  {orderSuccess && cart.length === 0 && (
-                    <p className="text-center mt-3 text-sm font-bold" style={{ color: 'var(--pe-success)' }}>✓ Bestellung gespeichert!</p>
-                  )}
-                </div>
-              </div>
+          {/* Right column: cart (only when a guest is selected) */}
+          {guest && (
+            <div className="md:w-80 md:flex-shrink-0">
+              <OrderCart
+                items={cart}
+                onAdd={addToCart}
+                onRemove={removeFromCart}
+                onSubmit={submitOrder}
+                submitting={submitting}
+                isBlocked={isBlocked}
+                guestName={guest?.name}
+                orderSuccess={orderSuccess}
+              />
             </div>
           )}
         </div>
       )}
 
-      {/* ===== KASSEN-ANSICHT (Kassier) ===== */}
-      {view === 'register' && (
-        <div className="max-w-5xl mx-auto">
+      {/* ===== KITCHEN STATION ===== */}
+      {station === 'kitchen' && (
+        <KitchenView />
+      )}
+
+      {/* ===== REGISTER (KASSE) STATION ===== */}
+      {station === 'register' && (
+        <div className="max-w-5xl mx-auto p-4">
           <RegisterView
             guestOrders={guestOrders}
             settledIds={settledIds}

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -87,14 +87,17 @@ export default function GastronomyPage() {
 
   // Cart helpers
   const addToCart = (product) => {
+    // Accept both full product objects (product.id) from ProductGrid
+    // and cart item objects (product.product_id) from OrderCartItem's + button
+    const pid = product.id ?? product.product_id;
     setCart((prev) => {
-      const existing = prev.find((item) => item.product_id === product.id);
+      const existing = prev.find((item) => item.product_id === pid);
       if (existing) {
         return prev.map((item) =>
-          item.product_id === product.id ? { ...item, quantity: item.quantity + 1 } : item
+          item.product_id === pid ? { ...item, quantity: item.quantity + 1 } : item
         );
       }
-      return [...prev, { product_id: product.id, name: product.name, price: product.price, quantity: 1 }];
+      return [...prev, { product_id: pid, name: product.name, price: product.price, quantity: 1 }];
     });
   };
 
@@ -276,9 +279,8 @@ export default function GastronomyPage() {
           alignItems: 'center',
           justifyContent: 'space-between',
           padding: '8px 16px',
-          marginBottom: 4,
           maxWidth: 1200,
-          margin: '0 auto',
+          margin: '0 auto 4px',
         }}
       >
         {badge && (
@@ -395,6 +397,7 @@ export default function GastronomyPage() {
             settledIds={settledIds}
             onSettle={initSettle}
             loading={registerLoading}
+            submitting={submitting}
           />
         </div>
       )}

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -86,6 +86,138 @@ const btnStyle = {
   cursor: 'pointer',
 };
 
+// Station picker — shown when no station is selected yet
+function StationPicker({ onSelect }) {
+  const stations = [
+    {
+      id: 'bar',
+      label: 'Bar',
+      icon: '🍺',
+      description: 'Getränke',
+      accent: 'var(--pe-cyan-bright)',
+      accentBg: 'rgba(0,184,255,0.10)',
+      accentBorder: 'rgba(0,184,255,0.35)',
+    },
+    {
+      id: 'kueche',
+      label: 'Küche',
+      icon: '🍽️',
+      description: 'Speisen',
+      accent: 'var(--pe-warning)',
+      accentBg: 'rgba(255,176,32,0.10)',
+      accentBorder: 'rgba(255,176,32,0.35)',
+    },
+    {
+      id: 'kasse',
+      label: 'Kasse',
+      icon: '💳',
+      description: 'Alle Artikel',
+      accent: 'var(--pe-success)',
+      accentBg: 'rgba(0,229,160,0.10)',
+      accentBorder: 'rgba(0,229,160,0.35)',
+    },
+  ];
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '24px 16px',
+        background: 'var(--pe-bg)',
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}
+    >
+      <div style={{ marginBottom: '8px', fontSize: '28px', textAlign: 'center' }}>📍</div>
+      <h1
+        style={{
+          color: 'var(--pe-text)',
+          fontWeight: 'bold',
+          fontSize: '22px',
+          margin: '0 0 6px',
+          textAlign: 'center',
+          fontFamily: 'Verdana, Geneva, sans-serif',
+        }}
+      >
+        Station wählen
+      </h1>
+      <p
+        style={{
+          color: 'var(--pe-text-sub)',
+          fontSize: '14px',
+          margin: '0 0 32px',
+          textAlign: 'center',
+          fontFamily: 'Verdana, Geneva, sans-serif',
+        }}
+      >
+        Wähle deine Station
+      </p>
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          width: '100%',
+          maxWidth: '420px',
+        }}
+      >
+        {stations.map((s) => (
+          <button
+            key={s.id}
+            onClick={() => onSelect(s.id)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '20px',
+              minHeight: '130px',
+              padding: '20px 24px',
+              borderRadius: '16px',
+              background: s.accentBg,
+              border: `2px solid ${s.accentBorder}`,
+              cursor: 'pointer',
+              textAlign: 'left',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              transition: 'transform 0.1s, border-color 0.1s',
+            }}
+            onMouseDown={(e) => { e.currentTarget.style.transform = 'scale(0.98)'; }}
+            onMouseUp={(e) => { e.currentTarget.style.transform = 'scale(1)'; }}
+            onTouchStart={(e) => { e.currentTarget.style.transform = 'scale(0.98)'; }}
+            onTouchEnd={(e) => { e.currentTarget.style.transform = 'scale(1)'; }}
+          >
+            <span style={{ fontSize: '42px', lineHeight: 1, flexShrink: 0 }}>{s.icon}</span>
+            <div>
+              <div
+                style={{
+                  color: s.accent,
+                  fontWeight: 'bold',
+                  fontSize: '22px',
+                  marginBottom: '4px',
+                  fontFamily: 'Verdana, Geneva, sans-serif',
+                }}
+              >
+                {s.label}
+              </div>
+              <div
+                style={{
+                  color: 'var(--pe-text-sub)',
+                  fontSize: '13px',
+                  fontFamily: 'Verdana, Geneva, sans-serif',
+                }}
+              >
+                {s.description}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function GastronomyPage() {
   const { addToast } = useToastStore();
   const { token, setToken: storeSetToken } = useStore();
@@ -95,6 +227,21 @@ export default function GastronomyPage() {
   const [view, setView] = useState(
     tabParam === 'kasse' ? 'register' : tabParam === 'products' ? 'products' : 'order'
   );
+
+  // Station state — persisted in sessionStorage
+  const [station, setStation] = useState(() => {
+    try { return sessionStorage.getItem('gastro_station') || null; } catch { return null; }
+  });
+
+  const selectStation = (s) => {
+    setStation(s);
+    try { sessionStorage.setItem('gastro_station', s); } catch { /* ignore */ }
+  };
+
+  const clearStation = () => {
+    setStation(null);
+    try { sessionStorage.removeItem('gastro_station'); } catch { /* ignore */ }
+  };
 
   // Keep view in sync when user navigates between tabs (URL changes without unmount)
   useEffect(() => {
@@ -293,13 +440,41 @@ export default function GastronomyPage() {
     </div>
   );
 
+  // Show station picker if no station selected yet
+  if (station === null) return (
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 400,
+      background: 'var(--pe-bg)',
+      overflow: 'auto',
+    }}>
+      <StationPicker onSelect={selectStation} />
+    </div>
+  );
+
   const cartTotal = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
-  const filteredProducts = productFilter === 'all'
-    ? products.filter((p) => p.available)
-    : products.filter((p) => p.available && p.category === productFilter);
+
+  // Station-based category restriction: bar=drink, kueche=food, kasse=all
+  const stationCategory = station === 'bar' ? 'drink' : station === 'kueche' ? 'food' : null;
+
+  const filteredProducts = products.filter((p) => {
+    if (!p.available) return false;
+    // Apply station restriction first
+    if (stationCategory && p.category !== stationCategory) return false;
+    // Then apply manual tab filter (but only if it makes sense given the station)
+    if (productFilter !== 'all' && p.category !== productFilter) return false;
+    return true;
+  });
+
+  // Station badge config
+  const stationBadgeConfig = {
+    bar:    { label: 'Bar',   icon: '🍺', accent: 'var(--pe-cyan-bright)', accentBg: 'rgba(0,184,255,0.12)', accentBorder: 'rgba(0,184,255,0.35)' },
+    kueche: { label: 'Küche', icon: '🍽️', accent: 'var(--pe-warning)',    accentBg: 'rgba(255,176,32,0.12)', accentBorder: 'rgba(255,176,32,0.35)' },
+    kasse:  { label: 'Kasse', icon: '💳', accent: 'var(--pe-success)',    accentBg: 'rgba(0,229,160,0.12)', accentBorder: 'rgba(0,229,160,0.35)' },
+  };
+  const currentBadge = stationBadgeConfig[station];
 
   return (
-    <div className="min-h-screen p-4" style={{ fontFamily: 'var(--pe-font-body)' }}>
+    <div className="min-h-screen p-4" style={{ fontFamily: 'Verdana, Geneva, sans-serif' }}>
       {/* Bestätigungs-Dialog */}
       {settleTarget && (
         <SettleConfirmDialog
@@ -308,6 +483,45 @@ export default function GastronomyPage() {
           onConfirm={confirmSettle}
           onCancel={() => setSettleTarget(null)}
         />
+      )}
+
+      {/* Station badge */}
+      {currentBadge && (
+        <div className="max-w-5xl mx-auto mb-4" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <div
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '8px',
+              padding: '8px 14px',
+              borderRadius: '20px',
+              background: currentBadge.accentBg,
+              border: `1px solid ${currentBadge.accentBorder}`,
+              fontFamily: 'Verdana, Geneva, sans-serif',
+            }}
+          >
+            <span style={{ fontSize: '16px' }}>{currentBadge.icon}</span>
+            <span style={{ color: currentBadge.accent, fontWeight: 'bold', fontSize: '14px' }}>
+              {currentBadge.label}
+            </span>
+          </div>
+          <button
+            onClick={clearStation}
+            style={{
+              padding: '8px 14px',
+              borderRadius: '20px',
+              border: '1px solid var(--pe-border)',
+              background: 'var(--pe-bg-elevated)',
+              color: 'var(--pe-text-sub)',
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              fontSize: '12px',
+              cursor: 'pointer',
+              minHeight: '44px',
+            }}
+          >
+            Station wechseln
+          </button>
+        </div>
       )}
 
       {/* NEU: View-Toggle — Bestellung | Kasse */}

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -516,7 +516,7 @@ export default function GastronomyPage() {
               fontFamily: 'Verdana, Geneva, sans-serif',
               fontSize: '12px',
               cursor: 'pointer',
-              minHeight: '44px',
+              minHeight: '64px',
             }}
           >
             Station wechseln

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -5,6 +5,7 @@ import { api } from '../api/client';
 import NFCScanner from '../components/nfc/NFCScanner';
 import GuestHeader from '../components/gastro/GuestHeader';
 import OpenOrdersPanel from '../components/gastro/OpenOrdersPanel';
+import RegisterView from '../components/gastro/RegisterView';
 import { useToastStore } from '../store/toasts';
 import { useStore } from '../store';
 
@@ -731,72 +732,12 @@ export default function GastronomyPage() {
       {/* ===== KASSEN-ANSICHT (Kassier) ===== */}
       {view === 'register' && (
         <div className="max-w-5xl mx-auto">
-          {registerLoading && guestOrders.length === 0 && (
-            <p className="text-center" style={{ color: 'var(--pe-text-sub)' }}>Lade Bestellungen...</p>
-          )}
-
-          {/* Liste aller Gäste mit offenen Bestellungen */}
-          <div className="space-y-3">
-            {guestOrders.map((g) => {
-              const isJustSettled = settledIds.has(g.guest_id);
-              return (
-                <div
-                  key={g.guest_id}
-                  className="rounded-xl overflow-hidden"
-                  style={{
-                    background: isJustSettled ? 'rgba(0,229,160,0.08)' : 'var(--pe-bg-card)',
-                    border: isJustSettled ? '1px solid var(--pe-success)' : '1px solid var(--pe-border)',
-                    transition: 'all 0.3s',
-                  }}
-                >
-                  {/* Gast-Header */}
-                  <div style={{ padding: '12px 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '1px solid var(--pe-border)' }}>
-                    <span style={{ fontWeight: 'bold', fontSize: '16px', color: 'var(--pe-text)' }}>{g.guest_name || 'Gast'}</span>
-                    <span style={{ fontWeight: 'bold', fontSize: '20px', color: isJustSettled ? 'var(--pe-success)' : 'var(--pe-cyan-bright)' }}>
-                      {isJustSettled ? '✓ Abgerechnet' : `${parseFloat(g.total || 0).toFixed(2)} €`}
-                    </span>
-                  </div>
-
-                  {/* Artikel-Tabelle */}
-                  <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                    <thead>
-                      <tr style={{ background: 'rgba(255,255,255,0.03)' }}>
-                        <th style={{ textAlign: 'left', padding: '8px 16px', fontSize: '11px', color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Artikel</th>
-                        <th style={{ textAlign: 'center', padding: '8px 16px', fontSize: '11px', color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: '0.5px', width: '64px' }}>Menge</th>
-                        <th style={{ textAlign: 'right', padding: '8px 16px', fontSize: '11px', color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: '0.5px', width: '96px' }}>Preis</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {(g.items || []).map((item, i) => (
-                        <tr key={i} style={{ borderTop: '1px solid var(--pe-border)' }}>
-                          <td style={{ padding: '10px 16px', fontSize: '14px', color: 'var(--pe-text)' }}>{item.product_name}</td>
-                          <td style={{ padding: '10px 16px', fontSize: '14px', color: 'var(--pe-text)', textAlign: 'center' }}>{item.quantity}</td>
-                          <td style={{ padding: '10px 16px', fontSize: '14px', color: 'var(--pe-text-sub)', textAlign: 'right', whiteSpace: 'nowrap' }}>{parseFloat(item.total).toFixed(2)} €</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-
-                  {/* Jetzt-abrechnen Button */}
-                  {!isJustSettled && (
-                    <div style={{ padding: '12px 16px' }}>
-                      <button
-                        onClick={() => initSettle(g)}
-                        disabled={submitting}
-                        style={{ ...btnStyle, width: '100%', minHeight: '64px', background: 'var(--pe-success)', color: '#000', border: 'none', fontSize: '15px' }}
-                      >
-                        Jetzt abrechnen
-                      </button>
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-
-            {!registerLoading && guestOrders.length === 0 && (
-              <p className="text-center py-8" style={{ color: 'var(--pe-text-muted)' }}>Keine offenen Bestellungen</p>
-            )}
-          </div>
+          <RegisterView
+            guestOrders={guestOrders}
+            settledIds={settledIds}
+            onSettle={initSettle}
+            loading={registerLoading}
+          />
         </div>
       )}
     </div>

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -4,6 +4,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { api } from '../api/client';
 import NFCScanner from '../components/nfc/NFCScanner';
 import GuestHeader from '../components/gastro/GuestHeader';
+import OpenOrdersPanel from '../components/gastro/OpenOrdersPanel';
 import { useToastStore } from '../store/toasts';
 import { useStore } from '../store';
 
@@ -630,34 +631,8 @@ export default function GastronomyPage() {
                 />
 
                 {/* Bereits offene Bestellungen dieses Gastes */}
-                {guestOpenOrders && guestOpenOrders.items?.length > 0 && (
-                  <div className="mb-4 p-3 rounded-xl" style={{ background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)' }}>
-                    <p className="text-xs font-bold mb-2" style={{ color: 'var(--pe-text-muted)', textTransform: 'uppercase', letterSpacing: 1 }}>Offene Bestellungen</p>
-                    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                      <thead>
-                        <tr>
-                          <th style={{ textAlign: 'left', padding: '4px 8px', fontSize: '11px', color: 'var(--pe-text-muted)', textTransform: 'uppercase' }}>Artikel</th>
-                          <th style={{ textAlign: 'center', padding: '4px 8px', fontSize: '11px', color: 'var(--pe-text-muted)', textTransform: 'uppercase', width: '48px' }}>Menge</th>
-                          <th style={{ textAlign: 'right', padding: '4px 8px', fontSize: '11px', color: 'var(--pe-text-muted)', textTransform: 'uppercase', width: '80px' }}>Preis</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {guestOpenOrders.items.map((item, i) => (
-                          <tr key={i} style={{ borderTop: '1px solid var(--pe-border)' }}>
-                            <td style={{ padding: '7px 8px', fontSize: '13px', color: 'var(--pe-text)' }}>{item.product_name}</td>
-                            <td style={{ padding: '7px 8px', fontSize: '13px', color: 'var(--pe-text)', textAlign: 'center' }}>{item.quantity}</td>
-                            <td style={{ padding: '7px 8px', fontSize: '13px', color: 'var(--pe-text-sub)', textAlign: 'right' }}>{parseFloat(item.total).toFixed(2)} €</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                      <tfoot>
-                        <tr style={{ borderTop: '2px solid var(--pe-border)' }}>
-                          <td colSpan="2" style={{ padding: '7px 8px', fontSize: '13px', fontWeight: 'bold', color: 'var(--pe-text-sub)' }}>Gesamt offen</td>
-                          <td style={{ padding: '7px 8px', fontSize: '14px', fontWeight: 'bold', color: 'var(--pe-cyan-bright)', textAlign: 'right' }}>{parseFloat(guestOpenOrders.total || 0).toFixed(2)} €</td>
-                        </tr>
-                      </tfoot>
-                    </table>
-                  </div>
+                {guestOpenOrders?.items?.length > 0 && (
+                  <OpenOrdersPanel items={guestOpenOrders.items} total={guestOpenOrders.total} />
                 )}
 
                 {/* Kategorien-Tabs */}

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { api } from '../api/client';
-import NFCScanner from '../components/nfc/NFCScanner';
+import GuestSelector from '../components/gastro/GuestSelector';
 import GuestHeader from '../components/gastro/GuestHeader';
 import OpenOrdersPanel from '../components/gastro/OpenOrdersPanel';
 import RegisterView from '../components/gastro/RegisterView';
@@ -254,7 +254,6 @@ export default function GastronomyPage() {
 
   // NEU: Bestellungs-Ansicht State
   const [guest, setGuest] = useState(null);
-  const [guestSearch, setGuestSearch] = useState('');
   const [products, setProducts] = useState([]);
   const [cart, setCart] = useState([]);
   const [productFilter, setProductFilter] = useState('all');
@@ -560,60 +559,16 @@ export default function GastronomyPage() {
       {view === 'order' && (
         <div className="max-w-5xl mx-auto">
           {!guest && (
-            <>
-              {/* NFC-Scan */}
-              <NFCScanner onScan={handleNFCScan} scanning={scanning} />
-
-              {/* Gäste-Liste (Fallback ohne NFC) */}
-              <div style={{ marginTop: '12px', padding: '12px', borderRadius: '10px', background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)' }}>
-                <p style={{ color: 'var(--pe-text-sub)', fontSize: '13px', marginBottom: '8px', fontWeight: 'bold' }}>GAST AUSWÄHLEN</p>
-                <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
-                  <input
-                    type="text"
-                    value={guestSearch}
-                    onChange={(e) => setGuestSearch(e.target.value)}
-                    placeholder="Name suchen..."
-                    style={{ flex: 1, padding: '10px 14px', borderRadius: '8px', background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)', minHeight: '64px', outline: 'none' }}
-                  />
-                  <button
-                    onClick={() => {
-                      api.post('/nfc/create-manual', { name: guestSearch.trim() || 'Neuer Gast' })
-                        .then((g) => { setGuest(g); setCart([]); setGuestSearch(''); setAllGuests(prev => [...prev, g]); })
-                        .catch((err) => addToast({ type: 'error', message: err.message || 'Gast konnte nicht angelegt werden' }));
-                    }}
-                    style={{ padding: '10px 14px', borderRadius: '8px', background: 'var(--pe-blue-mid)', color: 'var(--pe-text)', border: 'none', fontFamily: 'var(--pe-font-body)', fontWeight: 'bold', cursor: 'pointer', minHeight: '64px', whiteSpace: 'nowrap' }}
-                  >
-                    + Neu
-                  </button>
-                </div>
-                <div style={{ maxHeight: '300px', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                  {allGuests
-                    .filter((g) => !guestSearch || g.name?.toLowerCase().includes(guestSearch.toLowerCase()))
-                    .map((g) => {
-                      const gBlocked = g.active === 0 || g.active === false;
-                      return (
-                        <button
-                          key={g.id}
-                          onClick={() => { setGuest(g); setCart([]); setOrderSuccess(false); }}
-                          style={{ padding: '12px 16px', borderRadius: '8px', background: 'var(--pe-bg-card)', border: `1px solid ${gBlocked ? 'var(--pe-danger)' : 'var(--pe-border)'}`, color: 'var(--pe-text)', textAlign: 'left', fontFamily: 'var(--pe-font-body)', cursor: 'pointer', minHeight: '64px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-                        >
-                          <span style={{ fontWeight: 'bold' }}>{g.name || 'Gast'}</span>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            {gBlocked && (
-                              <span style={{ fontSize: '11px', fontWeight: 'bold', color: 'var(--pe-danger)', border: '1px solid var(--pe-danger)', borderRadius: '20px', padding: '2px 8px' }}>Gesperrt</span>
-                            )}
-                            <span style={{ color: 'var(--pe-text-muted)', fontSize: '12px' }}>#{g.id}</span>
-                          </div>
-                        </button>
-                      );
-                    })
-                  }
-                  {allGuests.length === 0 && (
-                    <p style={{ color: 'var(--pe-text-muted)', textAlign: 'center', padding: '16px', fontSize: '13px' }}>Noch keine Gäste. Mit "+ Neu" ersten Gast anlegen.</p>
-                  )}
-                </div>
-              </div>
-            </>
+            <GuestSelector
+              guests={allGuests}
+              onGuestSelect={(g) => { setGuest(g); setCart([]); setOrderSuccess(false); }}
+              onCreateGuest={(name) => api.post('/nfc/create-manual', { name })
+                .then((g) => { setGuest(g); setCart([]); setAllGuests((prev) => [...prev, g]); })
+                .catch((err) => addToast({ type: 'error', message: err.message }))}
+              nfcAvailable={'NDEFReader' in window}
+              onRequestNfcScan={handleNFCScan}
+              scanning={scanning}
+            />
           )}
 
           {guest && (


### PR DESCRIPTION
## Summary

- Reworks GastronomyPage from a 666-line monolith into 13 focused components under `frontend/src/components/gastro/`
- Introduces station-split: Bar / Küche / Kasse selected after login, persisted in `sessionStorage`
- Fixes touch-target violations: cart remove button 44px → 64px, all interactive elements ≥ 64px
- Adds two-column tablet layout from 768px (product grid + sticky cart sidebar)
- NFC scanner no longer auto-starts on mount — requires user tap (fixes Chrome NDEFReader policy)
- Kitchen view: food-only ticket board with 5s polling and oldest-order-first timing
- Register view: guest search filter added
- SettleDialog: tablet-width aware (`min(480px, 90vw)`), backdrop-tap to dismiss
- Backend: adds `oldest_order_at` to `/api/orders/by-guest` response

## New Components

| Component | Purpose |
|-----------|---------|
| `StationSelector` | Full-screen station picker (Bar / Küche / Kasse) |
| `GastronomyLogin` | Extracted login form |
| `GuestSelector` | NFC tap-to-start + manual accordion guest picker |
| `ProductGrid` | Category filter tabs + responsive product button grid |
| `OrderCart` | Cart sidebar (tablet sticky) / bottom-sheet (mobile) |
| `OrderCartItem` | Single cart row with 64px +/− buttons |
| `GuestHeader` | Guest name, status badge, lock/unlock, settle |
| `OpenOrdersPanel` | Collapsible accordion of existing open orders |
| `KitchenView` | Food-only ticket board with 5s polling |
| `RegisterView` | Register list with search filter |
| `RegisterGuestCard` | Single guest card with settle button |
| `SettleDialog` | Tablet-aware confirmation modal |
| `GuestSearchInput` | Reusable search input with optional "+ Neu" |

## Test Plan

- [ ] Login as gastronomy user → StationSelector appears
- [ ] Select Bar → two-column layout at 768px (iPad Mini in DevTools)
- [ ] NFC circle requires tap before scanning starts (no auto-start)
- [ ] Select a guest → GuestHeader, OpenOrdersPanel, ProductGrid render
- [ ] Add items → cart appears as bottom-sheet (mobile) and sticky sidebar (tablet)
- [ ] `+` and `−` buttons in cart correctly adjust quantities
- [ ] Category filter (Alle / Getränke / Speisen) filters product grid
- [ ] Submit order → success state shown, cart clears
- [ ] Select Küche → food-only tickets appear, auto-refreshes every 5s
- [ ] Select Kasse → search field filters guest list, settle flow works end-to-end
- [ ] Refresh page → station persists via sessionStorage
- [ ] "Station wechseln" button returns to StationSelector
- [ ] No white backgrounds or light-mode elements on any station view
- [ ] Verdana font throughout

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)