### PR TITLE
feat: player card UX — open animation, walkon marquee, tournament placeholder

### DIFF
--- a/frontend/src/components/WalkonBadge.jsx
+++ b/frontend/src/components/WalkonBadge.jsx
@@ -4,42 +4,70 @@
 //   artist  : string (used when status === 'ready')
 //   title   : string (used when status === 'ready')
 //   error   : string (used when status === 'error')
+import { useRef, useState, useEffect } from 'react';
 import { Loader2, AlertCircle, Music } from 'lucide-react';
+
+const badgeBase = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  borderRadius: '6px',
+  padding: '2px 7px',
+  fontSize: '11px',
+  fontFamily: 'var(--pe-font-body)',
+  maxWidth: '100%',
+  overflow: 'hidden',
+};
+
+// Marquee label: scrolls overflowing text left↔right on hover
+function MarqueeLabel({ text }) {
+  const containerRef = useRef(null);
+  const textRef = useRef(null);
+  const [shift, setShift] = useState(0);
+  const [hovered, setHovered] = useState(false);
+
+  useEffect(() => {
+    if (!containerRef.current || !textRef.current) return;
+    const overflow = textRef.current.scrollWidth - containerRef.current.clientWidth;
+    setShift(overflow > 2 ? overflow : 0);
+  }, [text]);
+
+  const duration = shift > 0 ? Math.max(2, shift / 60) : 0;
+
+  return (
+    <span
+      ref={containerRef}
+      style={{ overflow: 'hidden', minWidth: 0, flex: 1 }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <span
+        ref={textRef}
+        style={{
+          display: 'inline-block',
+          whiteSpace: 'nowrap',
+          ...(hovered && shift > 0 ? {
+            '--walkon-shift': `-${shift}px`,
+            animation: `walkon-marquee ${duration}s ease-in-out infinite alternate`,
+          } : {}),
+        }}
+      >
+        {text}
+      </span>
+    </span>
+  );
+}
 
 export default function WalkonBadge({ status, artist, title, error }) {
   if (!status || status === 'none') return null;
 
-  // Map legacy backend values to our four canonical states
   const resolvedStatus =
     status === 'pending' || status === 'downloading' ? 'loading' : status;
 
   if (resolvedStatus === 'loading') {
     return (
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '4px',
-          background: 'rgba(255,176,32,0.1)',
-          border: '1px solid rgba(255,176,32,0.3)',
-          borderRadius: '6px',
-          padding: '2px 7px',
-          fontSize: '11px',
-          color: 'var(--pe-warning)',
-          fontFamily: 'var(--pe-font-body)',
-          maxWidth: '100%',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        <Loader2
-          size={11}
-          style={{
-            flexShrink: 0,
-            animation: 'spin 1s linear infinite',
-          }}
-        />
+      <span style={{ ...badgeBase, background: 'rgba(255,176,32,0.1)', border: '1px solid rgba(255,176,32,0.3)', color: 'var(--pe-warning)', whiteSpace: 'nowrap' }}>
+        <Loader2 size={11} style={{ flexShrink: 0, animation: 'spin 1s linear infinite' }} />
         Lädt...
       </span>
     );
@@ -47,24 +75,7 @@ export default function WalkonBadge({ status, artist, title, error }) {
 
   if (resolvedStatus === 'error') {
     return (
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '4px',
-          background: 'rgba(255,69,96,0.1)',
-          border: '1px solid rgba(255,69,96,0.3)',
-          borderRadius: '6px',
-          padding: '2px 7px',
-          fontSize: '11px',
-          color: 'var(--pe-danger)',
-          fontFamily: 'var(--pe-font-body)',
-          maxWidth: '100%',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
+      <span style={{ ...badgeBase, background: 'rgba(255,69,96,0.1)', border: '1px solid rgba(255,69,96,0.3)', color: 'var(--pe-danger)', whiteSpace: 'nowrap' }}>
         <AlertCircle size={11} style={{ flexShrink: 0 }} />
         {error || 'Fehler'}
       </span>
@@ -72,48 +83,17 @@ export default function WalkonBadge({ status, artist, title, error }) {
   }
 
   if (resolvedStatus === 'ready') {
-    const label = artist && title ? `${artist} — ${title}` : 'bereit';
+    const label = artist && title ? `${artist} — ${title}` : (title || artist || 'bereit');
     return (
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '4px',
-          background: 'rgba(0,229,160,0.1)',
-          border: '1px solid rgba(0,229,160,0.3)',
-          borderRadius: '6px',
-          padding: '2px 7px',
-          fontSize: '11px',
-          color: 'var(--pe-success)',
-          fontFamily: 'var(--pe-font-body)',
-          maxWidth: '100%',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
+      <span style={{ ...badgeBase, background: 'rgba(0,229,160,0.1)', border: '1px solid rgba(0,229,160,0.3)', color: 'var(--pe-success)', overflow: 'hidden' }}>
         <Music size={11} style={{ flexShrink: 0 }} />
-        {label}
+        <MarqueeLabel text={label} />
       </span>
     );
   }
 
-  // Unknown / fallback — muted music icon
   return (
-    <span
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: '4px',
-        background: 'transparent',
-        border: '1px solid transparent',
-        borderRadius: '6px',
-        padding: '2px 7px',
-        fontSize: '11px',
-        color: 'var(--pe-text-muted)',
-        fontFamily: 'var(--pe-font-body)',
-      }}
-    >
+    <span style={{ ...badgeBase, background: 'transparent', border: '1px solid transparent', color: 'var(--pe-text-muted)' }}>
       <Music size={11} style={{ flexShrink: 0 }} />
     </span>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -160,6 +160,16 @@ body {
   to   { opacity: 0; }
 }
 
+@keyframes pe-slide-down {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes walkon-marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(var(--walkon-shift, 0px)); }
+}
+
 /* ─── Responsive nav wrappers ─── */
 /* Desktop TopNav: shown only on ≥768px */
 .pe-topnav-wrap { display: none; }

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -561,10 +561,14 @@ function PlayersTab() {
                   {/* Name + badges */}
                   <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
                     <div style={{ fontSize: '12px', fontWeight: 'bold', color: 'var(--pe-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</div>
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: p.active_tournament_name || p.has_walkon || p.walkon_youtube ? '3px' : 0 }}>
-                      {p.active_tournament_name && (
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '3px' }}>
+                      {p.active_tournament_name ? (
                         <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', background: 'rgba(26,79,214,0.15)', border: '1px solid rgba(26,79,214,0.4)', borderRadius: '6px', padding: '1px 6px', fontSize: '10px', color: 'var(--pe-cyan-light)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '100%' }}>
                           🏆 {p.active_tournament_name}
+                        </span>
+                      ) : (
+                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', background: 'transparent', border: '1px solid var(--pe-border)', borderRadius: '6px', padding: '1px 6px', fontSize: '10px', color: 'var(--pe-text-muted)' }}>
+                          kein Turnier
                         </span>
                       )}
                       {(p.has_walkon || p.walkon_youtube) && (
@@ -619,7 +623,7 @@ function PlayersTab() {
                 </div>
                 {/* Expanded accordion form */}
                 {isExpanded && (
-                  <form onSubmit={handleEdit} style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', gap: '5px' }}>
+                  <form onSubmit={handleEdit} style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', gap: '5px', animation: 'pe-slide-down 0.18s ease' }}>
                     <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '5px' }}>
                       <input type="text" value={editingPlayer.vorname} onChange={e => setEditingPlayer({ ...editingPlayer, vorname: e.target.value })} placeholder="Vorname *" required style={{ ...inputStyle, padding: '6px 8px' }} />
                       <input type="text" value={editingPlayer.nachname} onChange={e => setEditingPlayer({ ...editingPlayer, nachname: e.target.value })} placeholder="Nachname *" required style={{ ...inputStyle, padding: '6px 8px' }} />
@@ -663,10 +667,14 @@ function PlayersTab() {
             <div key={p.id} className="p-3 rounded-lg flex justify-between items-center" style={{ background: 'var(--pe-bg-card)', border: `1px solid ${playingId === p.id ? 'var(--pe-cyan-bright)' : 'var(--pe-border)'}`, boxShadow: playingId === p.id ? '0 0 8px var(--pe-cyan-bright)' : 'none', transition: 'box-shadow 0.2s, border-color 0.2s' }}>
               <div style={{ minWidth: 0, overflow: 'hidden', flex: 1 }}>
                 <span className="font-bold" style={{ color: 'var(--pe-text)', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</span>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: p.active_tournament_name || p.has_walkon || p.walkon_youtube ? '3px' : 0 }}>
-                  {p.active_tournament_name && (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '3px' }}>
+                  {p.active_tournament_name ? (
                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', background: 'rgba(26,79,214,0.15)', border: '1px solid rgba(26,79,214,0.4)', borderRadius: '6px', padding: '1px 6px', fontSize: '10px', color: 'var(--pe-cyan-light)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '100%' }}>
                       🏆 {p.active_tournament_name}
+                    </span>
+                  ) : (
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', background: 'transparent', border: '1px solid var(--pe-border)', borderRadius: '6px', padding: '1px 6px', fontSize: '10px', color: 'var(--pe-text-muted)' }}>
+                      kein Turnier
                     </span>
                   )}
                   {(p.has_walkon || p.walkon_youtube) && (


### PR DESCRIPTION
## Summary
- Card expand: `pe-slide-down` animation (opacity + translateY) when edit form opens
- WalkonBadge: text scrolls left↔right on hover if it overflows the badge width; no animation if full text fits
- Players without active tournament show a dim "kein Turnier" placeholder badge instead of nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)