### PR TITLE
feat: player delete + active tournament badge in profile registry

### DIFF
--- a/backend/src/routes/players.js
+++ b/backend/src/routes/players.js
@@ -231,6 +231,31 @@ router.put('/:id', requireAdminOrDirector, (req, res) => {
   return res.json(updated);
 });
 
+// DELETE /api/players/:id — Spielerprofil löschen (nur wenn in keinem aktiven Turnier)
+router.delete('/:id', requireAdminOrDirector, (req, res) => {
+  const playerId = parseInt(req.params.id, 10);
+  if (!playerId || playerId <= 0) return res.status(400).json({ error: 'Ungültige Spieler-ID' });
+
+  const player = db.prepare('SELECT * FROM players WHERE id = ?').get(playerId);
+  if (!player) return res.status(404).json({ error: 'Spieler nicht gefunden' });
+
+  const activeTournament = db.prepare(`
+    SELECT t.name FROM tournament_registrations tr
+    JOIN tournaments t ON t.id = tr.tournament_id
+    WHERE tr.player_id = ? AND t.status IN ('open', 'active')
+    LIMIT 1
+  `).get(playerId);
+
+  if (activeTournament) {
+    return res.status(409).json({ error: `Spieler ist noch im Turnier "${activeTournament.name}" angemeldet und kann nicht gelöscht werden.` });
+  }
+
+  db.prepare('DELETE FROM tournament_registrations WHERE player_id = ?').run(playerId);
+  db.prepare('DELETE FROM players WHERE id = ?').run(playerId);
+  auditLog(req, 'player', 'DELETE', `Spielerprofil "${player.name}" gelöscht`, playerId);
+  return res.json({ ok: true });
+});
+
 // GET /api/players — Alle Spielerprofile mit Gesamt-Stats
 router.get('/', (req, res) => {
   const players = db.prepare(`
@@ -242,7 +267,15 @@ router.get('/', (req, res) => {
       p.registered_at,
       COUNT(DISTINCT tr.tournament_id) as tournaments_count,
       COUNT(CASE WHEN g.winner_id = p.id THEN 1 END) as wins,
-      COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = p.id OR g.player2_id = p.id) AND g.winner_id != p.id THEN 1 END) as losses
+      COUNT(CASE WHEN g.status = 'finished' AND (g.player1_id = p.id OR g.player2_id = p.id) AND g.winner_id != p.id THEN 1 END) as losses,
+      (SELECT t.id FROM tournament_registrations tr2
+       JOIN tournaments t ON t.id = tr2.tournament_id
+       WHERE tr2.player_id = p.id AND t.status IN ('open', 'active')
+       ORDER BY t.id DESC LIMIT 1) AS active_tournament_id,
+      (SELECT t.name FROM tournament_registrations tr2
+       JOIN tournaments t ON t.id = tr2.tournament_id
+       WHERE tr2.player_id = p.id AND t.status IN ('open', 'active')
+       ORDER BY t.id DESC LIMIT 1) AS active_tournament_name
     FROM players p
     LEFT JOIN tournament_registrations tr ON tr.player_id = p.id
     LEFT JOIN games g ON (g.player1_id = p.id OR g.player2_id = p.id) AND g.status = 'finished'

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -558,16 +558,23 @@ function PlayersTab() {
                   <div style={{ width: '36px', height: '36px', borderRadius: '50%', flexShrink: 0, background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 'bold', fontSize: '11px', color: 'var(--pe-cyan-bright)', letterSpacing: '0.5px' }}>
                     {`${(p.vorname || '')[0] || ''}${(p.nachname || '')[0] || ''}`.toUpperCase() || '?'}
                   </div>
-                  {/* Name + walk-on status */}
+                  {/* Name + badges */}
                   <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
                     <div style={{ fontSize: '12px', fontWeight: 'bold', color: 'var(--pe-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</div>
-                    {(p.has_walkon || p.walkon_youtube) && (
-                      <WalkonBadge
-                        status={effectiveWalkonStatus}
-                        title={p.walkon_title}
-                        artist={p.walkon_artist}
-                      />
-                    )}
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: p.active_tournament_name || p.has_walkon || p.walkon_youtube ? '3px' : 0 }}>
+                      {p.active_tournament_name && (
+                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', background: 'rgba(26,79,214,0.15)', border: '1px solid rgba(26,79,214,0.4)', borderRadius: '6px', padding: '1px 6px', fontSize: '10px', color: 'var(--pe-cyan-light)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '100%' }}>
+                          🏆 {p.active_tournament_name}
+                        </span>
+                      )}
+                      {(p.has_walkon || p.walkon_youtube) && (
+                        <WalkonBadge
+                          status={effectiveWalkonStatus}
+                          title={p.walkon_title}
+                          artist={p.walkon_artist}
+                        />
+                      )}
+                    </div>
                   </div>
                   {/* Walk-On Play/Stop button — only when ready */}
                   {effectiveWalkonStatus === 'ready' && (
@@ -625,17 +632,19 @@ function PlayersTab() {
                         <input type="number" min="5" max="120" value={editingPlayer.walkon_duration ?? 30} onChange={e => setEditingPlayer({ ...editingPlayer, walkon_duration: e.target.value })} placeholder="Länge (Sek.)" required style={{ ...inputStyle, padding: '6px 8px' }} />
                       </div>
                     )}
-                    <button
-                      type="button"
-                      onClick={async () => {
-                        if (!confirm(`${p.name} löschen?`)) return;
-                        try { await api.del(`/players/${p.id}`); await loadPlayers(); }
-                        catch (err) { addToast({ type: 'error', message: err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen' }); }
-                      }}
-                      style={{ ...btnSmall, padding: '6px', fontSize: '10px', cursor: 'pointer', color: 'var(--pe-danger)' }}
-                    >
-                      Löschen
-                    </button>
+                    {!p.active_tournament_id && (
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          if (!confirm(`${p.name} löschen?`)) return;
+                          try { await api.del(`/players/${p.id}`); await loadPlayers(); }
+                          catch (err) { addToast({ type: 'error', message: err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen' }); }
+                        }}
+                        style={{ ...btnSmall, padding: '6px', fontSize: '10px', cursor: 'pointer', color: 'var(--pe-danger)' }}
+                      >
+                        Löschen
+                      </button>
+                    )}
                       <button type="submit" disabled={isSaving} style={{ ...btnSmall, background: 'var(--pe-gradient)', color: 'var(--pe-text)', borderRadius: '6px', padding: '8px', fontSize: '10px', opacity: isSaving ? 0.7 : 1, cursor: isSaving ? 'not-allowed' : 'pointer' }}>
                         {isSaving ? 'Speichert…' : 'Speichern'}
                       </button>
@@ -654,13 +663,20 @@ function PlayersTab() {
             <div key={p.id} className="p-3 rounded-lg flex justify-between items-center" style={{ background: 'var(--pe-bg-card)', border: `1px solid ${playingId === p.id ? 'var(--pe-cyan-bright)' : 'var(--pe-border)'}`, boxShadow: playingId === p.id ? '0 0 8px var(--pe-cyan-bright)' : 'none', transition: 'box-shadow 0.2s, border-color 0.2s' }}>
               <div style={{ minWidth: 0, overflow: 'hidden', flex: 1 }}>
                 <span className="font-bold" style={{ color: 'var(--pe-text)', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</span>
-                {(p.has_walkon || p.walkon_youtube) && (
-                  <WalkonBadge
-                    status={walkonStatuses[p.id] ?? p.walkon_status ?? (p.has_walkon ? 'ready' : null)}
-                    title={p.walkon_title}
-                    artist={p.walkon_artist}
-                  />
-                )}
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: p.active_tournament_name || p.has_walkon || p.walkon_youtube ? '3px' : 0 }}>
+                  {p.active_tournament_name && (
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', background: 'rgba(26,79,214,0.15)', border: '1px solid rgba(26,79,214,0.4)', borderRadius: '6px', padding: '1px 6px', fontSize: '10px', color: 'var(--pe-cyan-light)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '100%' }}>
+                      🏆 {p.active_tournament_name}
+                    </span>
+                  )}
+                  {(p.has_walkon || p.walkon_youtube) && (
+                    <WalkonBadge
+                      status={walkonStatuses[p.id] ?? p.walkon_status ?? (p.has_walkon ? 'ready' : null)}
+                      title={p.walkon_title}
+                      artist={p.walkon_artist}
+                    />
+                  )}
+                </div>
               </div>
               <div className="flex gap-2">
                 {/* Walk-On Play/Stop button — only when ready */}
@@ -707,16 +723,18 @@ function PlayersTab() {
                 >
                   Bearbeiten
                 </button>
-                <button
-                  onClick={async () => {
-                    if (!confirm(`${p.name} löschen?`)) return;
-                    try { await api.del(`/players/${p.id}`); await loadPlayers(); }
-                    catch (err) { addToast({ type: 'error', message: err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen' }); }
-                  }}
-                  style={{ ...btnSmall, padding: '4px 12px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-danger)', minHeight: '36px', cursor: 'pointer' }}
-                >
-                  Löschen
-                </button>
+                {!p.active_tournament_id && (
+                  <button
+                    onClick={async () => {
+                      if (!confirm(`${p.name} löschen?`)) return;
+                      try { await api.del(`/players/${p.id}`); await loadPlayers(); }
+                      catch (err) { addToast({ type: 'error', message: err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen' }); }
+                    }}
+                    style={{ ...btnSmall, padding: '4px 12px', background: 'var(--pe-bg-elevated)', color: 'var(--pe-danger)', minHeight: '36px', cursor: 'pointer' }}
+                  >
+                    Löschen
+                  </button>
+                )}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Backend: add `DELETE /api/players/:id` — blocked with 409 if player is in any open/active tournament
- Backend: `GET /api/players` now returns `active_tournament_id` + `active_tournament_name`
- Frontend: player cards show a 🏆 badge with the tournament name if registered in an active tournament
- Frontend: Löschen button is hidden when player is in an active tournament (desktop + mobile)

## Test plan
- [ ] Player in active tournament: 🏆 badge visible, no Löschen button
- [ ] Player not in any tournament: no badge, Löschen button visible, delete works
- [ ] Löschen → confirm → player removed from list

🤖 Generated with [Claude Code](https://claude.com/claude-code)