### PR TITLE
fix: set trust proxy for express-rate-limit behind nginx

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -30,6 +30,9 @@ const historyRoutes = require('./routes/history');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+// Trust nginx reverse proxy (required for express-rate-limit + X-Forwarded-For)
+app.set('trust proxy', 1);
+
 // Middleware
 app.use(helmet());
 const corsOptions = {


### PR DESCRIPTION
## Summary
- Adds `app.set('trust proxy', 1)` so Express correctly reads `X-Forwarded-For` headers set by nginx
- Fixes `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` ValidationError from express-rate-limit
- Required for accurate rate limiting per client IP when running behind a reverse proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)