### PR TITLE
fix: allow player profile creation without tournament selection

### DIFF
--- a/backend/src/routes/players.js
+++ b/backend/src/routes/players.js
@@ -176,6 +176,27 @@ router.delete('/:id/players/:playerId', requireAdminOrDirector, (req, res) => {
   res.json({ success: true });
 });
 
+// POST /api/players — Neues Spielerprofil anlegen (ohne Turnier-Anmeldung)
+router.post('/', requireAdminOrDirector, requireFields(['vorname', 'nickname', 'nachname']), (req, res) => {
+  const { vorname, nickname, nachname, walkon_youtube } = req.body;
+  const vn = vorname.trim();
+  const nn = nickname.trim();
+  const na = nachname.trim();
+
+  const existing = db.prepare('SELECT * FROM players WHERE LOWER(TRIM(nickname)) = LOWER(?)').get(nn);
+  if (existing) {
+    return res.status(409).json({ error: `Ein Spieler mit dem Nickname "${nn}" existiert bereits.` });
+  }
+
+  const displayName = `${vn} "${nn}" ${na}`;
+  const result = db.prepare(
+    'INSERT INTO players (name, vorname, nickname, nachname, walkon_youtube) VALUES (?, ?, ?, ?, ?)'
+  ).run(displayName, vn, nn, na, walkon_youtube || null);
+  const player = db.prepare('SELECT * FROM players WHERE id = ?').get(result.lastInsertRowid);
+  auditLog(req, 'player', 'CREATE', `Spielerprofil "${displayName}" angelegt`, player.id);
+  return res.status(201).json(player);
+});
+
 // GET /api/players — Alle Spielerprofile mit Gesamt-Stats
 router.get('/', (req, res) => {
   const players = db.prepare(`

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -466,9 +466,11 @@ function PlayersTab() {
 
   const handleCreate = async (e) => {
     e.preventDefault();
-    if (!form.vorname.trim() || !form.nickname.trim() || !form.nachname.trim() || !selectedTournament) return;
+    if (!form.vorname.trim() || !form.nickname.trim() || !form.nachname.trim()) return;
     try {
-      const res = await api.post(`/tournaments/${selectedTournament}/players`, form);
+      const res = selectedTournament
+        ? await api.post(`/tournaments/${selectedTournament}/players`, form)
+        : await api.post('/players', form);
       const newPlayerId = res.id || res.player_id || res.player?.id;
       if (form.walk_on_song && newPlayerId) {
         try {
@@ -711,7 +713,7 @@ function PlayersTab() {
                 </p>
               )}
               <button type="submit" disabled={!form.vorname.trim() || !form.nickname.trim() || !form.nachname.trim()} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'var(--pe-font-body)' }}>
-                Spieler anlegen & anmelden
+                {selectedTournament ? 'Spieler anlegen & anmelden' : 'Spielerprofil anlegen'}
               </button>
             </form>
           )}


### PR DESCRIPTION
## Summary
- Creating a player silently failed when no tournament was selected (missing guard)
- Root cause: player creation was hardcoded to `POST /api/tournaments/:id/players` which requires a tournament
- Players are persistent profiles by design — creation should work without a tournament

## Changes
- **Backend:** new `POST /api/players` endpoint — creates standalone player profile, no tournament registration
- **Frontend:** `handleCreate` branches on whether a tournament is selected; button label adapts accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)