### PR TITLE
feat: unified login with role-based redirect and admin nav dropdowns

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -89,7 +89,7 @@ export default function App() {
             <Route path="/tournament/:id/register" element={<PlayerRegistrationPage />} />
             <Route path="/gastronomy" element={<ProtectedRoute element={<GastronomyPage />} roles={['admin', 'gastronomy']} />} />
             <Route path="/login" element={<LoginSelectionPage />} />
-            {/* AdminPage has its own AdminLogin gate — no ProtectedRoute needed */}
+            {/* AdminPage redirects to /login internally if unauthenticated */}
             <Route path="/admin" element={<AdminPage />} />
             {/* /admin/users → redirect to /admin?tab=users */}
             <Route path="/admin/users" element={<Navigate to="/admin?tab=users" replace />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,9 +26,9 @@ const AdminReportsPage = lazy(() => import('./pages/AdminReportsPage'));
 // Protected Route mit Rollenprüfung und Expiry-Check
 function ProtectedRoute({ element, roles }) {
   const token = localStorage.getItem('token');
-  if (!isTokenValid(token)) return <Navigate to="/" replace />;
+  if (!isTokenValid(token)) return <Navigate to="/login" replace />;
   const payload = parseJwt(token);
-  if (!payload || (roles && !roles.includes(payload.role))) return <Navigate to="/" replace />;
+  if (!payload || (roles && !roles.includes(payload.role))) return <Navigate to="/login" replace />;
   return element;
 }
 
@@ -87,7 +87,7 @@ export default function App() {
             <Route path="/" element={<HomePage />} />
             <Route path="/tournament/:id" element={<TournamentPage />} />
             <Route path="/tournament/:id/register" element={<PlayerRegistrationPage />} />
-            <Route path="/gastronomy" element={<GastronomyPage />} />
+            <Route path="/gastronomy" element={<ProtectedRoute element={<GastronomyPage />} roles={['admin', 'gastronomy']} />} />
             <Route path="/login" element={<LoginSelectionPage />} />
             {/* AdminPage has its own AdminLogin gate — no ProtectedRoute needed */}
             <Route path="/admin" element={<AdminPage />} />
@@ -100,9 +100,9 @@ export default function App() {
           </Route>
 
           {/* ── Standalone routes: no shell ── */}
-          {/* /referee: login = no TopBar; board picker = TopBar only (RefereeEntryPage renders it) */}
-          <Route path="/referee" element={<RefereeEntryPage />} />
-          <Route path="/referee/:boardId" element={<RefereePage />} />
+          {/* /referee: protected — login is now handled at /login */}
+          <Route path="/referee" element={<ProtectedRoute element={<RefereeEntryPage />} roles={['admin', 'director', 'referee']} />} />
+          <Route path="/referee/:boardId" element={<ProtectedRoute element={<RefereePage />} roles={['admin', 'director', 'referee']} />} />
           <Route path="/board/:boardId" element={<CurrentGameView />} />
           <Route path="/nfc" element={<NFCScanPage />} />
           <Route path="/nfc-scan" element={<NFCScanPage />} />

--- a/frontend/src/components/TopNav.jsx
+++ b/frontend/src/components/TopNav.jsx
@@ -1,7 +1,9 @@
 // frontend/src/components/TopNav.jsx
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useStore } from '../store';
 
+// ── Flat tab definitions (public, referee, gastronomy, director) ─────────────
 const TABS = {
   public: [
     { icon: '🏠', label: 'Home',          path: '/',                        exact: true },
@@ -18,22 +20,6 @@ const TABS = {
     { icon: '📦', label: 'Produkte',      path: '/gastronomy?tab=products', exact: false },
     { icon: '📡', label: 'NFC',           path: '/nfc-scan',                exact: false },
   ],
-  admin: [
-    { icon: '🏠', label: 'Home',          path: '/',                        exact: true },
-    { icon: '📊', label: 'Übersicht',     path: '/admin',                   exact: false, noQuery: true },
-    { icon: '👑', label: 'Turnierleiter', path: '/admin?tab=director',      exact: false },
-    { icon: '🏆', label: 'Turniere',      path: '/admin?tab=tournaments',   exact: false },
-    { icon: '👥', label: 'Spieler',       path: '/admin?tab=players',       exact: false },
-    { icon: '🎯', label: 'Boards',        path: '/admin?tab=boards',        exact: false },
-    { icon: '🍽️', label: 'Gastro',        path: '/gastronomy',              exact: false, noQuery: true },
-    { icon: '👤', label: 'User',          path: '/admin?tab=users',         exact: false },
-    { icon: '📧', label: 'Mailing',       path: '/admin?tab=mailing',       exact: false },
-    { icon: '⚙️', label: 'Settings',      path: '/admin?tab=settings',      exact: false },
-    { icon: '📋', label: 'System-Log',    path: '/admin?tab=log',           exact: false },
-    { icon: '📈', label: 'Reports',       path: '/admin/reports',           exact: false },
-    { icon: '📜', label: 'Archiv',        path: '/history',                 exact: false },
-    { icon: '❓', label: 'Hilfe',          path: '/admin?tab=help',          exact: false },
-  ],
   director: [
     { icon: '📊', label: 'Übersicht',     path: '/admin',                   exact: false, noQuery: true },
     { icon: '🏆', label: 'Turniere',      path: '/admin?tab=tournaments',   exact: false },
@@ -44,6 +30,45 @@ const TABS = {
   ],
 };
 
+// ── Admin grouped nav definition ─────────────────────────────────────────────
+const ADMIN_GROUPS = [
+  { icon: '🏠', label: 'Home',     path: '/',       exact: true },
+  { icon: '📊', label: 'Übersicht', path: '/admin', noQuery: true },
+  {
+    label: 'Turnier',
+    items: [
+      { icon: '👑', label: 'Turnierleiter', path: '/admin?tab=director' },
+      { icon: '🏆', label: 'Turniere',      path: '/admin?tab=tournaments' },
+    ],
+  },
+  {
+    label: 'Spieler',
+    items: [
+      { icon: '👥', label: 'Spieler', path: '/admin?tab=players' },
+      { icon: '🎯', label: 'Boards',  path: '/admin?tab=boards' },
+    ],
+  },
+  {
+    label: 'Betrieb',
+    items: [
+      { icon: '🍽️', label: 'Gastro',  path: '/gastronomy', noQuery: true },
+      { icon: '📧', label: 'Mailing', path: '/admin?tab=mailing' },
+    ],
+  },
+  {
+    label: 'System',
+    items: [
+      { icon: '👤', label: 'User',           path: '/admin?tab=users' },
+      { icon: '⚙️', label: 'Einstellungen',  path: '/admin?tab=settings' },
+      { icon: '📋', label: 'System-Log',     path: '/admin?tab=log' },
+      { icon: '📈', label: 'Reports',        path: '/admin/reports' },
+      { icon: '❓', label: 'Hilfe',           path: '/admin?tab=help' },
+    ],
+  },
+  { icon: '📜', label: 'Archiv', path: '/history' },
+];
+
+// ── isActive helper ───────────────────────────────────────────────────────────
 function isActive(tab, pathname, search) {
   const [base, query] = tab.path.split('?');
   if (tab.exact) return pathname === base;
@@ -52,49 +77,222 @@ function isActive(tab, pathname, search) {
   return pathname.startsWith(base);
 }
 
+// ── Shared nav button style ───────────────────────────────────────────────────
+function navButtonStyle(active) {
+  return {
+    padding: '0 14px',
+    height: '100%',
+    background: 'none',
+    border: 'none',
+    borderBottom: active ? '2px solid var(--pe-cyan-bright)' : '2px solid transparent',
+    cursor: 'pointer',
+    fontSize: '12px',
+    fontWeight: active ? 'bold' : 'normal',
+    color: active ? 'var(--pe-cyan-bright)' : 'var(--pe-text-muted)',
+    whiteSpace: 'nowrap',
+    fontFamily: 'var(--pe-font-body)',
+    transition: 'color 150ms ease, border-color 150ms ease',
+  };
+}
+
+// ── Dropdown group component ──────────────────────────────────────────────────
+function DropdownGroup({ group, pathname, search, navigate, openGroup, setOpenGroup }) {
+  const groupRef = useRef(null);
+  const isOpen = openGroup === group.label;
+
+  // Check if any sub-item is active
+  const anyActive = group.items.some(item => isActive(item, pathname, search));
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e) => {
+      if (groupRef.current && !groupRef.current.contains(e.target)) {
+        setOpenGroup(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    document.addEventListener('touchstart', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('touchstart', handler);
+    };
+  }, [isOpen, setOpenGroup]);
+
+  return (
+    <div ref={groupRef} style={{ position: 'relative', height: '100%', display: 'flex', alignItems: 'stretch' }}>
+      <button
+        onClick={() => setOpenGroup(isOpen ? null : group.label)}
+        aria-expanded={isOpen}
+        style={{
+          ...navButtonStyle(anyActive),
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+        }}
+        onMouseEnter={e => { if (!anyActive) e.currentTarget.style.color = 'var(--pe-text-sub)'; }}
+        onMouseLeave={e => { if (!anyActive) e.currentTarget.style.color = 'var(--pe-text-muted)'; }}
+      >
+        {group.label}
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="currentColor"
+          style={{ transition: 'transform 150ms', transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)', flexShrink: 0 }}
+        >
+          <path d="M2 3l3 4 3-4H2z" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div style={{
+          position: 'absolute',
+          top: '100%',
+          left: 0,
+          zIndex: 1000,
+          background: 'var(--pe-bg-card)',
+          border: '1px solid var(--pe-border)',
+          borderRadius: '10px',
+          minWidth: '164px',
+          padding: '6px',
+          boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+          fontFamily: 'var(--pe-font-body)',
+        }}>
+          {group.items.map((item) => {
+            const active = isActive(item, pathname, search);
+            return (
+              <button
+                key={item.label}
+                onClick={() => { navigate(item.path); setOpenGroup(null); }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                  width: '100%',
+                  minHeight: '40px',
+                  padding: '8px 12px',
+                  background: active ? 'rgba(0,184,255,0.1)' : 'none',
+                  border: 'none',
+                  borderRadius: '7px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: active ? 'bold' : 'normal',
+                  color: active ? 'var(--pe-cyan-bright)' : 'var(--pe-text-sub)',
+                  fontFamily: 'var(--pe-font-body)',
+                  textAlign: 'left',
+                  transition: 'background 120ms, color 120ms',
+                  whiteSpace: 'nowrap',
+                }}
+                onMouseEnter={e => {
+                  if (!active) {
+                    e.currentTarget.style.background = 'var(--pe-bg-elevated)';
+                    e.currentTarget.style.color = 'var(--pe-text)';
+                  }
+                }}
+                onMouseLeave={e => {
+                  if (!active) {
+                    e.currentTarget.style.background = 'none';
+                    e.currentTarget.style.color = 'var(--pe-text-sub)';
+                  }
+                }}
+              >
+                {item.icon && <span style={{ fontSize: '13px', flexShrink: 0 }}>{item.icon}</span>}
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Admin nav (grouped) ───────────────────────────────────────────────────────
+function AdminNav({ pathname, search }) {
+  const navigate = useNavigate();
+  const [openGroup, setOpenGroup] = useState(null);
+
+  return (
+    <>
+      {ADMIN_GROUPS.map((entry) => {
+        // Grouped dropdown
+        if (entry.items) {
+          return (
+            <DropdownGroup
+              key={entry.label}
+              group={entry}
+              pathname={pathname}
+              search={search}
+              navigate={navigate}
+              openGroup={openGroup}
+              setOpenGroup={setOpenGroup}
+            />
+          );
+        }
+
+        // Standalone flat tab
+        const active = isActive(entry, pathname, search);
+        return (
+          <button
+            key={entry.label}
+            onClick={() => { navigate(entry.path); setOpenGroup(null); }}
+            aria-current={active ? 'page' : undefined}
+            style={navButtonStyle(active)}
+            onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-sub)'; }}
+            onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-muted)'; }}
+          >
+            {entry.icon && <span style={{ fontSize: '13px', marginRight: '4px' }}>{entry.icon}</span>}
+            {entry.label}
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+// ── Main TopNav ───────────────────────────────────────────────────────────────
 export default function TopNav() {
   const role = useStore(s => s.role);
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
-  const tabs = TABS[role] ?? TABS.public;
 
   return (
-    <nav aria-label="Hauptnavigation" style={{
-      background: 'var(--pe-bg-card)',
-      borderBottom: '1px solid var(--pe-border)',
-      display: 'flex', alignItems: 'stretch',
-      padding: '0 8px', height: '64px',
-      flexShrink: 0, overflowX: 'auto',
-      fontFamily: 'var(--pe-font-body)',
-      scrollbarWidth: 'none',
-    }}>
-      {tabs.map((tab) => {
-        const active = isActive(tab, pathname, search);
-        return (
-          <button
-            key={tab.label}
-            onClick={() => navigate(tab.path)}
-            aria-current={active ? 'page' : undefined}
-            style={{
-              padding: '0 14px', height: '100%',
-              background: 'none', border: 'none',
-              borderBottom: active ? '2px solid var(--pe-cyan-bright)' : '2px solid transparent',
-              cursor: 'pointer',
-              fontSize: '12px',
-              fontWeight: active ? 'bold' : 'normal',
-              color: active ? 'var(--pe-cyan-bright)' : 'var(--pe-text-muted)',
-              whiteSpace: 'nowrap',
-              fontFamily: 'var(--pe-font-body)',
-              transition: 'color 150ms ease, border-color 150ms ease',
-            }}
-            onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-sub)'; }}
-            onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-muted)'; }}
-          >
-            {tab.icon && <span style={{ fontSize: '13px', marginRight: '4px' }}>{tab.icon}</span>}
-            {tab.label}
-          </button>
-        );
-      })}
+    <nav
+      aria-label="Hauptnavigation"
+      style={{
+        background: 'var(--pe-bg-card)',
+        borderBottom: '1px solid var(--pe-border)',
+        display: 'flex',
+        alignItems: 'stretch',
+        padding: '0 8px',
+        height: '64px',
+        flexShrink: 0,
+        overflowX: 'auto',
+        fontFamily: 'var(--pe-font-body)',
+        scrollbarWidth: 'none',
+      }}
+    >
+      {role === 'admin' ? (
+        <AdminNav pathname={pathname} search={search} />
+      ) : (
+        (TABS[role] ?? TABS.public).map((tab) => {
+          const active = isActive(tab, pathname, search);
+          return (
+            <button
+              key={tab.label}
+              onClick={() => navigate(tab.path)}
+              aria-current={active ? 'page' : undefined}
+              style={navButtonStyle(active)}
+              onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-sub)'; }}
+              onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--pe-text-muted)'; }}
+            >
+              {tab.icon && <span style={{ fontSize: '13px', marginRight: '4px' }}>{tab.icon}</span>}
+              {tab.label}
+            </button>
+          );
+        })
+      )}
     </nav>
   );
 }

--- a/frontend/src/pages/LoginSelectionPage.jsx
+++ b/frontend/src/pages/LoginSelectionPage.jsx
@@ -1,42 +1,67 @@
 // frontend/src/pages/LoginSelectionPage.jsx
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { api } from '../api/client';
+import { useStore } from '../store';
+import { isTokenValid, parseJwt } from '../lib/parseJwt';
 
-const OPTIONS = [
-  {
-    icon: '📋',
-    label: 'Schiedsrichter',
-    sub: 'Boards verwalten & Würfe eingeben',
-    path: '/referee',
-    color: 'var(--pe-warning)',
-    bg: 'rgba(255,176,32,0.1)',
-    border: 'rgba(255,176,32,0.3)',
-  },
-  {
-    icon: '🛒',
-    label: 'Gastronomy / Kasse',
-    sub: 'Bestellungen & Zahlungen',
-    path: '/gastronomy',
-    color: 'var(--pe-success)',
-    bg: 'rgba(0,229,160,0.1)',
-    border: 'rgba(0,229,160,0.3)',
-  },
-  {
-    icon: '⚙️',
-    label: 'Admin / Veranstalter',
-    sub: 'Turniere, Spieler, Boards verwalten',
-    path: '/admin',
-    color: 'var(--pe-cyan-bright)',
-    bg: 'rgba(0,184,255,0.1)',
-    border: 'rgba(0,184,255,0.3)',
-  },
-];
+function getRoleRedirect(role) {
+  if (role === 'referee') return '/referee';
+  if (role === 'gastronomy') return '/gastronomy';
+  if (role === 'admin' || role === 'director') return '/admin';
+  return '/';
+}
 
-export default function LoginSelectionPage() {
+const inputStyle = {
+  background: 'var(--pe-bg-card)',
+  border: '1px solid var(--pe-border)',
+  color: 'var(--pe-text)',
+  fontFamily: 'var(--pe-font-body)',
+  minHeight: '64px',
+  borderRadius: '10px',
+  padding: '0 16px',
+  width: '100%',
+  outline: 'none',
+  fontSize: '16px',
+  boxSizing: 'border-box',
+};
+
+export default function LoginPage() {
   const navigate = useNavigate();
+  const { token, setToken } = useStore();
+  const [form, setForm] = useState({ username: '', password: '' });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // Redirect immediately if already authenticated
+  useEffect(() => {
+    if (isTokenValid(token)) {
+      const payload = parseJwt(token);
+      navigate(getRoleRedirect(payload?.role), { replace: true });
+    }
+  }, [token, navigate]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const data = await api.post('/auth/login', { username: form.username, password: form.password });
+      setToken(data.token);
+      const payload = parseJwt(data.token);
+      navigate(getRoleRedirect(payload?.role), { replace: true });
+    } catch (err) {
+      setError(err.message || 'Login fehlgeschlagen');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isDisabled = loading || !form.username.trim() || !form.password.trim();
 
   return (
     <div style={{
-      minHeight: '70vh',
+      minHeight: '80vh',
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
@@ -44,49 +69,91 @@ export default function LoginSelectionPage() {
       padding: '24px 16px',
       fontFamily: 'var(--pe-font-body)',
     }}>
-      <p style={{
-        fontSize: '10px',
-        color: 'var(--pe-text-muted)',
-        textTransform: 'uppercase',
-        letterSpacing: '1.5px',
-        marginBottom: '20px',
-      }}>
-        Bereich auswählen
-      </p>
+      <div style={{ width: '100%', maxWidth: '380px' }}>
+        {/* Logo + Title */}
+        <div style={{ textAlign: 'center', marginBottom: '36px' }}>
+          <img
+            src="/logo.jpeg"
+            alt="DartEvent Logo"
+            style={{ width: '72px', height: '72px', objectFit: 'contain', borderRadius: '16px', marginBottom: '16px' }}
+          />
+          <h1 style={{
+            margin: 0,
+            fontSize: '28px',
+            fontWeight: 'bold',
+            fontFamily: 'var(--pe-font-display)',
+            background: 'var(--pe-gradient)',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+            backgroundClip: 'text',
+          }}>
+            DartEvent
+          </h1>
+          <p style={{
+            margin: '6px 0 0',
+            fontSize: '13px',
+            color: 'var(--pe-text-muted)',
+          }}>
+            Bitte anmelden um fortzufahren
+          </p>
+        </div>
 
-      <div style={{ width: '100%', maxWidth: '420px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
-        {OPTIONS.map((opt) => (
+        {/* Form */}
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <input
+            type="text"
+            value={form.username}
+            onChange={e => setForm(f => ({ ...f, username: e.target.value }))}
+            placeholder="Benutzername"
+            autoComplete="username"
+            autoFocus
+            style={inputStyle}
+          />
+          <input
+            type="password"
+            value={form.password}
+            onChange={e => setForm(f => ({ ...f, password: e.target.value }))}
+            placeholder="Passwort"
+            autoComplete="current-password"
+            style={inputStyle}
+          />
+
+          {error && (
+            <p style={{
+              margin: 0,
+              color: 'var(--pe-danger)',
+              fontSize: '14px',
+              textAlign: 'center',
+              padding: '8px 12px',
+              background: 'rgba(255,69,96,0.1)',
+              border: '1px solid rgba(255,69,96,0.3)',
+              borderRadius: '8px',
+            }}>
+              {error}
+            </p>
+          )}
+
           <button
-            key={opt.path}
-            onClick={() => navigate(opt.path)}
+            type="submit"
+            disabled={isDisabled}
             style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '16px',
-              background: opt.bg,
-              border: `1px solid ${opt.border}`,
-              borderRadius: '14px',
-              padding: '18px 20px',
-              cursor: 'pointer',
-              textAlign: 'left',
+              background: isDisabled ? 'var(--pe-bg-elevated)' : 'var(--pe-gradient)',
+              color: isDisabled ? 'var(--pe-text-muted)' : 'var(--pe-text)',
+              border: 'none',
+              borderRadius: '10px',
+              padding: '0 16px',
               fontFamily: 'var(--pe-font-body)',
-              minHeight: '72px',
-              transition: 'opacity 120ms',
+              fontWeight: 'bold',
+              fontSize: '16px',
+              cursor: isDisabled ? 'not-allowed' : 'pointer',
+              minHeight: '64px',
+              transition: 'opacity 150ms, background 150ms',
+              marginTop: '4px',
             }}
-            onMouseEnter={e => e.currentTarget.style.opacity = '0.8'}
-            onMouseLeave={e => e.currentTarget.style.opacity = '1'}
           >
-            <span style={{ fontSize: '28px', flexShrink: 0 }}>{opt.icon}</span>
-            <div>
-              <div style={{ fontSize: '15px', fontWeight: 'bold', color: opt.color }}>
-                {opt.label}
-              </div>
-              <div style={{ fontSize: '11px', color: 'var(--pe-text-muted)', marginTop: '2px' }}>
-                {opt.sub}
-              </div>
-            </div>
+            {loading ? 'Anmelden...' : 'Anmelden'}
           </button>
-        ))}
+        </form>
       </div>
     </div>
   );

--- a/frontend/src/pages/RefereeEntryPage.jsx
+++ b/frontend/src/pages/RefereeEntryPage.jsx
@@ -1,113 +1,10 @@
 // frontend/src/pages/RefereeEntryPage.jsx
 import { useState, useEffect } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useStore } from '../store';
 import { api } from '../api/client';
 import TopBar from '../components/TopBar';
 import { useToastStore } from '../store/toasts';
-
-// ── Login form ──────────────────────────────────────────────────────────────
-function RefereeLogin({ onLogin }) {
-  const [form, setForm] = useState({ username: '', password: '' });
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-
-  const submit = async (e) => {
-    e.preventDefault();
-    setLoading(true);
-    setError('');
-    try {
-      const data = await api.post('/auth/login', form);
-      if (!['admin', 'director', 'referee'].includes(data.user?.role)) {
-        setError('Keine Berechtigung für den Referee-Bereich.');
-        return;
-      }
-      onLogin(data.token);
-    } catch (err) {
-      setError(err.message || 'Login fehlgeschlagen');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const inp = {
-    background: 'var(--pe-bg-card)',
-    border: '1px solid var(--pe-border)',
-    color: 'var(--pe-text)',
-    fontFamily: 'var(--pe-font-body)',
-    minHeight: '64px',
-    borderRadius: 'var(--pe-radius-md)',
-    padding: '0 16px',
-    width: '100%',
-    outline: 'none',
-    fontSize: '16px',
-  };
-
-  return (
-    <div style={{
-      minHeight: '80vh',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: '16px',
-      fontFamily: 'var(--pe-font-body)',
-    }}>
-      <div style={{ width: '100%', maxWidth: '380px' }}>
-        <h2 style={{
-          textAlign: 'center',
-          marginBottom: '24px',
-          fontSize: '18px',
-          background: 'var(--pe-gradient)',
-          WebkitBackgroundClip: 'text',
-          WebkitTextFillColor: 'transparent',
-          fontWeight: 'bold',
-        }}>
-          Referee Login
-        </h2>
-        <form onSubmit={submit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-          <input
-            type="text"
-            value={form.username}
-            onChange={e => setForm({ ...form, username: e.target.value })}
-            placeholder="Benutzername"
-            style={inp}
-          />
-          <input
-            type="password"
-            value={form.password}
-            onChange={e => setForm({ ...form, password: e.target.value })}
-            placeholder="Passwort"
-            style={inp}
-          />
-          {error && (
-            <p style={{ color: 'var(--pe-danger)', fontSize: '14px', textAlign: 'center' }}>
-              {error}
-            </p>
-          )}
-          <button
-            type="submit"
-            disabled={loading || !form.username || !form.password}
-            style={{
-              background: 'var(--pe-gradient)',
-              color: 'var(--pe-text)',
-              border: 'none',
-              borderRadius: 'var(--pe-radius-md)',
-              padding: '16px',
-              fontFamily: 'var(--pe-font-body)',
-              fontWeight: 'bold',
-              fontSize: '16px',
-              cursor: 'pointer',
-              minHeight: '64px',
-              opacity: loading ? 0.6 : 1,
-            }}
-          >
-            {loading ? 'Anmelden...' : 'Anmelden'}
-          </button>
-        </form>
-      </div>
-    </div>
-  );
-}
 
 // ── Board picker ────────────────────────────────────────────────────────────
 function BoardPicker() {
@@ -195,12 +92,12 @@ function BoardPicker() {
               )}
               {board.current_game && (
                 <div style={{ fontSize: '11px', color: 'var(--pe-success)', marginTop: '3px' }}>
-                  ● {board.current_game}
+                  {'\u25CF'} {board.current_game}
                 </div>
               )}
               {occupied && (
                 <div style={{ fontSize: '11px', color: 'var(--pe-danger)', marginTop: '2px' }}>
-                  🔒 Referee: {board.referee_name}
+                  Referee: {board.referee_name}
                 </div>
               )}
               {!occupied && !board.current_game && (
@@ -220,27 +117,80 @@ function BoardPicker() {
           Keine Boards eingerichtet.
         </p>
       )}
-
     </div>
   );
 }
 
-// ── Entry point ─────────────────────────────────────────────────────────────
-// Standalone page (no AppShell):
-//   - Login state:       no TopBar, no nav — just the form
-//   - Board picker state: TopBar (logo + avatar) only — no nav
-export default function RefereeEntryPage() {
-  const { setToken, token } = useStore();
+// ── Logout button ────────────────────────────────────────────────────────────
+function LogoutButton() {
+  const navigate = useNavigate();
+  const { logout } = useStore();
 
-  const handleLogin = (newToken) => {
-    setToken(newToken);
+  const handleLogout = () => {
+    logout();
+    navigate('/login', { replace: true });
   };
 
-  if (!token) return <RefereeLogin onLogin={handleLogin} />;
+  return (
+    <button
+      onClick={handleLogout}
+      title="Abmelden"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        background: 'rgba(255,69,96,0.12)',
+        border: '1px solid rgba(255,69,96,0.3)',
+        color: 'var(--pe-danger)',
+        borderRadius: '8px',
+        padding: '0 14px',
+        minHeight: '44px',
+        cursor: 'pointer',
+        fontFamily: 'var(--pe-font-body)',
+        fontSize: '13px',
+        fontWeight: '600',
+        transition: 'background 150ms, border-color 150ms',
+        flexShrink: 0,
+      }}
+      onMouseEnter={e => {
+        e.currentTarget.style.background = 'rgba(255,69,96,0.22)';
+        e.currentTarget.style.borderColor = 'rgba(255,69,96,0.6)';
+      }}
+      onMouseLeave={e => {
+        e.currentTarget.style.background = 'rgba(255,69,96,0.12)';
+        e.currentTarget.style.borderColor = 'rgba(255,69,96,0.3)';
+      }}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+        <polyline points="16 17 21 12 16 7" />
+        <line x1="21" y1="12" x2="9" y2="12" />
+      </svg>
+      Abmelden
+    </button>
+  );
+}
 
+// ── Entry point ─────────────────────────────────────────────────────────────
+// Standalone page (no AppShell). Auth is handled by ProtectedRoute in App.jsx.
+export default function RefereeEntryPage() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh', background: 'var(--pe-bg)' }}>
       <TopBar />
+      {/* Sub-header: page title + logout */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '12px 16px',
+        borderBottom: '1px solid var(--pe-border)',
+        fontFamily: 'var(--pe-font-body)',
+      }}>
+        <span style={{ fontSize: '15px', fontWeight: '600', color: 'var(--pe-text)' }}>
+          Referee
+        </span>
+        <LogoutButton />
+      </div>
       <BoardPicker />
     </div>
   );


### PR DESCRIPTION
Closes #133 (partial: login + referee + TopNav)

## Changes

- **LoginSelectionPage** → rewritten as real auth form with username/password, logo, gradient title, role-based redirect on success, and auto-redirect if token already valid
- **App.jsx** — `ProtectedRoute` now redirects to `/login` (was `/`); `/gastronomy`, `/referee`, `/referee/:boardId` wrapped with role guards
- **RefereeEntryPage** — inline `RefereeLogin` component removed (auth now at app level); logout button added in sub-header row
- **TopNav** — admin role gets grouped dropdown submenus: Turnier, Spieler, Betrieb, System (14 flat items → 4 dropdowns + 3 standalones); other roles unchanged

## Redirect table after login
| Role | Destination |
|------|-------------|
| `referee` | `/referee` |
| `gastronomy` | `/gastronomy` |
| `admin` / `director` | `/admin` |
| other | `/` |

🤖 Generated with Claude Code