### PR TITLE
fix: use git reset --hard in update-dev.sh to avoid merge conflicts

### DIFF
--- a/deploy/update-dev.sh
+++ b/deploy/update-dev.sh
@@ -27,7 +27,7 @@ echo -e "${GREEN}>>> git pull (dev)...${NC}"
 cd "$APP_DIR"
 git fetch origin || (sleep 10 && git fetch origin) || (sleep 30 && git fetch origin)
 git checkout dev
-git pull origin dev
+git reset --hard origin/dev
 
 # --- 2. Update backend dependencies ---
 echo -e "${GREEN}>>> Backend: npm install...${NC}"


### PR DESCRIPTION
## Summary
- Replace `git pull origin dev` with `git reset --hard origin/dev`
- Prevents deploy failures when the server has uncommitted local changes
- The server's working directory should always match remote `dev` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)