### PR TITLE
fix: security hardening — JWT expiry, role fallback removal, token validation

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -24,44 +24,41 @@ function verifyToken(req, res, next) {
 // NEU: Auth-Middleware die nur Authentifizierung prueft (alle Rollen erlaubt)
 const requireAuth = verifyToken;
 
-// NEU: Rollen-basierte Middleware — prueft ob User die Rolle 'admin' hat
-// Kompatibel mit alten Admin-JWTs (ohne role-Feld) und neuen User-JWTs
+// Prueft ob User explizit die Rolle 'admin' hat — kein Fallback auf fehlende Rolle
 const requireAdmin = (req, res, next) => {
   verifyToken(req, res, () => {
-    // Alte Admin-JWTs haben kein role-Feld — diese sind immer admin
-    if (!req.user.role || req.user.role === 'admin') {
+    if (req.user.role === 'admin') {
       return next();
     }
     return res.status(403).json({ error: 'Keine Admin-Berechtigung für diese Aktion' });
   });
 };
 
-// NEU: Middleware-Factory fuer eine bestimmte Rolle
+// Middleware-Factory fuer eine bestimmte Rolle — kein Fallback auf fehlende Rolle
 const requireRole = (role) => (req, res, next) => {
   verifyToken(req, res, () => {
-    if (req.user.role === role || (!req.user.role && role === 'admin')) {
+    if (req.user.role === role) {
       return next();
     }
     return res.status(403).json({ error: 'Keine Berechtigung für diese Aktion' });
   });
 };
 
-// NEU: Middleware-Factory fuer mehrere erlaubte Rollen
+// Middleware-Factory fuer mehrere erlaubte Rollen — 403 wenn role fehlt oder nicht enthalten
 const requireAny = (roles) => (req, res, next) => {
   verifyToken(req, res, () => {
-    // Alte Admin-JWTs (ohne role) gelten als 'admin'
-    const userRole = req.user.role || 'admin';
-    if (roles.includes(userRole)) {
-      return next();
+    const userRole = req.user.role;
+    if (!userRole || !roles.includes(userRole)) {
+      return res.status(403).json({ error: 'Keine Berechtigung für diese Aktion' });
     }
-    return res.status(403).json({ error: 'Keine Berechtigung für diese Aktion' });
+    return next();
   });
 };
 
 // Admin oder Turnierleitung — für alle Turnier-Management-Operationen
 const requireAdminOrDirector = (req, res, next) => {
   verifyToken(req, res, () => {
-    const role = req.user.role || 'admin';
+    const role = req.user.role;
     if (role === 'admin' || role === 'director') return next();
     return res.status(403).json({ error: 'Keine Berechtigung – Admin oder Turnierleitung erforderlich' });
   });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ import LoginSelectionPage from './pages/LoginSelectionPage';
 // NEU: Board-Ansicht importieren
 import CurrentGameView from './pages/CurrentGameView';
 import AppShell from './components/AppShell';
-import { parseJwt } from './lib/parseJwt';
+import { parseJwt, isTokenValid } from './lib/parseJwt';
 import Toaster from './components/Toaster';
 
 // NEU: Lazy imports für Seiten die von frontend-referee-admin erstellt werden
@@ -23,10 +23,10 @@ const TournamentDetailPage = lazy(() => import('./pages/TournamentDetailPage'));
 const PlayerProfilePage = lazy(() => import('./pages/PlayerProfilePage'));
 const AdminReportsPage = lazy(() => import('./pages/AdminReportsPage'));
 
-// NEU: Protected Route mit Rollenprüfung
+// Protected Route mit Rollenprüfung und Expiry-Check
 function ProtectedRoute({ element, roles }) {
   const token = localStorage.getItem('token');
-  if (!token) return <Navigate to="/" replace />;
+  if (!isTokenValid(token)) return <Navigate to="/" replace />;
   const payload = parseJwt(token);
   if (!payload || (roles && !roles.includes(payload.role))) return <Navigate to="/" replace />;
   return element;

--- a/frontend/src/lib/parseJwt.js
+++ b/frontend/src/lib/parseJwt.js
@@ -3,3 +3,11 @@ export function parseJwt(token) {
     return JSON.parse(atob(token.split('.')[1]));
   } catch { return null; }
 }
+
+export function isTokenValid(token) {
+  if (!token) return false;
+  const payload = parseJwt(token);
+  if (!payload) return false;
+  if (!payload.exp) return false;
+  return payload.exp * 1000 > Date.now();
+}

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useStore } from '../store';
+import { parseJwt, isTokenValid } from '../lib/parseJwt';
 import { api } from '../api/client';
 import { useToastStore } from '../store/toasts';
 import AdminLogin from '../components/admin/AdminLogin';
@@ -25,10 +26,6 @@ const ALL_TABS = [
   { id: 'log',         label: 'System-Log',    Icon: ScrollText,      color: 'var(--pe-text-muted)',  roles: ['admin', 'director'] },
   { id: 'help',        label: 'Hilfe',         Icon: HelpCircle,      color: 'var(--pe-text-sub)',    roles: ['admin', 'director'] },
 ];
-
-function parseJwt(token) {
-  try { return JSON.parse(atob(token.split('.')[1])); } catch { return null; }
-}
 
 // NEU: Rollen-Farben
 const ROLE_COLORS = {
@@ -2905,7 +2902,7 @@ function HelpTab() {
 export default function AdminPage() {
   const { token } = useStore();
 
-  if (!token) {
+  if (!token || !isTokenValid(token)) {
     // Overlay covers entire viewport including AppShell TopBar — no double header
     return (
       <div style={{
@@ -2926,8 +2923,8 @@ function AdminDashboard() {
   const token = useStore(s => s.token);
 
   const payload = parseJwt(token);
-  const userRole = payload?.role || 'admin';
-  const visibleTabs = ALL_TABS.filter(t => t.roles.includes(userRole));
+  const userRole = payload?.role ?? null;
+  const visibleTabs = ALL_TABS.filter(t => userRole && t.roles.includes(userRole));
 
   const [searchParams, setSearchParams] = useSearchParams();
   // Keep role-based guard: if URL names a tab not visible for this role, fall back to 'overview'

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,9 +1,13 @@
 import { create } from 'zustand';
-import { parseJwt } from '../lib/parseJwt';
+import { parseJwt, isTokenValid } from '../lib/parseJwt';
+
+const storedToken = localStorage.getItem('token');
+const validToken = isTokenValid(storedToken) ? storedToken : null;
+if (!validToken && storedToken) localStorage.removeItem('token');
 
 export const useStore = create((set) => ({
-  token: localStorage.getItem('token'),
-  role:  parseJwt(localStorage.getItem('token'))?.role ?? null,
+  token: validToken,
+  role:  parseJwt(validToken)?.role ?? null,
   admin: null,
 
   setToken: (token) => {


### PR DESCRIPTION
## Security Fixes

- **JWT expiry:** tokens now expire after 8h (`expiresIn: '8h'`) — already present in both login paths, confirmed no change needed
- **Role fallback removed:** missing `role` claim no longer defaults to `admin` in backend middleware (`requireAdmin`, `requireRole`, `requireAny`, `requireAdminOrDirector`)
- **`isTokenValid()`:** frontend helper added to `parseJwt.js` — checks token existence, parse success, presence of `exp` claim, and expiry timestamp
- **Store init:** expired tokens are cleared from localStorage on app start — no stale sessions survive a page reload
- **Route guards:** `ProtectedRoute` in `App.jsx` and `AdminPage` gate both use `isTokenValid()` instead of a simple null check
- **Inline duplicate removed:** `AdminPage.jsx` had its own inline `parseJwt` — replaced with import from `../lib/parseJwt`
- **Role fallback removed (frontend):** `payload?.role || 'admin'` in `AdminDashboard` replaced with `payload?.role ?? null`

## Manual step required (server)
Rotate `JWT_SECRET` in `backend/.env` on the server to immediately invalidate all existing infinite-lifetime tokens:
```bash
node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
```

Closes security audit findings #1–#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)