### PR TITLE
feat: Telegram deploy notifications via webhook

### DIFF
--- a/backend/webhook.js
+++ b/backend/webhook.js
@@ -6,19 +6,39 @@
 // On push to 'dev' branch: runs deploy/update-dev.sh
 //
 // Requires env vars (in backend/.env):
-//   WEBHOOK_SECRET  — must match the secret set in GitHub
-//   WEBHOOK_PORT    — optional, default 9001
+//   WEBHOOK_SECRET       — must match the secret set in GitHub
+//   WEBHOOK_PORT         — optional, default 9001
+//   TELEGRAM_BOT_TOKEN   — Telegram bot token from @BotFather
+//   TELEGRAM_CHAT_ID     — your Telegram chat ID
 // ============================================================
 
 require('dotenv').config({ path: require('path').join(__dirname, '.env') });
 
 const http   = require('http');
+const https  = require('https');
 const crypto = require('crypto');
 const { exec } = require('child_process');
 
 const PORT   = process.env.WEBHOOK_PORT || 9001;
 const SECRET = process.env.WEBHOOK_SECRET || '';
 const SCRIPT = '/var/www/dartsturnier/deploy/update-dev.sh';
+
+const TELEGRAM_TOKEN   = process.env.TELEGRAM_BOT_TOKEN || '';
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID || '';
+
+function sendTelegram(text) {
+  if (!TELEGRAM_TOKEN || !TELEGRAM_CHAT_ID) return;
+  const body = JSON.stringify({ chat_id: TELEGRAM_CHAT_ID, text, parse_mode: 'HTML' });
+  const req = https.request({
+    hostname: 'api.telegram.org',
+    path: `/bot${TELEGRAM_TOKEN}/sendMessage`,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+  });
+  req.on('error', e => console.error('[webhook] Telegram error:', e.message));
+  req.write(body);
+  req.end();
+}
 
 function verifySignature(secret, payload, signature) {
   if (!secret) return true; // no secret → skip (local dev only)
@@ -61,17 +81,36 @@ const server = http.createServer((req, res) => {
 
     const pusher  = event.pusher?.name || 'unknown';
     const commits = event.commits?.length || 0;
+    const commitList = (event.commits || [])
+      .slice(0, 5)
+      .map(c => `• ${c.message.split('\n')[0]}`)
+      .join('\n');
     console.log(`[webhook] Push to dev by ${pusher} (${commits} commit(s)) — deploying...`);
 
     res.writeHead(200); res.end('deploying');
 
+    const startTime = Date.now();
+
     exec(`bash ${SCRIPT}`, { timeout: 300000 }, (err, stdout, stderr) => {
+      const duration = Math.round((Date.now() - startTime) / 1000);
       if (err) {
         console.error('[webhook] Deploy FAILED:', err.message);
         if (stderr) console.error(stderr.slice(-500));
+        sendTelegram(
+          `❌ <b>Deploy fehlgeschlagen</b>\n` +
+          `👤 Push von: ${pusher} (${commits} commit(s))\n` +
+          `⏱ Dauer: ${duration}s\n\n` +
+          `<pre>${(stderr || err.message).slice(-300)}</pre>`
+        );
       } else {
         console.log('[webhook] Deploy successful');
         if (stdout) console.log(stdout.slice(-300));
+        sendTelegram(
+          `✅ <b>Deploy erfolgreich</b>\n` +
+          `👤 Push von: ${pusher} (${commits} commit(s))\n` +
+          `⏱ Dauer: ${duration}s\n\n` +
+          `${commitList}`
+        );
       }
     });
   });


### PR DESCRIPTION
## Summary
- After `update-dev.sh` completes, sends a Telegram message to the configured chat
- ✅ Success: pusher name, commit count, commit messages (up to 5), duration
- ❌ Failure: pusher name, last 300 chars of stderr, duration
- Uses native `https` module — zero new dependencies

## Setup (on server)
Add to `backend/.env`:
```
TELEGRAM_BOT_TOKEN=<token from @BotFather>
TELEGRAM_CHAT_ID=<your chat ID>
```
Then restart the webhook service:
```bash
systemctl restart dartevent-webhook
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)