### PR TITLE
feat: GitHub webhook auto-deploy for dev branch

### DIFF
--- a/backend/webhook.js
+++ b/backend/webhook.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// ============================================================
+// DartEvent — GitHub Webhook Receiver
+//
+// Listens on 127.0.0.1:9001 (proxied by nginx at /webhook).
+// On push to 'dev' branch: runs deploy/update-dev.sh
+//
+// Requires env vars (in backend/.env):
+//   WEBHOOK_SECRET  — must match the secret set in GitHub
+//   WEBHOOK_PORT    — optional, default 9001
+// ============================================================
+
+require('dotenv').config({ path: require('path').join(__dirname, '.env') });
+
+const http   = require('http');
+const crypto = require('crypto');
+const { exec } = require('child_process');
+
+const PORT   = process.env.WEBHOOK_PORT || 9001;
+const SECRET = process.env.WEBHOOK_SECRET || '';
+const SCRIPT = '/var/www/dartsturnier/deploy/update-dev.sh';
+
+function verifySignature(secret, payload, signature) {
+  if (!secret) return true; // no secret → skip (local dev only)
+  const hmac     = crypto.createHmac('sha256', secret);
+  const expected = 'sha256=' + hmac.update(payload).digest('hex');
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method !== 'POST' || req.url !== '/webhook') {
+    res.writeHead(404); res.end(); return;
+  }
+
+  const chunks = [];
+  req.on('data', c => chunks.push(c));
+  req.on('end', () => {
+    const payload   = Buffer.concat(chunks);
+    const signature = req.headers['x-hub-signature-256'] || '';
+
+    if (!verifySignature(SECRET, payload, signature)) {
+      console.warn('[webhook] Invalid signature — rejected');
+      res.writeHead(401); res.end('Unauthorized'); return;
+    }
+
+    let event;
+    try { event = JSON.parse(payload.toString()); }
+    catch { res.writeHead(400); res.end('Bad JSON'); return; }
+
+    const githubEvent = req.headers['x-github-event'];
+    const ref         = event.ref || '';
+
+    // Only react to pushes on the dev branch
+    if (githubEvent !== 'push' || ref !== 'refs/heads/dev') {
+      res.writeHead(200); res.end('ignored'); return;
+    }
+
+    const pusher  = event.pusher?.name || 'unknown';
+    const commits = event.commits?.length || 0;
+    console.log(`[webhook] Push to dev by ${pusher} (${commits} commit(s)) — deploying...`);
+
+    res.writeHead(200); res.end('deploying');
+
+    exec(`bash ${SCRIPT}`, { timeout: 300000 }, (err, stdout, stderr) => {
+      if (err) {
+        console.error('[webhook] Deploy FAILED:', err.message);
+        if (stderr) console.error(stderr.slice(-500));
+      } else {
+        console.log('[webhook] Deploy successful');
+        if (stdout) console.log(stdout.slice(-300));
+      }
+    });
+  });
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[webhook] Listening on 127.0.0.1:${PORT}`);
+});

--- a/deploy/dartevent-webhook.service
+++ b/deploy/dartevent-webhook.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=DartEvent GitHub Webhook Receiver
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/var/www/dartsturnier/backend
+ExecStart=/usr/bin/node /var/www/dartsturnier/backend/webhook.js
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=dartevent-webhook
+EnvironmentFile=/var/www/dartsturnier/backend/.env
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/setup-ubuntu.sh
+++ b/deploy/setup-ubuntu.sh
@@ -79,6 +79,9 @@ fi
 # JWT Secret (auto-generate)
 JWT_SECRET=$(openssl rand -hex 48)
 
+# Webhook Secret (auto-generate, only used on dev branch)
+WEBHOOK_SECRET=$(openssl rand -hex 32)
+
 # Summary
 APP_DIR="/var/www/dartsturnier"
 SERVICE_NAME="dartevent"
@@ -169,6 +172,8 @@ JWT_SECRET=$JWT_SECRET
 DB_PATH=./data/dartevent.db
 ADMIN_USERNAME=$ADMIN_USER
 ADMIN_PASSWORD=$ADMIN_PASS
+WEBHOOK_SECRET=$WEBHOOK_SECRET
+WEBHOOK_PORT=9001
 EOF
   chmod 600 "$ENV_FILE"
   chown "$SERVICE_NAME":"$SERVICE_NAME" "$ENV_FILE"
@@ -226,6 +231,17 @@ server {
             add_header Cache-Control "public, immutable";
         }
     }
+$([ "$BRANCH" = "dev" ] && cat <<'WEBHOOK_BLOCK'
+    location /webhook {
+        proxy_pass http://127.0.0.1:9001/webhook;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+WEBHOOK_BLOCK
+)
 }
 EOF
 
@@ -277,6 +293,15 @@ systemctl daemon-reload
 systemctl enable --now dartevent
 sleep 2
 
+# ── Webhook service (dev branch only) ───────────────────────
+
+if [ "$BRANCH" = "dev" ]; then
+  cp "$APP_DIR/deploy/dartevent-webhook.service" /etc/systemd/system/
+  systemctl daemon-reload
+  systemctl enable --now dartevent-webhook
+  echo -e "${GREEN}    ✓ Webhook service installed and running${NC}"
+fi
+
 # ── Final status ────────────────────────────────────────────
 
 echo ""
@@ -297,5 +322,14 @@ echo -e "  Update: ${CYAN}sudo bash $APP_DIR/deploy/update-dev.sh${NC}   (dev)"
 echo -e "         ${CYAN}sudo bash $APP_DIR/deploy/update.sh${NC}        (prod)"
 echo ""
 echo -e "  Logs:   ${CYAN}journalctl -u dartevent -f${NC}"
+if [ "$BRANCH" = "dev" ]; then
+  echo ""
+  echo -e "  ${BOLD}${YELLOW}GitHub Webhook (auto-deploy):${NC}"
+  echo -e "  Payload URL:  ${CYAN}https://$DOMAIN/webhook${NC}"
+  echo -e "  Secret:       ${CYAN}$WEBHOOK_SECRET${NC}"
+  echo -e "  Content type: application/json"
+  echo -e "  Event:        Just the push event"
+  echo -e "  ${BOLD}→ GitHub → Repo → Settings → Webhooks → Add webhook${NC}"
+fi
 echo -e "${CYAN}══════════════════════════════════════════════${NC}"
 echo ""


### PR DESCRIPTION
## Summary
- `backend/webhook.js` — lightweight Node.js HTTP server (no extra deps) on port 9001; verifies HMAC-SHA256 signature from GitHub, triggers `deploy/update-dev.sh` on pushes to `refs/heads/dev`
- `deploy/dartevent-webhook.service` — systemd unit that runs the receiver as root (needed to restart the dartevent service)
- `deploy/setup-ubuntu.sh` — extended for dev deployments:
  - auto-generates `WEBHOOK_SECRET` and writes it to `.env`
  - adds `/webhook` nginx proxy location (dev branch only)
  - installs and starts `dartevent-webhook.service`
  - prints webhook URL + secret at end of setup for GitHub config

## After merge: server setup
Re-run `setup-ubuntu.sh` on the dev server, or manually:
```bash
cp deploy/dartevent-webhook.service /etc/systemd/system/
systemctl daemon-reload && systemctl enable --now dartevent-webhook
# add WEBHOOK_SECRET=<generated> and WEBHOOK_PORT=9001 to backend/.env
# add /webhook location to nginx config, then nginx -s reload
```

## Test plan
- [ ] Push a commit to `dev` → server pulls and restarts automatically
- [ ] Send request without valid signature → 401 returned, no deploy triggered
- [ ] Push to `main` branch → webhook responds `ignored`, no deploy triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)