### PR TITLE
fix: restore Inter + Barlow Condensed font tokens in CSS variables

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,8 +18,8 @@
   --pe-success: #00E5A0;
   --pe-warning: #FFB020;
   --pe-danger: #FF4560;
-  --pe-font-body: Verdana, Geneva, sans-serif;
-  --pe-font-display: Verdana, Geneva, sans-serif;
+  --pe-font-body: 'Inter', system-ui, sans-serif;
+  --pe-font-display: 'Barlow Condensed', system-ui, sans-serif;
 }
 
 /* Display font utility — used for stats, numbers, headings */


### PR DESCRIPTION
## Summary
- `--pe-font-body` was set to `Verdana` after an erroneous revert
- `--pe-font-display` was also set to `Verdana`
- `index.html` already loads Inter + Barlow Condensed from Google Fonts — tokens now match

## Root cause
A previous commit restored Verdana as a fallback but accidentally overwrote the CSS token values. The font `<link>` tags in `index.html` were never touched, creating a mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)