### PR TITLE
fix: gastro follow-up bugs — Küche station, full width, guest name validation

### DIFF
--- a/docs/superpowers/plans/2026-03-17-tap-to-order.md
+++ b/docs/superpowers/plans/2026-03-17-tap-to-order.md
@@ -1,0 +1,526 @@
+# Tap-to-Order Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the cart+submit flow in the Bar station with direct tap-to-order — each product tap immediately POSTs an order, and a session list below the grid shows what was ordered with per-item undo.
+
+**Architecture:** Three focused changes: (1) new DELETE endpoint on the backend, (2) new `SessionOrderList` component, (3) GastronomyPage state refactor replacing `cart`/`addToCart`/`submitOrder` with `sessionOrders`/`tapProduct`/`tapUndo` plus a 20s inactivity timer. `OrderCart` and `OrderCartItem` are deleted. `ProductGrid` gets a session-count badge.
+
+**Tech Stack:** React 18 + Vite + Zustand + TailwindCSS; Node.js + Express + better-sqlite3; PE CSS tokens (`var(--pe-*)`); Verdana font; touch targets ≥ 64px
+
+**Spec:** `docs/superpowers/specs/2026-03-17-tap-to-order-design.md`
+
+---
+
+## Chunk 1: Backend — DELETE /api/orders/:id
+
+### Task 1: Add DELETE endpoint to orders route
+
+**Files:**
+- Modify: `backend/src/routes/orders.js`
+
+- [ ] Open `backend/src/routes/orders.js`. Read the existing route handlers to find the correct insertion point. The new handler must be placed **before** the `GET /by-guest` handler to avoid Express matching `/:id` as a literal path collision with named routes. A safe placement is directly after the existing `POST /api/orders/settle/:guestId` handler.
+
+- [ ] Add the following handler:
+
+```js
+router.delete('/:id', requireAuth, (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) return res.status(400).json({ error: 'Invalid order id' });
+  const result = db.prepare(
+    "DELETE FROM orders WHERE id = ? AND status = 'open'"
+  ).run(id);
+  if (result.changes === 0) {
+    return res.status(404).json({ error: 'Order not found or already paid' });
+  }
+  res.json({ message: 'Order deleted' });
+});
+```
+
+- [ ] Verify the handler is placed before any `GET /by-guest` or `GET /dashboard` routes so Express does not interpret `by-guest` or `dashboard` as an `:id` param. (Express evaluates routes in declaration order — named segments like `/by-guest` are fine as long as they are declared before `/:id`.)
+
+- [ ] Manual test — start the backend and run:
+```bash
+# 1. Get auth token
+TOKEN=$(curl -s -X POST http://localhost:3001/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"admin"}' | jq -r .token)
+
+# 2. Create a test order (requires an existing guest and product)
+curl -s -X POST http://localhost:3001/api/orders \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"guest_id":1,"product_id":1,"quantity":1}' | jq .
+# Expected: JSON with id, product_name, price, status: "open"
+
+# 3. Note the returned id (e.g. 42), then delete it
+curl -s -X DELETE http://localhost:3001/api/orders/42 \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# Expected: {"message":"Order deleted"}
+
+# 4. Delete same id again — should 404
+curl -s -o /dev/null -w "%{http_code}" \
+  -X DELETE http://localhost:3001/api/orders/42 \
+  -H "Authorization: Bearer $TOKEN"
+# Expected: 404
+
+# 5. Delete non-existent id
+curl -s -o /dev/null -w "%{http_code}" \
+  -X DELETE http://localhost:3001/api/orders/999999 \
+  -H "Authorization: Bearer $TOKEN"
+# Expected: 404
+```
+
+- [ ] Commit:
+```bash
+git add backend/src/routes/orders.js
+git commit -m "feat: add DELETE /api/orders/:id endpoint for tap-to-order undo"
+```
+
+---
+
+## Chunk 2: New Component — SessionOrderList
+
+### Task 2: Create SessionOrderList component
+
+**Files:**
+- Create: `frontend/src/components/gastro/SessionOrderList.jsx`
+
+- [ ] Create the file `frontend/src/components/gastro/SessionOrderList.jsx` with the following content:
+
+```jsx
+// frontend/src/components/gastro/SessionOrderList.jsx
+export default function SessionOrderList({ orders, onUndo }) {
+  if (!orders || orders.length === 0) return null;
+
+  const total = orders.reduce((sum, o) => sum + parseFloat(o.price), 0);
+
+  return (
+    <div style={{
+      background: 'var(--pe-bg-card)',
+      border: '1px solid var(--pe-border)',
+      borderRadius: 12,
+      padding: 12,
+      marginTop: 12,
+      fontFamily: 'Verdana, Geneva, sans-serif',
+    }}>
+      {/* Header */}
+      <div style={{
+        fontWeight: 'bold',
+        color: 'var(--pe-text)',
+        fontSize: 14,
+        marginBottom: 8,
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}>
+        Diese Bestellung ({orders.length} Artikel, {total.toFixed(2)} €)
+      </div>
+
+      {/* Order rows */}
+      {orders.map((order) => (
+        <div
+          key={order.id}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 8,
+            padding: '4px 0',
+            borderBottom: '1px solid var(--pe-border)',
+          }}
+        >
+          <span style={{
+            flex: 1,
+            color: 'var(--pe-text)',
+            fontSize: 14,
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}>
+            {order.product_name}
+          </span>
+          <span style={{
+            color: 'var(--pe-text-sub)',
+            fontSize: 13,
+            minWidth: 56,
+            textAlign: 'right',
+            fontFamily: 'Verdana, Geneva, sans-serif',
+          }}>
+            {parseFloat(order.price).toFixed(2)} €
+          </span>
+          <button
+            onClick={() => onUndo(order.id)}
+            style={{
+              minWidth: 64,
+              minHeight: 64,
+              color: 'var(--pe-danger)',
+              background: 'var(--pe-bg-elevated)',
+              border: 'none',
+              borderRadius: 12,
+              cursor: 'pointer',
+              fontWeight: 'bold',
+              fontSize: 18,
+              fontFamily: 'Verdana, Geneva, sans-serif',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+
+      {/* Total */}
+      <div style={{
+        textAlign: 'right',
+        marginTop: 10,
+        color: 'var(--pe-cyan-bright)',
+        fontWeight: 'bold',
+        fontSize: 15,
+        fontFamily: 'Verdana, Geneva, sans-serif',
+      }}>
+        Gesamt: {total.toFixed(2)} €
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] Visual check: `SessionOrderList` renders nothing when `orders` is empty or null. When orders are present, the header, rows, and total show correctly.
+
+- [ ] Commit:
+```bash
+git add frontend/src/components/gastro/SessionOrderList.jsx
+git commit -m "feat: add SessionOrderList component for tap-to-order session"
+```
+
+---
+
+## Chunk 3: Frontend Refactor
+
+### Task 3: Update ProductGrid — rename prop + session badge
+
+**Files:**
+- Modify: `frontend/src/components/gastro/ProductGrid.jsx`
+
+- [ ] Read `frontend/src/components/gastro/ProductGrid.jsx` in full.
+
+- [ ] Rename the prop `onAddToCart` to `onTap` in the component signature and everywhere it is referenced inside the file.
+
+- [ ] Add the optional `sessionCounts` prop (default: empty `Map`):
+```jsx
+export default function ProductGrid({ products, onTap, isBlocked, categoryFilter, onCategoryChange, sessionCounts = new Map() }) {
+```
+
+- [ ] On each product button, after the price display, add the session count badge — render only when `sessionCounts.get(product.id) > 0`:
+```jsx
+{sessionCounts.get(product.id) > 0 && (
+  <span style={{
+    fontSize: 11,
+    fontWeight: 'bold',
+    color: 'var(--pe-cyan-bright)',
+    fontFamily: 'Verdana, Geneva, sans-serif',
+  }}>
+    ×{sessionCounts.get(product.id)}
+  </span>
+)}
+```
+
+- [ ] Change the product button's `onClick` from `onAddToCart(product)` to `onTap(product)`.
+
+- [ ] Commit:
+```bash
+git add frontend/src/components/gastro/ProductGrid.jsx
+git commit -m "feat: productgrid rename onAddToCart to onTap, add session count badge"
+```
+
+---
+
+### Task 4: Refactor GastronomyPage — state, timer, tapProduct, tapUndo
+
+**Files:**
+- Modify: `frontend/src/pages/GastronomyPage.jsx`
+
+This is the core refactor. Read the full file first, then apply the changes below in order.
+
+- [ ] Read `frontend/src/pages/GastronomyPage.jsx` in full.
+
+- [ ] **Replace state declarations** — find the `cart` and `orderSuccess` state variables and replace:
+```jsx
+// REMOVE:
+const [cart, setCart] = useState([]);
+const [orderSuccess, setOrderSuccess] = useState(false);
+
+// ADD:
+const [sessionOrders, setSessionOrders] = useState([]);
+const timerRef = useRef(null);
+```
+Add `useRef` to the React imports if not already present.
+
+- [ ] **Add `clearSession`, `resetTimer`, `selectGuest` functions** — add these after the existing state declarations:
+```jsx
+const clearSession = useCallback(() => {
+  clearTimeout(timerRef.current);
+  setGuest(null);        // isBlocked is derived from guest — becomes false automatically
+  setSessionOrders([]);
+  setGuestOpenOrders(null);
+  setProductFilter('all');
+}, []);
+
+const resetTimer = useCallback(() => {
+  clearTimeout(timerRef.current);
+  timerRef.current = setTimeout(clearSession, 20000);
+}, [clearSession]);
+
+const selectGuest = useCallback((g) => {
+  setGuest(g);
+  setSessionOrders([]);
+  setGuestOpenOrders(null);
+  resetTimer();
+}, [resetTimer]);
+```
+
+- [ ] **Add `useEffect` cleanup** for the timer (add alongside existing effects):
+```jsx
+useEffect(() => {
+  return () => clearTimeout(timerRef.current);
+}, []);
+```
+
+- [ ] **Extract `fetchGuestOpenOrders` as a named callback** — the existing open-orders fetch is done inline in a `useEffect` and inside `submitOrder`. Extract it so `tapUndo` can call it:
+```jsx
+const fetchGuestOpenOrders = useCallback(async (guestId) => {
+  try {
+    const data = await api.get(`/orders/guest/${guestId}`);
+    setGuestOpenOrders(data);
+  } catch {
+    setGuestOpenOrders(null);
+  }
+}, []);
+```
+Update the existing `useEffect` that fetches open orders to call `fetchGuestOpenOrders(guest.id)` instead of inlining the API call.
+
+- [ ] **Remove `addToCart`, `removeFromCart`, and `submitOrder`** — delete all three functions. `removeFromCart` also references `setCart` and is only consumed by `OrderCart` which is being deleted. Then add `tapProduct`:
+```jsx
+const tapProduct = useCallback(async (product) => {
+  resetTimer();
+  try {
+    const order = await api.post('/orders', {
+      guest_uid: guest.nfc_uid,
+      product_id: product.id,
+      quantity: 1,
+    });
+    setSessionOrders(prev => [...prev, order]);
+  } catch (err) {
+    addToast({ type: 'error', message: 'Fehler beim Buchen' });
+  }
+}, [guest, resetTimer, addToast]);
+```
+
+- [ ] **Add `tapUndo` function**:
+```jsx
+const tapUndo = useCallback(async (orderId) => {
+  resetTimer();
+  try {
+    await api.delete(`/orders/${orderId}`);
+    setSessionOrders(prev => prev.filter(o => o.id !== orderId));
+    if (guest) fetchGuestOpenOrders(guest.id);
+  } catch (err) {
+    // Distinguish already-paid (404) from generic network errors
+    if (err.status === 404) {
+      addToast({ type: 'error', message: 'Bereits abgerechnet — kann nicht entfernt werden' });
+    } else {
+      addToast({ type: 'error', message: 'Rückgängig nicht möglich' });
+    }
+  }
+}, [guest, resetTimer, addToast, fetchGuestOpenOrders]);
+```
+
+- [ ] **Update `handleNFCScan`** — replace `setCart([])` and `setOrderSuccess(false)` with `selectGuest(resolvedGuest)`:
+
+Find the `handleNFCScan` function. It currently does `setGuest(result)` and `setCart([])`. Replace the guest-setting part with `selectGuest(result)` and remove the `setCart([])` and `setOrderSuccess(false)` lines.
+
+- [ ] **Update `confirmSettle`** — replace every `setCart([])` with `setSessionOrders([])` and remove any `setOrderSuccess(false)`. There should be one occurrence in the settle success branch for the bar station.
+
+- [ ] **Derive `sessionCounts`** from `sessionOrders` (add as a derived constant in the render, before the return):
+```jsx
+const sessionCounts = sessionOrders.reduce((map, o) => {
+  map.set(o.product_id, (map.get(o.product_id) || 0) + 1);
+  return map;
+}, new Map());
+```
+
+- [ ] **Update imports** — remove `OrderCart` import, add `SessionOrderList` import:
+```jsx
+import SessionOrderList from '../components/gastro/SessionOrderList';
+// Remove: import OrderCart from '../components/gastro/OrderCart';
+```
+
+- [ ] **Update Bar layout JSX** — find the Bar station render block. Make these changes:
+
+  1. Replace the two-column layout (`flex-col md:flex-row` with `md:w-80` cart column) with a single-column `w-full` layout.
+  2. In the `GuestSelector` `onGuestSelect` prop, replace the inline callback that calls `setCart([])` and `setOrderSuccess(false)` with `selectGuest(g)`.
+  3. In the `GuestSelector` `onCreateGuest` prop, find the `.then((g) => { setGuest(g); setCart([]); ... })` callback and replace it with `selectGuest(g)` so the new guest also starts the inactivity timer and clears session state:
+  ```jsx
+  onCreateGuest={(name) =>
+    api.post('/nfc/create-manual', { name })
+      .then((g) => { selectGuest(g); setAllGuests((prev) => [...prev, g]); })
+      .catch((err) => addToast({ type: 'error', message: err.message }))
+  }
+  ```
+  4. Replace `<ProductGrid ... onAddToCart={addToCart} .../>` with `<ProductGrid ... onTap={tapProduct} sessionCounts={sessionCounts} onCategoryChange={handleCategoryChange} .../>`.
+  5. After `<ProductGrid>`, add `<SessionOrderList orders={sessionOrders} onUndo={tapUndo} />`.
+  6. Remove `{guest && <div className="md:w-80 ..."><OrderCart .../></div>}` entirely.
+
+  The updated Bar layout should look like:
+  ```jsx
+  <div style={{ maxWidth: 900, margin: '0 auto', padding: '0 16px 100px' }}>
+    {!guest && (
+      <GuestSelector
+        guests={allGuests}
+        onGuestSelect={selectGuest}
+        onCreateGuest={...}
+        nfcAvailable={'NDEFReader' in window}
+        onRequestNfcScan={handleNFCScan}
+        scanning={scanning}
+      />
+    )}
+    {guest && (
+      <>
+        <GuestHeader
+          guest={guest}
+          isBlocked={isBlocked}
+          onClose={clearSession}
+          onToggleLock={toggleGuestLock}
+          lockLoading={lockLoading}
+          onSettle={() => initSettle(guest)}
+        />
+        {guestOpenOrders?.items?.length > 0 && (
+          <OpenOrdersPanel items={guestOpenOrders.items} total={guestOpenOrders.total} />
+        )}
+        <ProductGrid
+          products={stationFilteredProducts}
+          onTap={tapProduct}
+          isBlocked={isBlocked}
+          categoryFilter={productFilter}
+          onCategoryChange={handleCategoryChange}
+          sessionCounts={sessionCounts}
+        />
+        <SessionOrderList orders={sessionOrders} onUndo={tapUndo} />
+      </>
+    )}
+  </div>
+  ```
+
+  Note: `handleCategoryChange` now calls `setProductFilter(cat)` AND `resetTimer()` (see below).
+
+- [ ] **Add `handleCategoryChange` function** (replaces direct `setProductFilter` calls):
+```jsx
+const handleCategoryChange = useCallback((cat) => {
+  setProductFilter(cat);
+  resetTimer();
+}, [resetTimer]);
+```
+
+- [ ] **Update `GuestHeader` `onClose` prop** — the close button should call `clearSession` instead of an inline `() => { setGuest(null); setCart([]); }`.
+
+- [ ] Commit:
+```bash
+git add frontend/src/pages/GastronomyPage.jsx
+git commit -m "feat: tap-to-order — replace cart flow with sessionOrders + 20s inactivity timer"
+```
+
+---
+
+### Task 5: Delete obsolete components
+
+**Files:**
+- Delete: `frontend/src/components/gastro/OrderCart.jsx`
+- Delete: `frontend/src/components/gastro/OrderCartItem.jsx`
+
+- [ ] Verify `OrderCart` and `OrderCartItem` are no longer imported anywhere:
+```bash
+grep -r "OrderCart" /home/moritzwolf/dartsturnier/frontend/src/
+# Expected: no results (or only the files themselves if they still exist)
+grep -r "OrderCartItem" /home/moritzwolf/dartsturnier/frontend/src/
+# Expected: no results
+```
+
+- [ ] Delete the files:
+```bash
+git rm frontend/src/components/gastro/OrderCart.jsx
+git rm frontend/src/components/gastro/OrderCartItem.jsx
+```
+
+- [ ] Commit:
+```bash
+git commit -m "refactor: remove OrderCart and OrderCartItem — replaced by SessionOrderList"
+```
+
+---
+
+## Chunk 4: Integration & PR
+
+### Task 6: Smoke test checklist
+
+Before creating the PR, verify the following manually in the browser (or document as known-working):
+
+- [ ] Open `/gastronomy` → login → select Bar station → guest selector shows
+- [ ] Select a guest → product grid appears full-width, no cart sidebar
+- [ ] Tap a product → item appears immediately in SessionOrderList below the grid
+- [ ] Tap same product again → second row appears (same product, separate row)
+- [ ] Product button shows `×2` badge after two taps
+- [ ] Tap ✕ on a row → row disappears, badge decrements
+- [ ] Wait 20 seconds without interaction → screen silently resets to guest selector
+- [ ] Tap any product, then wait 20 seconds → resets (timer resets on tap)
+- [ ] Tap ✕, wait 20 seconds → resets (timer resets on undo)
+- [ ] Change category filter → timer resets (no accidental reset to guest select)
+- [ ] Blocked guest → product grid dimmed, tapping does nothing
+- [ ] Kasse/Küche/KitchenView stations → unaffected by this change
+- [ ] Register settle flow → still works (submitting state preserved)
+
+### Task 7: Push branch and create PR
+
+**Files:** none
+
+- [ ] Verify all commits are on the feature branch:
+```bash
+git log --oneline dev..HEAD
+```
+
+- [ ] Push:
+```bash
+git push origin feat/tap-to-order
+```
+
+- [ ] Create PR:
+```bash
+gh pr create --base dev --head feat/tap-to-order \
+  --title "feat: tap-to-order bar station — direct booking with session list (#107)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Replaces cart+submit flow with direct tap-to-order in Bar station
+- Each product tap immediately POSTs \`/api/orders\` — no Bestellen button
+- Session list below product grid shows orders for current guest with per-item undo (✕)
+- 20s inactivity timer auto-resets to guest selection silently
+- Product buttons show ×N badge when tapped multiple times in same session
+- Product grid now full-width (no cart sidebar column)
+- Adds \`DELETE /api/orders/:id\` backend endpoint
+- Removes \`OrderCart.jsx\` and \`OrderCartItem.jsx\`
+
+## Test Plan
+
+- [ ] Tap product → immediate row in session list, no submit step
+- [ ] ×N badge on product button after multiple taps
+- [ ] ✕ undo removes row and syncs OpenOrdersPanel
+- [ ] 20s inactivity → silent return to guest selector
+- [ ] Interaction (tap, undo, category change) resets timer
+- [ ] Kasse / Register settle flow unaffected
+- [ ] Backend DELETE /api/orders/:id returns 404 for paid/missing orders
+
+Closes #107
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-03-17-tap-to-order-design.md
+++ b/docs/superpowers/specs/2026-03-17-tap-to-order-design.md
@@ -1,0 +1,179 @@
+# Tap-to-Order Design Spec
+# Gastro Bar Station — Direct Order Flow
+
+**Date:** 2026-03-17
+**Issue:** #107
+**Status:** Approved
+
+---
+
+## Problem
+
+The current Bar flow requires: guest select → add items to cart → click "Bestellen". This creates unnecessary friction for staff:
+- With 30+ products the grid is unwieldy with a sidebar taking space
+- A separate cart + submit step adds overhead for every single order
+- The "Bestellen" button adds a confirmation step that has no value in a fast-paced environment
+
+---
+
+## Solution: Tap-to-Order with Session List
+
+**One tap = one item booked immediately.** No cart, no submit button. A live session list below the product grid shows what has been ordered for this guest, with per-item undo.
+
+### Flow
+
+```
+1. Select guest (NFC or manual) — unchanged
+2. Product grid appears full-width
+3. Tap any product → instant POST /api/orders → item appears in session list below
+4. Tap again → another item added
+5. ✕ on any session list item → DELETE /api/orders/:id → item removed
+6. 20s inactivity → silent reset → back to guest selection
+7. Any interaction (tap product, tap ✕, change category) resets the timer
+```
+
+### Screen Layout (Bar Station)
+
+```
+┌─────────────────────────────────────────┐
+│  👤 Max Mustermann  [Aktiv]  [Sperren]  │  GuestHeader
+├─────────────────────────────────────────┤
+│  [Alle] [Getränke] [Speisen]            │  Category filter
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐   │
+│  │ Bier │ │Wein  │ │Wasser│ │Cola  │   │  ProductGrid (full width)
+│  │×2 3,50│ │ 4,00│ │ 1,50│ │ 2,00│   │  (badge shows session count)
+│  └──────┘ └──────┘ └──────┘ └──────┘   │
+│  ...                                    │
+├─────────────────────────────────────────┤
+│  Diese Bestellung (3 Artikel, 10,50 €)  │  SessionOrderList (new)
+│  Bier                    3,50 €  [✕]   │
+│  Cola                    2,00 €  [✕]   │
+│  Bier                    3,50 €  [✕]   │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## Component Changes
+
+### Modified
+
+| Component | Change |
+|-----------|--------|
+| `GastronomyPage.jsx` | Replace `cart` state with `sessionOrders` (array of POST responses). Add `inactivityTimer` ref. Replace `addToCart`/`submitOrder` with `tapProduct(product)`. Remove cart column from Bar layout (full-width). |
+| `ProductGrid.jsx` | Rename `onAddToCart` → `onTap`. Accept optional `sessionCounts: Map<product_id, count>` prop to show `×N` badge on product buttons when count > 0. |
+
+### New
+
+| Component | Purpose |
+|-----------|---------|
+| `frontend/src/components/gastro/SessionOrderList.jsx` | Shows orders created in this session. Props: `orders`, `onUndo(orderId)`. Renders item rows with name, price, ✕ button. Shows total at bottom. Hidden when `orders.length === 0`. |
+
+### Deleted
+
+| Component | Reason |
+|-----------|--------|
+| `OrderCart.jsx` | Replaced by SessionOrderList |
+| `OrderCartItem.jsx` | No longer needed |
+
+### Unchanged
+
+`GuestSelector`, `GuestHeader`, `OpenOrdersPanel`, `RegisterView`, `SettleDialog`, `StationSelector`, `KitchenView`, `GuestSearchInput`, `RegisterGuestCard`
+
+---
+
+## Backend Changes
+
+### New Endpoint
+
+```
+DELETE /api/orders/:id
+```
+
+- **Auth:** Required (referee / admin / director)
+- **Success:** 200 `{ message: 'Order deleted' }`
+- **404:** Order not found
+- **409:** Order already paid (`status !== 'open'`)
+- Uses prepared statement: `DELETE FROM orders WHERE id = ? AND status = 'open'`
+
+### Modified
+
+`backend/src/routes/orders.js` — add DELETE handler.
+
+---
+
+## State Design
+
+### `sessionOrders` (replaces `cart`)
+
+```js
+// Array of order objects returned by POST /api/orders
+[
+  { id: 42, product_id: 3, product_name: 'Bier', price: 3.50, quantity: 1 },
+  { id: 43, product_id: 5, product_name: 'Cola', price: 2.00, quantity: 1 },
+]
+```
+
+Each entry has `id` (order DB id) which is used for DELETE.
+
+### `sessionCounts` (derived, not stored)
+
+```js
+// Computed from sessionOrders on render
+const sessionCounts = sessionOrders.reduce((map, o) => {
+  map.set(o.product_id, (map.get(o.product_id) || 0) + 1);
+  return map;
+}, new Map());
+```
+
+Passed to ProductGrid as prop to show `×N` badges.
+
+### Inactivity Timer
+
+```js
+const timerRef = useRef(null);
+
+const resetTimer = () => {
+  clearTimeout(timerRef.current);
+  timerRef.current = setTimeout(clearSession, 20000); // 20 seconds
+};
+
+const tapProduct = async (product) => {
+  resetTimer();
+  // POST /api/orders ...
+};
+
+// Also reset on: category change, ✕ undo
+// Clear timer in useEffect cleanup
+```
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| POST fails (network/server error) | Toast "Fehler beim Buchen" — no entry added to sessionOrders |
+| Product unavailable (backend 400) | Toast "Produkt nicht verfügbar" |
+| Guest blocked | ProductGrid stays dimmed (`isBlocked` prop, unchanged) |
+| DELETE fails | Toast "Rückgängig nicht möglich" — entry stays in list |
+| DELETE 409 (already paid) | Toast "Bereits abgerechnet — kann nicht entfernt werden" |
+
+---
+
+## Design Constraints
+
+- **Font:** Verdana, Geneva, sans-serif throughout
+- **Colors:** PE CSS tokens only (`var(--pe-*)`)
+- **Touch targets:** All buttons ≥ 64px (✕ undo buttons, product buttons already 96px)
+- **Dark mode:** Always
+- **Inactivity timeout:** 20 seconds hardcoded — no config needed
+
+---
+
+## Out of Scope
+
+- Quantity selector (1 tap = 1 item, always)
+- Kitchen view changes (separate issue #103)
+- Product management UI (separate issue #108)
+- Tournament association (separate issue #106)

--- a/docs/superpowers/specs/2026-03-17-tap-to-order-design.md
+++ b/docs/superpowers/specs/2026-03-17-tap-to-order-design.md
@@ -24,12 +24,14 @@ The current Bar flow requires: guest select → add items to cart → click "Bes
 
 ```
 1. Select guest (NFC or manual) — unchanged
-2. Product grid appears full-width
-3. Tap any product → instant POST /api/orders → item appears in session list below
-4. Tap again → another item added
-5. ✕ on any session list item → DELETE /api/orders/:id → item removed
-6. 20s inactivity → silent reset → back to guest selection
-7. Any interaction (tap product, tap ✕, change category) resets the timer
+2. Timer starts immediately when guest is set (sessionOrders reset to [])
+3. Product grid appears full-width
+4. Tap any product → instant POST /api/orders → item appears in session list below
+5. Tap again → another item added
+6. ✕ on any session list item → DELETE /api/orders/:id → item removed from sessionOrders;
+   re-fetch guestOpenOrders to keep OpenOrdersPanel in sync
+7. 20s inactivity → clearSession() → back to guest selection
+8. Any interaction (tap product, tap ✕, change category) resets the timer
 ```
 
 ### Screen Layout (Bar Station)
@@ -56,18 +58,56 @@ The current Bar flow requires: guest select → add items to cart → click "Bes
 
 ## Component Changes
 
-### Modified
+### Modified: `GastronomyPage.jsx`
 
-| Component | Change |
-|-----------|--------|
-| `GastronomyPage.jsx` | Replace `cart` state with `sessionOrders` (array of POST responses). Add `inactivityTimer` ref. Replace `addToCart`/`submitOrder` with `tapProduct(product)`. Remove cart column from Bar layout (full-width). |
-| `ProductGrid.jsx` | Rename `onAddToCart` → `onTap`. Accept optional `sessionCounts: Map<product_id, count>` prop to show `×N` badge on product buttons when count > 0. |
+Complete list of state/function changes:
 
-### New
+| Old | New | Notes |
+|-----|-----|-------|
+| `cart` state (`[]`) | `sessionOrders` state (`[]`) | Array of POST response objects |
+| `setCart([])` everywhere | `setSessionOrders([])` everywhere | Including `onGuestSelect`, `handleNFCScan`, `confirmSettle`, `onClose` in GuestHeader |
+| `addToCart(product)` | `tapProduct(product)` | Direct POST, no cart accumulation |
+| `submitOrder()` | _(removed)_ | No submit step |
+| `submitting` state | Kept for settle flow only — NOT used by `tapProduct` | `confirmSettle` still uses `setSubmitting(true/false)` |
+| `orderSuccess` state | _(removed)_ | Success is implicit: item appears in SessionOrderList |
+| Bar layout: two columns (`flex-col md:flex-row`) | Single column (`w-full`) | Cart sidebar column removed |
+| `<OrderCart ... />` | `<SessionOrderList orders={sessionOrders} onUndo={tapUndo} />` | |
 
-| Component | Purpose |
-|-----------|---------|
-| `frontend/src/components/gastro/SessionOrderList.jsx` | Shows orders created in this session. Props: `orders`, `onUndo(orderId)`. Renders item rows with name, price, ✕ button. Shows total at bottom. Hidden when `orders.length === 0`. |
+Add `inactivityTimer` ref (`useRef(null)`). Add `resetTimer()` / `clearSession()` functions (see State Design section below).
+
+### Modified: `ProductGrid.jsx`
+
+| Change | Detail |
+|--------|--------|
+| Rename prop `onAddToCart` → `onTap` | Update all call sites |
+| Add optional prop `sessionCounts: Map<number, number>` | Default: empty Map |
+| Show `×N` badge on product button | When `sessionCounts.get(product.id) > 0`, render a small badge (top-right corner or below price): `×N` in `var(--pe-cyan-bright)`, `fontSize: 11px`, `fontWeight: bold` |
+
+### New: `SessionOrderList.jsx`
+
+**File:** `frontend/src/components/gastro/SessionOrderList.jsx`
+
+**Props:**
+```js
+orders: Array<{
+  id: number,            // order DB id — used for DELETE
+  product_id: number,
+  product_name: string,
+  price: number,         // display with .toFixed(2)
+  quantity: number,      // always 1 per entry (one tap = one row)
+  category: string,
+  status: string,
+  ordered_at: string,
+}>
+onUndo: (orderId: number) => void
+```
+
+**Render:** Hidden when `orders.length === 0`. When visible:
+- Header: `"Diese Bestellung (${orders.length} Artikel, ${total.toFixed(2)} €)"` — `fontWeight: bold`, `color: var(--pe-text)`, `fontSize: 14px`
+- Rows: each order is one row — product_name left, `${parseFloat(price).toFixed(2)} €` center, `[✕]` button right
+- ✕ button: `minWidth: 64px`, `minHeight: 64px`, `color: var(--pe-danger)`, `background: var(--pe-bg-elevated)`, `border: none`, `borderRadius: 12px`, `cursor: pointer`
+- Total row at bottom: `"Gesamt: ${total.toFixed(2)} €"` — `color: var(--pe-cyan-bright)`, `fontWeight: bold`, `textAlign: right`
+- Container: `background: var(--pe-bg-card)`, `border: 1px solid var(--pe-border)`, `borderRadius: 12px`, `padding: 12px`, `marginTop: 12px`
 
 ### Deleted
 
@@ -90,45 +130,83 @@ The current Bar flow requires: guest select → add items to cart → click "Bes
 DELETE /api/orders/:id
 ```
 
-- **Auth:** Required (referee / admin / director)
+- **Auth:** `requireAuth` middleware (same as all other order endpoints — any valid JWT)
 - **Success:** 200 `{ message: 'Order deleted' }`
-- **404:** Order not found
-- **409:** Order already paid (`status !== 'open'`)
-- Uses prepared statement: `DELETE FROM orders WHERE id = ? AND status = 'open'`
+- **404:** Order not found or already paid (use `DELETE FROM orders WHERE id = ? AND status = 'open'`; if `changes === 0`, return 404)
+- **Implementation:**
+```js
+router.delete('/:id', requireAuth, (req, res) => {
+  const result = db.prepare(
+    'DELETE FROM orders WHERE id = ? AND status = \'open\''
+  ).run(req.params.id);
+  if (result.changes === 0) return res.status(404).json({ error: 'Order not found or already paid' });
+  res.json({ message: 'Order deleted' });
+});
+```
 
 ### Modified
 
-`backend/src/routes/orders.js` — add DELETE handler.
+`backend/src/routes/orders.js` — add DELETE handler above.
+
+### POST /api/orders response shape
+
+The existing POST handler returns the full joined row. Implementers can rely on these fields in the response:
+
+```js
+{
+  id: number,           // order DB id
+  guest_id: number,
+  product_id: number,
+  product_name: string, // from JOIN with products table
+  price: number,        // float from SQLite — use .toFixed(2) for display
+  quantity: number,     // always 1 for tap-to-order
+  category: string,     // 'drink' | 'food'
+  status: string,       // 'open'
+  ordered_at: string,   // ISO datetime string
+}
+```
 
 ---
 
 ## State Design
 
-### `sessionOrders` (replaces `cart`)
+### `sessionOrders`
 
 ```js
-// Array of order objects returned by POST /api/orders
-[
-  { id: 42, product_id: 3, product_name: 'Bier', price: 3.50, quantity: 1 },
-  { id: 43, product_id: 5, product_name: 'Cola', price: 2.00, quantity: 1 },
-]
+const [sessionOrders, setSessionOrders] = useState([]);
+// Array of POST response objects (see POST response shape above)
+// Each tap appends one entry. Undo removes by order id.
 ```
-
-Each entry has `id` (order DB id) which is used for DELETE.
 
 ### `sessionCounts` (derived, not stored)
 
 ```js
-// Computed from sessionOrders on render
 const sessionCounts = sessionOrders.reduce((map, o) => {
   map.set(o.product_id, (map.get(o.product_id) || 0) + 1);
   return map;
 }, new Map());
 ```
 
-Passed to ProductGrid as prop to show `×N` badges.
+Passed to ProductGrid as prop.
+
+### `clearSession()`
+
+Resets ALL guest-related state and returns to guest selection:
+
+```js
+const clearSession = () => {
+  clearTimeout(timerRef.current);
+  setGuest(null);
+  setSessionOrders([]);
+  setGuestOpenOrders(null);
+  setProductFilter('all');
+  setIsBlocked(false);
+};
+```
 
 ### Inactivity Timer
+
+Timer starts when guest is set. Resets on every interaction.
 
 ```js
 const timerRef = useRef(null);
@@ -138,13 +216,70 @@ const resetTimer = () => {
   timerRef.current = setTimeout(clearSession, 20000); // 20 seconds
 };
 
+// Start timer when guest is selected (both manual and NFC paths):
+const selectGuest = (g) => {
+  setGuest(g);
+  setSessionOrders([]);
+  setGuestOpenOrders(null);
+  resetTimer(); // start immediately
+};
+// handleNFCScan must also call resetTimer() after resolving the guest,
+// either by delegating to selectGuest() or calling resetTimer() directly.
+
+// Reset on every interaction:
 const tapProduct = async (product) => {
   resetTimer();
   // POST /api/orders ...
 };
 
-// Also reset on: category change, ✕ undo
-// Clear timer in useEffect cleanup
+const tapUndo = async (orderId) => {
+  resetTimer();
+  // DELETE /api/orders/:id ...
+};
+
+const handleCategoryChange = (cat) => {
+  setProductFilter(cat);
+  resetTimer();
+};
+
+// Cleanup:
+useEffect(() => {
+  return () => clearTimeout(timerRef.current);
+}, []);
+```
+
+### `tapProduct(product)`
+
+```js
+const tapProduct = async (product) => {
+  resetTimer();
+  try {
+    const order = await api.post('/orders', {
+      guest_uid: guest.nfc_uid,
+      product_id: product.id,
+      quantity: 1,
+    });
+    setSessionOrders(prev => [...prev, order]);
+  } catch (err) {
+    addToast({ type: 'error', message: 'Fehler beim Buchen' });
+  }
+};
+```
+
+### `tapUndo(orderId)`
+
+```js
+const tapUndo = async (orderId) => {
+  resetTimer();
+  try {
+    await api.delete(`/orders/${orderId}`);
+    setSessionOrders(prev => prev.filter(o => o.id !== orderId));
+    // Re-fetch open orders to keep OpenOrdersPanel in sync
+    fetchGuestOpenOrders(guest.id);
+  } catch (err) {
+    addToast({ type: 'error', message: 'Rückgängig nicht möglich' });
+  }
+};
 ```
 
 ---
@@ -154,10 +289,10 @@ const tapProduct = async (product) => {
 | Scenario | Behaviour |
 |----------|-----------|
 | POST fails (network/server error) | Toast "Fehler beim Buchen" — no entry added to sessionOrders |
-| Product unavailable (backend 400) | Toast "Produkt nicht verfügbar" |
+| Product unavailable (backend 404) | Toast "Produkt nicht verfügbar" |
 | Guest blocked | ProductGrid stays dimmed (`isBlocked` prop, unchanged) |
-| DELETE fails | Toast "Rückgängig nicht möglich" — entry stays in list |
-| DELETE 409 (already paid) | Toast "Bereits abgerechnet — kann nicht entfernt werden" |
+| DELETE fails (network/server error) | Toast "Rückgängig nicht möglich" — entry stays in list |
+| DELETE 404 (not found / already paid) | Toast "Bereits abgerechnet — kann nicht entfernt werden" |
 
 ---
 
@@ -165,7 +300,7 @@ const tapProduct = async (product) => {
 
 - **Font:** Verdana, Geneva, sans-serif throughout
 - **Colors:** PE CSS tokens only (`var(--pe-*)`)
-- **Touch targets:** All buttons ≥ 64px (✕ undo buttons, product buttons already 96px)
+- **Touch targets:** All buttons ≥ 64px (✕ undo buttons min 64×64px, product buttons already 96px)
 - **Dark mode:** Always
 - **Inactivity timeout:** 20 seconds hardcoded — no config needed
 

--- a/frontend/src/components/gastro/GuestSelector.jsx
+++ b/frontend/src/components/gastro/GuestSelector.jsx
@@ -23,6 +23,7 @@ export default function GuestSelector({
 }) {
   const [manualOpen, setManualOpen] = useState(!nfcAvailable);
   const [search, setSearch] = useState('');
+  const [searchTouched, setSearchTouched] = useState(false);
 
   const filteredGuests = guests.filter(
     (g) => !search || g.name?.toLowerCase().includes(search.toLowerCase())
@@ -63,9 +64,21 @@ export default function GuestSelector({
         <div style={{ marginTop: '8px' }}>
           <GuestSearchInput
             value={search}
-            onChange={setSearch}
-            onCreateNew={() => onCreateGuest(search.trim() || 'Neuer Gast')}
+            onChange={(val) => { setSearch(val); setSearchTouched(true); }}
+            onCreateNew={search.trim() ? () => onCreateGuest(search.trim()) : undefined}
           />
+          {searchTouched && !search.trim() && (
+            <p
+              style={{
+                color: 'var(--pe-warning)',
+                fontSize: 12,
+                margin: '4px 0 0',
+                fontFamily: 'Verdana, Geneva, sans-serif',
+              }}
+            >
+              Bitte Namen eingeben
+            </p>
+          )}
 
           <div
             style={{

--- a/frontend/src/components/gastro/StationSelector.jsx
+++ b/frontend/src/components/gastro/StationSelector.jsx
@@ -9,13 +9,6 @@ const stations = [
     accent: 'var(--pe-cyan-bright)',
   },
   {
-    id: 'kitchen',
-    emoji: '🍳',
-    label: 'Küche',
-    description: 'Küchen-Tickets verwalten',
-    accent: 'var(--pe-warning)',
-  },
-  {
     id: 'register',
     emoji: '💳',
     label: 'Kasse',
@@ -74,8 +67,8 @@ export default function StationSelector({ onSelect }) {
         }
         @media (min-width: 768px) {
           .station-grid {
-            grid-template-columns: repeat(3, 1fr);
-            max-width: 720px;
+            grid-template-columns: repeat(2, 1fr);
+            max-width: 480px;
           }
         }
       `}</style>

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -1,10 +1,9 @@
 // GastronomyPage — station-split architecture
-// Stations: 'bar' (drinks + ordering), 'kitchen' (food tickets), 'register' (settle)
+// Stations: 'bar' (drinks + ordering), 'register' (settle)
 import { useEffect, useState, useCallback } from 'react';
 import { api } from '../api/client';
 import GastronomyLogin from '../components/gastro/GastronomyLogin';
 import StationSelector from '../components/gastro/StationSelector';
-import KitchenView from '../components/gastro/KitchenView';
 import RegisterView from '../components/gastro/RegisterView';
 import GuestSelector from '../components/gastro/GuestSelector';
 import GuestHeader from '../components/gastro/GuestHeader';
@@ -244,7 +243,7 @@ export default function GastronomyPage() {
   }
 
   // Station-level product filtering
-  // 'bar' shows drinks only, 'kitchen' and 'register' show all available
+  // 'bar' shows drinks only, 'register' shows all available
   const stationCategory = station === 'bar' ? 'drink' : null;
   const stationFilteredProducts = products.filter((p) => {
     if (!p.available) return false;
@@ -255,7 +254,6 @@ export default function GastronomyPage() {
   // Station badge config
   const badgeConfig = {
     bar:      { label: 'Bar',   icon: '🍺', accent: 'var(--pe-cyan-bright)', accentBg: 'rgba(0,184,255,0.12)', accentBorder: 'rgba(0,184,255,0.35)' },
-    kitchen:  { label: 'Küche', icon: '🍳', accent: 'var(--pe-warning)',     accentBg: 'rgba(255,176,32,0.12)',  accentBorder: 'rgba(255,176,32,0.35)' },
     register: { label: 'Kasse', icon: '💳', accent: 'var(--pe-success)',     accentBg: 'rgba(0,229,160,0.12)',  accentBorder: 'rgba(0,229,160,0.35)' },
   };
   const badge = badgeConfig[station];
@@ -322,7 +320,7 @@ export default function GastronomyPage() {
 
       {/* ===== BAR STATION ===== */}
       {station === 'bar' && (
-        <div className="flex flex-col md:flex-row gap-4 max-w-5xl mx-auto p-4">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 1200, margin: '0 auto', padding: 16 }} className="md:flex-row">
           {/* Left column: guest selector or guest detail + products */}
           <div className="flex-1 min-w-0">
             {!guest && (
@@ -384,14 +382,9 @@ export default function GastronomyPage() {
         </div>
       )}
 
-      {/* ===== KITCHEN STATION ===== */}
-      {station === 'kitchen' && (
-        <KitchenView />
-      )}
-
       {/* ===== REGISTER (KASSE) STATION ===== */}
       {station === 'register' && (
-        <div className="max-w-5xl mx-auto p-4">
+        <div style={{ maxWidth: 1200, margin: '0 auto', padding: 16 }}>
           <RegisterView
             guestOrders={guestOrders}
             settledIds={settledIds}


### PR DESCRIPTION
## Summary

- **#103** Remove Küche station from StationSelector — food orders use physical tickets, no digital kitchen display needed
- **#104** Bar and Kasse layouts now fill full container width on desktop (maxWidth: 1200, consistent with header bar)
- **#105** '+ Neu' button hidden when no name entered — prevents creating guests with fallback 'Neuer Gast' name; inline hint shown after user interaction

## Test Plan

- [ ] StationSelector shows only Bar and Kasse (no Küche)
- [ ] Bar station fills full width on desktop
- [ ] Kasse station fills full width on desktop
- [ ] '+ Neu' button not shown when search input is empty
- [ ] '+ Neu' works normally when a name is typed
- [ ] Inline hint 'Bitte Namen eingeben' appears after typing and clearing the name field

Closes #103
Closes #104
Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)