### PR TITLE
fix: add retry logic to git fetch in update-dev.sh

### DIFF
--- a/deploy/update-dev.sh
+++ b/deploy/update-dev.sh
@@ -25,7 +25,7 @@ echo ""
 # --- 1. Pull latest dev branch ---
 echo -e "${GREEN}>>> git pull (dev)...${NC}"
 cd "$APP_DIR"
-git fetch origin
+git fetch origin || (sleep 10 && git fetch origin) || (sleep 30 && git fetch origin)
 git checkout dev
 git pull origin dev
 


### PR DESCRIPTION
## Summary
- `git fetch origin` now retries on failure: wait 10s, retry, wait 30s, final retry
- Only triggers on network/TLS errors (non-zero exit) — normal deploys unaffected
- Addresses intermittent `gnutls_handshake() failed` errors seen on the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)