### PR TITLE
feat: admin panel — auth redirect, player search, mailing tab improvements

### DIFF
--- a/frontend/src/components/gastro/ProductGrid.jsx
+++ b/frontend/src/components/gastro/ProductGrid.jsx
@@ -1,8 +1,16 @@
 // ProductGrid — category filter bar + responsive product button grid
-export default function ProductGrid({ products, onTap, isBlocked, categoryFilter, onCategoryChange, sessionCounts = new Map() }) {
+// Props:
+//   products        — array of product objects
+//   onTap           — called with product when tapped
+//   isBlocked       — if true, grid is dimmed and non-interactive
+//   categoryFilter  — current active category ('all', 'drink', 'food')
+//   onCategoryChange — called with category id when filter changes
+//   sessionCounts   — Map<product_id, count> for tap feedback
+//   isTablet        — boolean: tablet layout active (hides category bar, enlarges cards)
+export default function ProductGrid({ products, onTap, isBlocked, categoryFilter, onCategoryChange, sessionCounts = new Map(), isTablet = false }) {
   const categories = [
     { id: 'all', label: 'Alle' },
-    { id: 'drink', label: 'Getränke' },
+    { id: 'drink', label: 'Getranke' },
     { id: 'food', label: 'Speisen' },
   ];
 
@@ -11,13 +19,21 @@ export default function ProductGrid({ products, onTap, isBlocked, categoryFilter
     : products;
 
   const gridContent = (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: isTablet
+          ? 'repeat(3, 1fr)'
+          : 'repeat(2, 1fr)',
+        gap: isTablet ? '12px' : '10px',
+      }}
+    >
       {filtered.map((product) => (
         <button
           key={product.id}
           onClick={() => onTap(product)}
           style={{
-            minHeight: '96px',
+            minHeight: isTablet ? '120px' : '96px',
             borderRadius: 'var(--pe-radius-md)',
             border: '1px solid var(--pe-border)',
             background: 'var(--pe-bg-card)',
@@ -28,23 +44,31 @@ export default function ProductGrid({ products, onTap, isBlocked, categoryFilter
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            padding: '12px',
-            gap: '6px',
+            padding: isTablet ? '16px' : '12px',
+            gap: isTablet ? '8px' : '6px',
             width: '100%',
+            transition: 'background 0.1s',
           }}
         >
-          <span style={{ fontWeight: 'bold', fontSize: '14px' }}>{product.name}</span>
-          <span style={{ fontSize: '13px', color: 'var(--pe-cyan-bright)' }}>
+          <span style={{ fontWeight: 'bold', fontSize: isTablet ? '15px' : '14px' }}>
+            {product.name}
+          </span>
+          <span style={{ fontSize: isTablet ? '14px' : '13px', color: 'var(--pe-cyan-bright)' }}>
             {parseFloat(product.price).toFixed(2)} €
           </span>
           {sessionCounts.get(product.id) > 0 && (
-            <span style={{
-              fontSize: 11,
-              fontWeight: 'bold',
-              color: 'var(--pe-cyan-bright)',
-              fontFamily: 'var(--pe-font-body)',
-            }}>
-              ×{sessionCounts.get(product.id)}
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 'bold',
+                color: 'var(--pe-cyan-bright)',
+                fontFamily: 'var(--pe-font-body)',
+                background: 'rgba(0,184,255,0.15)',
+                borderRadius: 'var(--pe-radius-xl)',
+                padding: '2px 8px',
+              }}
+            >
+              x{sessionCounts.get(product.id)}
             </span>
           )}
         </button>
@@ -54,29 +78,31 @@ export default function ProductGrid({ products, onTap, isBlocked, categoryFilter
 
   return (
     <div>
-      {/* Category filter bar */}
-      <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
-        {categories.map((cat) => (
-          <button
-            key={cat.id}
-            onClick={() => onCategoryChange(cat.id)}
-            style={{
-              flex: 1,
-              minHeight: '64px',
-              borderRadius: 'var(--pe-radius-md)',
-              border: '1px solid var(--pe-border)',
-              fontFamily: 'var(--pe-font-body)',
-              fontWeight: 'bold',
-              fontSize: '15px',
-              cursor: 'pointer',
-              background: categoryFilter === cat.id ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)',
-              color: categoryFilter === cat.id ? 'var(--pe-text)' : 'var(--pe-text-sub)',
-            }}
-          >
-            {cat.label}
-          </button>
-        ))}
-      </div>
+      {/* Category filter bar — hidden on tablet (sidebar handles filtering) */}
+      {!isTablet && (
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+          {categories.map((cat) => (
+            <button
+              key={cat.id}
+              onClick={() => onCategoryChange(cat.id)}
+              style={{
+                flex: 1,
+                minHeight: '64px',
+                borderRadius: 'var(--pe-radius-md)',
+                border: '1px solid var(--pe-border)',
+                fontFamily: 'var(--pe-font-body)',
+                fontWeight: 'bold',
+                fontSize: '15px',
+                cursor: 'pointer',
+                background: categoryFilter === cat.id ? 'var(--pe-blue-deep)' : 'var(--pe-bg-elevated)',
+                color: categoryFilter === cat.id ? 'var(--pe-text)' : 'var(--pe-text-sub)',
+              }}
+            >
+              {cat.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Product grid — dimmed and non-interactive when blocked */}
       {isBlocked ? (

--- a/frontend/src/components/gastro/RegisterView.jsx
+++ b/frontend/src/components/gastro/RegisterView.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import GuestSearchInput from './GuestSearchInput';
 import RegisterGuestCard from './RegisterGuestCard';
 
-export default function RegisterView({ guestOrders, settledIds, onSettle, loading, submitting }) {
+export default function RegisterView({ guestOrders, settledIds, onSettle, loading, submitting, isTablet = false }) {
   const [search, setSearch] = useState('');
 
   const filtered = guestOrders.filter(
@@ -41,8 +41,14 @@ export default function RegisterView({ guestOrders, settledIds, onSettle, loadin
         </p>
       )}
 
-      {/* Guest cards */}
-      <div className="space-y-3">
+      {/* Guest cards — two columns on tablet, single column on mobile */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: isTablet ? 'repeat(2, 1fr)' : '1fr',
+          gap: '12px',
+        }}
+      >
         {filtered.map((g) => (
           <RegisterGuestCard
             key={g.guest_id}

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,16 +1,15 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, Navigate } from 'react-router-dom';
 import { useStore } from '../store';
 import { parseJwt, isTokenValid } from '../lib/parseJwt';
 import { api } from '../api/client';
 import { useToastStore } from '../store/toasts';
-import AdminLogin from '../components/admin/AdminLogin';
 import TournamentManager from '../components/admin/TournamentManager';
 import WalkonBadge from '../components/WalkonBadge';
 import {
   LayoutDashboard, Flag, Trophy, Users, Target,
   UserCog, UtensilsCrossed, Mail, Settings, ScrollText, HelpCircle,
-  Play, Square, Loader2,
+  Play, Square, Loader2, Search, X, Trash2,
 } from 'lucide-react';
 
 const ALL_TABS = [
@@ -327,6 +326,7 @@ function PlayersTab() {
   const [form, setForm] = useState({ vorname: '', nickname: '', nachname: '', walk_on_song: '', walkon_start: 0, walkon_duration: 30 });
   const [editingPlayer, setEditingPlayer] = useState(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
   useEffect(() => { setEditingPlayer(null); }, [isDesktop]);
 
   // Poll every 3s for players whose walk-on is still downloading
@@ -454,6 +454,16 @@ function PlayersTab() {
     }
   };
 
+  const filteredPlayers = players.filter(p => {
+    if (!searchQuery.trim()) return true;
+    const q = searchQuery.toLowerCase().trim();
+    return (
+      (p.vorname || '').toLowerCase().includes(q) ||
+      (p.nickname || '').toLowerCase().includes(q) ||
+      (p.nachname || '').toLowerCase().includes(q)
+    );
+  });
+
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: '44px', marginBottom: '16px' }}>
@@ -466,6 +476,52 @@ function PlayersTab() {
           {addMode ? 'Abbrechen' : '+ Spieler'}
         </button>
       </div>
+
+      {/* Search bar */}
+      <div style={{ position: 'relative', marginBottom: '12px' }}>
+        <span style={{
+          position: 'absolute', left: '16px', top: '50%', transform: 'translateY(-50%)',
+          color: 'var(--pe-text-muted)', pointerEvents: 'none',
+          display: 'flex', alignItems: 'center',
+        }}>
+          <Search size={16} />
+        </span>
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          placeholder="Spieler suchen…"
+          style={{
+            ...inputStyle,
+            width: '100%',
+            paddingLeft: '44px',
+            paddingRight: searchQuery ? '40px' : '16px',
+            minHeight: '52px',
+            boxSizing: 'border-box',
+            borderRadius: 'var(--pe-radius-md, 12px)',
+          }}
+        />
+        {searchQuery && (
+          <button
+            onClick={() => setSearchQuery('')}
+            style={{
+              position: 'absolute', right: '12px', top: '50%', transform: 'translateY(-50%)',
+              background: 'none', border: 'none', cursor: 'pointer',
+              color: 'var(--pe-text-muted)', padding: '4px',
+              display: 'flex', alignItems: 'center',
+            }}
+          >
+            <X size={14} />
+          </button>
+        )}
+      </div>
+
+      {/* Result count */}
+      {searchQuery && (
+        <p style={{ fontSize: '11px', color: 'var(--pe-text-muted)', marginBottom: '8px' }}>
+          {filteredPlayers.length} von {players.length} Spielern
+        </p>
+      )}
 
       {addMode === 'new' && (
         <div className="p-4 rounded-xl mb-6" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
@@ -547,7 +603,7 @@ function PlayersTab() {
 
       {isDesktop ? (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px' }}>
-          {players.map((p) => {
+          {filteredPlayers.map((p) => {
             const isExpanded = editingPlayer?.id === p.id;
             const effectiveWalkonStatus = walkonStatuses[p.id] ?? p.walkon_status ?? (p.has_walkon ? 'ready' : null);
             return (
@@ -657,13 +713,15 @@ function PlayersTab() {
               </div>
             );
           })}
-          {players.length === 0 && (
-            <p style={{ gridColumn: '1 / -1', textAlign: 'center', color: 'var(--pe-text-muted)', fontSize: '13px', padding: '24px' }}>Keine Spieler</p>
+          {filteredPlayers.length === 0 && (
+            <p style={{ gridColumn: '1 / -1', textAlign: 'center', color: 'var(--pe-text-muted)', fontSize: '13px', padding: '24px' }}>
+              {searchQuery ? `Kein Spieler gefunden für «${searchQuery}»` : 'Keine Spieler'}
+            </p>
           )}
         </div>
       ) : (
         <div className="space-y-2">
-          {players.map((p) => (
+          {filteredPlayers.map((p) => (
             <div key={p.id} className="p-3 rounded-lg flex justify-between items-center" style={{ background: 'var(--pe-bg-card)', border: `1px solid ${playingId === p.id ? 'var(--pe-cyan-bright)' : 'var(--pe-border)'}`, boxShadow: playingId === p.id ? '0 0 8px var(--pe-cyan-bright)' : 'none', transition: 'box-shadow 0.2s, border-color 0.2s' }}>
               <div style={{ minWidth: 0, overflow: 'hidden', flex: 1 }}>
                 <span className="font-bold" style={{ color: 'var(--pe-text)', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</span>
@@ -746,7 +804,11 @@ function PlayersTab() {
               </div>
             </div>
           ))}
-          {players.length === 0 && <p className="text-sm" style={{ color: 'var(--pe-text-muted)' }}>Keine Spieler</p>}
+          {filteredPlayers.length === 0 && (
+            <p className="text-sm" style={{ color: 'var(--pe-text-muted)' }}>
+              {searchQuery ? `Kein Spieler gefunden für «${searchQuery}»` : 'Keine Spieler'}
+            </p>
+          )}
         </div>
       )}
     </div>
@@ -1241,9 +1303,14 @@ function MailingTab() {
   const [form, setForm] = useState({ name: '', subject: '', body_html: '' });
   const [testEmail, setTestEmail] = useState('');
   const [sending, setSending] = useState(false);
+  const [mailStatus, setMailStatus] = useState(null);
+  const [summaryForm, setSummaryForm] = useState({ email: '', tournament_id: '' });
+  const [tournaments, setTournaments] = useState([]);
 
   useEffect(() => {
     api.get('/mail/templates').then(setTemplates).catch(() => {});
+    api.get('/mail/status').then(setMailStatus).catch(() => setMailStatus({ configured: false }));
+    api.get('/tournaments').then(setTournaments).catch(() => {});
   }, []);
 
   const handleCreate = async (e) => {
@@ -1275,11 +1342,19 @@ function MailingTab() {
   };
 
   const handleSendEventSummary = async () => {
-    if (!confirm('Event-Zusammenfassung an alle senden?')) return;
+    if (!summaryForm.email.trim()) {
+      addToast({ type: 'error', message: 'Bitte E-Mail-Adresse eingeben' });
+      return;
+    }
+    if (!confirm(`Event-Zusammenfassung an ${summaryForm.email} senden?`)) return;
     setSending(true);
     try {
-      await api.post('/mail/send-event-summary');
+      await api.post('/mail/send-event-summary', {
+        email: summaryForm.email,
+        tournament_id: summaryForm.tournament_id ? Number(summaryForm.tournament_id) : undefined,
+      });
       addToast({ type: 'success', message: 'Event-Zusammenfassung gesendet!' });
+      setSummaryForm({ email: '', tournament_id: '' });
     } catch (err) {
       addToast({ type: 'error', message: err.message || 'Aktion fehlgeschlagen – bitte erneut versuchen' });
     } finally {
@@ -1290,7 +1365,20 @@ function MailingTab() {
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: '44px', marginBottom: '16px' }}>
-        <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px', margin: 0 }}>Mailing</h2>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <h2 style={{ color: 'var(--pe-cyan-bright)', fontWeight: 'bold', fontSize: '18px', margin: 0 }}>Mailing</h2>
+          {mailStatus && (
+            <span style={{
+              fontSize: '11px', fontWeight: 'bold',
+              padding: '3px 10px', borderRadius: '20px',
+              color: mailStatus.configured ? 'var(--pe-success)' : 'var(--pe-warning)',
+              background: mailStatus.configured ? 'rgba(0,229,160,0.12)' : 'rgba(255,176,32,0.12)',
+              border: `1px solid ${mailStatus.configured ? 'rgba(0,229,160,0.3)' : 'rgba(255,176,32,0.3)'}`,
+            }}>
+              {mailStatus.configured ? `✓ SMTP: ${mailStatus.host}` : '⚠ Dry-Run'}
+            </span>
+          )}
+        </div>
         <button onClick={() => setShowForm(!showForm)} className="px-4 py-2 rounded-lg text-sm font-bold" style={{ background: 'var(--pe-blue-deep)', color: 'var(--pe-text)', fontFamily: 'var(--pe-font-body)' }}>
           {showForm ? 'Abbrechen' : '+ Template'}
         </button>
@@ -1301,6 +1389,35 @@ function MailingTab() {
           <input type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="Template-Name" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
           <input type="text" value={form.subject} onChange={(e) => setForm({ ...form, subject: e.target.value })} placeholder="Betreff" className="w-full p-3 rounded-lg outline-none" style={inputStyle} />
           <textarea value={form.body_html} onChange={(e) => setForm({ ...form, body_html: e.target.value })} placeholder="HTML Body" rows={6} className="w-full p-3 rounded-lg outline-none resize-y" style={{ ...inputStyle, minHeight: '120px' }} />
+          {/* Placeholder chips */}
+          <div>
+            <p style={{ fontSize: '11px', color: 'var(--pe-text-muted)', margin: '0 0 6px' }}>
+              Verfügbare Platzhalter (klicken zum Einfügen):
+            </p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+              {[
+                { label: '{{tournament_name}}', desc: 'Turniername' },
+                { label: '{{tournament_date}}', desc: 'Datum' },
+                { label: '{{player_count}}', desc: 'Spieleranzahl' },
+                { label: '{{game_count}}', desc: 'Spielanzahl' },
+              ].map(ph => (
+                <button
+                  key={ph.label}
+                  type="button"
+                  onClick={() => setForm(prev => ({ ...prev, body_html: (prev.body_html || '') + ph.label }))}
+                  title={ph.desc}
+                  style={{
+                    background: 'var(--pe-bg-elevated)', border: '1px solid var(--pe-border)',
+                    color: 'var(--pe-cyan-light, #5DD5FF)', borderRadius: '6px',
+                    padding: '4px 10px', fontSize: '11px', cursor: 'pointer',
+                    fontFamily: 'monospace',
+                  }}
+                >
+                  {ph.label}
+                </button>
+              ))}
+            </div>
+          </div>
           <button type="submit" disabled={!form.name.trim() || !form.subject.trim()} className="w-full py-3 rounded-lg font-bold disabled:opacity-50" style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'var(--pe-font-body)' }}>
             Template speichern
           </button>
@@ -1309,9 +1426,38 @@ function MailingTab() {
 
       <div className="space-y-2 mb-6">
         {templates.map((t) => (
-          <div key={t.id} className="p-3 rounded-lg" style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)' }}>
-            <p className="font-bold" style={{ color: 'var(--pe-text)' }}>{t.name}</p>
-            <p className="text-sm" style={{ color: 'var(--pe-text-sub)' }}>Betreff: {t.subject}</p>
+          <div key={t.id} style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)',
+            borderRadius: 'var(--pe-radius-md, 12px)', padding: '12px 16px',
+          }}>
+            <div style={{ minWidth: 0 }}>
+              <p style={{ fontWeight: 'bold', color: 'var(--pe-text)', margin: 0 }}>{t.name}</p>
+              <p style={{ fontSize: '12px', color: 'var(--pe-text-sub)', margin: '2px 0 0' }}>Betreff: {t.subject}</p>
+            </div>
+            <button
+              onClick={async () => {
+                if (!confirm(`Template «${t.name}» löschen?`)) return;
+                try {
+                  await api.del(`/mail/templates/${t.id}`);
+                  const updated = await api.get('/mail/templates');
+                  setTemplates(updated);
+                  addToast({ type: 'success', message: 'Template gelöscht' });
+                } catch (err) {
+                  addToast({ type: 'error', message: err.message || 'Löschen fehlgeschlagen' });
+                }
+              }}
+              style={{
+                background: 'rgba(255,69,96,0.12)', border: '1px solid rgba(255,69,96,0.3)',
+                color: 'var(--pe-danger)', borderRadius: '8px',
+                padding: '8px 12px', cursor: 'pointer',
+                fontFamily: 'var(--pe-font-body)', fontSize: '12px', fontWeight: 'bold',
+                flexShrink: 0, marginLeft: '12px',
+                display: 'flex', alignItems: 'center', gap: '4px',
+              }}
+            >
+              <Trash2 size={14} /> Löschen
+            </button>
           </div>
         ))}
         {templates.length === 0 && <p className="text-sm" style={{ color: 'var(--pe-text-muted)' }}>Keine Templates</p>}
@@ -1327,14 +1473,44 @@ function MailingTab() {
         </div>
       </div>
 
-      <button
-        onClick={handleSendEventSummary}
-        disabled={sending}
-        className="w-full py-3 rounded-lg font-bold disabled:opacity-50"
-        style={{ background: 'var(--pe-gradient)', color: 'var(--pe-text)', minHeight: '48px', fontFamily: 'var(--pe-font-body)' }}
-      >
-        {sending ? 'Wird gesendet...' : 'Event-Zusammenfassung senden'}
-      </button>
+      <div style={{ background: 'var(--pe-bg-card)', border: '1px solid var(--pe-border)', borderRadius: 'var(--pe-radius-md, 12px)', padding: '16px' }}>
+        <h3 style={{ fontSize: '12px', fontWeight: 'bold', color: 'var(--pe-text-sub)', margin: '0 0 12px', textTransform: 'uppercase', letterSpacing: '1px' }}>
+          Event-Zusammenfassung
+        </h3>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <input
+            type="email"
+            value={summaryForm.email}
+            onChange={e => setSummaryForm(prev => ({ ...prev, email: e.target.value }))}
+            placeholder="Empfänger E-Mail *"
+            style={{ ...inputStyle, minHeight: '52px' }}
+          />
+          <select
+            value={summaryForm.tournament_id}
+            onChange={e => setSummaryForm(prev => ({ ...prev, tournament_id: e.target.value }))}
+            style={{ ...selectStyle, minHeight: '52px' }}
+          >
+            <option value="">Turnier wählen (optional)</option>
+            {tournaments.map(t => (
+              <option key={t.id} value={t.id}>{t.name}</option>
+            ))}
+          </select>
+          <button
+            onClick={handleSendEventSummary}
+            disabled={sending || !summaryForm.email.trim()}
+            style={{
+              background: 'var(--pe-gradient)', color: 'var(--pe-text)',
+              border: 'none', borderRadius: 'var(--pe-radius-md, 12px)',
+              padding: '14px', fontFamily: 'var(--pe-font-body)',
+              fontWeight: 'bold', fontSize: '15px',
+              cursor: sending || !summaryForm.email.trim() ? 'not-allowed' : 'pointer',
+              minHeight: '52px', opacity: sending ? 0.6 : 1,
+            }}
+          >
+            {sending ? 'Wird gesendet...' : 'Zusammenfassung senden'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -2892,17 +3068,12 @@ export default function AdminPage() {
   const { token } = useStore();
 
   if (!token || !isTokenValid(token)) {
-    // Overlay covers entire viewport including AppShell TopBar — no double header
-    return (
-      <div style={{
-        position: 'fixed', inset: 0, zIndex: 500,
-        background: 'var(--pe-bg)',
-        display: 'flex', flexDirection: 'column',
-        overflow: 'auto',
-      }}>
-        <AdminLogin />
-      </div>
-    );
+    return <Navigate to="/login" replace />;
+  }
+
+  const payload = parseJwt(token);
+  if (!['admin', 'director'].includes(payload?.role)) {
+    return <Navigate to="/login" replace />;
   }
 
   return <AdminDashboard />;

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -1,8 +1,8 @@
 // GastronomyPage — station-split architecture
 // Stations: 'bar' (drinks + ordering), 'register' (settle)
+// Auth is handled by ProtectedRoute in App.jsx — no inline login gate here.
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { api } from '../api/client';
-import GastronomyLogin from '../components/gastro/GastronomyLogin';
 import StationSelector from '../components/gastro/StationSelector';
 import RegisterView from '../components/gastro/RegisterView';
 import GuestSelector from '../components/gastro/GuestSelector';
@@ -12,11 +12,18 @@ import ProductGrid from '../components/gastro/ProductGrid';
 import SessionOrderList from '../components/gastro/SessionOrderList';
 import SettleDialog from '../components/gastro/SettleDialog';
 import { useToastStore } from '../store/toasts';
-import { useStore } from '../store';
 
 export default function GastronomyPage() {
   const { addToast } = useToastStore();
-  const { token, setToken: storeSetToken } = useStore();
+
+  // Tablet detection — responsive breakpoint at 768px
+  const [isTablet, setIsTablet] = useState(() => window.matchMedia('(min-width: 768px)').matches);
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 768px)');
+    const h = (e) => setIsTablet(e.matches);
+    mq.addEventListener('change', h);
+    return () => mq.removeEventListener('change', h);
+  }, []);
 
   // Station state — persisted in sessionStorage
   const [station, setStation] = useState(() => {
@@ -82,13 +89,12 @@ export default function GastronomyPage() {
     return () => clearTimeout(timerRef.current);
   }, []);
 
-  // Load products + all guests once token is available
+  // Load products + all guests on mount
   useEffect(() => {
-    if (!token) return;
     api.get('/products').then(setProducts).catch(() => {});
     api.get('/nfc/guests').then(setAllGuests).catch(() => {});
     api.get('/tournaments/active').then((t) => { if (t?.id) setActiveTournamentId(t.id); }).catch(() => {});
-  }, [token]);
+  }, []);
 
   // Fetch open orders for a guest
   const fetchGuestOpenOrders = useCallback(async (guestId) => {
@@ -102,10 +108,9 @@ export default function GastronomyPage() {
 
   // Load open orders for the currently selected guest
   useEffect(() => {
-    if (!token) return;
     if (!guest) { setGuestOpenOrders(null); return; }
     fetchGuestOpenOrders(guest.id);
-  }, [token, guest, fetchGuestOpenOrders]);
+  }, [guest, fetchGuestOpenOrders]);
 
   // NFC scan handler
   const handleNFCScan = async (uid) => {
@@ -220,35 +225,11 @@ export default function GastronomyPage() {
 
   // Auto-refresh register view every 10 seconds
   useEffect(() => {
-    if (!token) return;
     if (station !== 'register') return;
     loadRegister();
     const interval = setInterval(loadRegister, 10000);
     return () => clearInterval(interval);
-  }, [token, station, loadRegister]);
-
-  // Login gate
-  const handleLogin = (newToken) => {
-    storeSetToken(newToken);
-  };
-
-  if (!token) {
-    return (
-      <div
-        style={{
-          position: 'fixed',
-          inset: 0,
-          zIndex: 500,
-          background: 'var(--pe-bg)',
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'auto',
-        }}
-      >
-        <GastronomyLogin onLogin={handleLogin} />
-      </div>
-    );
-  }
+  }, [station, loadRegister]);
 
   // Station gate
   if (!station) {
@@ -287,10 +268,16 @@ export default function GastronomyPage() {
     bar:      { label: 'Bar',   icon: '🍺', accent: 'var(--pe-cyan-bright)', accentBg: 'rgba(0,184,255,0.12)', accentBorder: 'rgba(0,184,255,0.35)' },
     register: { label: 'Kasse', icon: '💳', accent: 'var(--pe-success)',     accentBg: 'rgba(0,229,160,0.12)',  accentBorder: 'rgba(0,229,160,0.35)' },
   };
-  const badge = badgeConfig[station];
+
+  // Category sidebar items for tablet bar layout
+  const sidebarCategories = [
+    { id: 'all',   label: 'Alle',       icon: '⊞' },
+    { id: 'drink', label: 'Getraenke',  icon: '🍺' },
+    { id: 'food',  label: 'Speisen',    icon: '🍕' },
+  ];
 
   return (
-    <div className="min-h-screen" style={{ fontFamily: 'var(--pe-font-body)' }}>
+    <div style={{ fontFamily: 'var(--pe-font-body)', minHeight: '100vh', background: 'var(--pe-bg)' }}>
       {/* Settle confirmation dialog — rendered at top level so it works from any station */}
       {settleTarget && (
         <SettleDialog
@@ -344,63 +331,212 @@ export default function GastronomyPage() {
 
       {/* ===== BAR STATION ===== */}
       {station === 'bar' && (
-        <div style={{ width: '100%', padding: 16 }}>
+        <>
+          {/* Guest selector — always shown above the layout panels when no guest */}
           {!guest && (
-            <GuestSelector
-              guests={allGuests}
-              onGuestSelect={selectGuest}
-              onCreateGuest={(name) => {
-                const payload = { name };
-                if (activeTournamentId) payload.tournament_id = activeTournamentId;
-                return api.post('/nfc/create-manual', payload)
-                  .then((g) => { selectGuest(g); setAllGuests((prev) => [...prev, g]); })
-                  .catch((err) => addToast({ type: 'error', message: err.message }));
-              }}
-              nfcAvailable={'NDEFReader' in window}
-              onRequestNfcScan={handleNFCScan}
-              scanning={scanning}
-            />
+            <div style={{ padding: '0 16px 16px' }}>
+              <GuestSelector
+                guests={allGuests}
+                onGuestSelect={selectGuest}
+                onCreateGuest={(name) => {
+                  const payload = { name };
+                  if (activeTournamentId) payload.tournament_id = activeTournamentId;
+                  return api.post('/nfc/create-manual', payload)
+                    .then((g) => { selectGuest(g); setAllGuests((prev) => [...prev, g]); })
+                    .catch((err) => addToast({ type: 'error', message: err.message }));
+                }}
+                nfcAvailable={'NDEFReader' in window}
+                onRequestNfcScan={handleNFCScan}
+                scanning={scanning}
+              />
+            </div>
           )}
 
           {guest && (
             <>
-              <GuestHeader
-                guest={guest}
-                isBlocked={isBlocked}
-                onClose={clearSession}
-                onToggleLock={toggleGuestLock}
-                lockLoading={lockLoading}
-                onSettle={() => initSettle(guest)}
-              />
+              {/* Guest header — always full-width above the layout */}
+              <div style={{ padding: '0 16px 8px' }}>
+                <GuestHeader
+                  guest={guest}
+                  isBlocked={isBlocked}
+                  onClose={clearSession}
+                  onToggleLock={toggleGuestLock}
+                  lockLoading={lockLoading}
+                  onSettle={() => initSettle(guest)}
+                />
+              </div>
 
-              {guestOpenOrders?.items?.length > 0 && (
-                <OpenOrdersPanel items={guestOpenOrders.items} total={guestOpenOrders.total} />
-              )}
+              {/* Tablet: three-panel layout. Mobile: single-column flow */}
+              <div
+                style={{
+                  display: isTablet ? 'grid' : 'flex',
+                  gridTemplateColumns: isTablet ? '200px 1fr 280px' : undefined,
+                  flexDirection: isTablet ? undefined : 'column',
+                  height: isTablet ? 'calc(100vh - 160px)' : undefined,
+                  gap: '0',
+                  overflow: 'hidden',
+                }}
+              >
+                {/* Left panel: category sidebar (tablet only) */}
+                {isTablet && (
+                  <div
+                    style={{
+                      background: 'var(--pe-bg-elevated)',
+                      borderRight: '1px solid var(--pe-border)',
+                      overflowY: 'auto',
+                      padding: '8px 0',
+                      display: 'flex',
+                      flexDirection: 'column',
+                    }}
+                  >
+                    {sidebarCategories.map((cat) => (
+                      <button
+                        key={cat.id}
+                        onClick={() => handleCategoryChange(cat.id)}
+                        style={{
+                          width: '100%',
+                          minHeight: '52px',
+                          padding: '12px 16px',
+                          textAlign: 'left',
+                          background: productFilter === cat.id ? 'var(--pe-bg-card)' : 'transparent',
+                          borderTop: 'none',
+                          borderRight: 'none',
+                          borderBottom: '1px solid var(--pe-border)',
+                          borderLeft: productFilter === cat.id
+                            ? '3px solid var(--pe-cyan-bright)'
+                            : '3px solid transparent',
+                          color: productFilter === cat.id ? 'var(--pe-cyan-bright)' : 'var(--pe-text-sub)',
+                          cursor: 'pointer',
+                          fontFamily: 'var(--pe-font-body)',
+                          fontSize: '13px',
+                          fontWeight: productFilter === cat.id ? 'bold' : 'normal',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '10px',
+                        }}
+                      >
+                        <span style={{ fontSize: '18px' }}>{cat.icon}</span>
+                        <span>{cat.label}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
 
-              <ProductGrid
-                products={stationFilteredProducts}
-                onTap={tapProduct}
-                sessionCounts={sessionCounts}
-                isBlocked={isBlocked}
-                categoryFilter={productFilter}
-                onCategoryChange={handleCategoryChange}
-              />
+                {/* Center panel: open orders summary + product grid */}
+                <div
+                  style={{
+                    overflowY: 'auto',
+                    padding: isTablet ? '12px' : '0 16px',
+                    flex: isTablet ? undefined : 1,
+                  }}
+                >
+                  {/* Open orders accordion — only on mobile (tablet shows them in right panel) */}
+                  {!isTablet && guestOpenOrders?.items?.length > 0 && (
+                    <div style={{ marginBottom: '8px' }}>
+                      <OpenOrdersPanel items={guestOpenOrders.items} total={guestOpenOrders.total} />
+                    </div>
+                  )}
 
-              <SessionOrderList orders={sessionOrders} onUndo={tapUndo} />
+                  <ProductGrid
+                    products={stationFilteredProducts}
+                    onTap={tapProduct}
+                    sessionCounts={sessionCounts}
+                    isBlocked={isBlocked}
+                    categoryFilter={productFilter}
+                    onCategoryChange={handleCategoryChange}
+                    isTablet={isTablet}
+                  />
+
+                  {/* Session order list below grid on mobile */}
+                  {!isTablet && (
+                    <SessionOrderList orders={sessionOrders} onUndo={tapUndo} />
+                  )}
+                </div>
+
+                {/* Right panel: order summary (tablet only) */}
+                {isTablet && (
+                  <div
+                    style={{
+                      background: 'var(--pe-bg-card)',
+                      borderLeft: '1px solid var(--pe-border)',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      overflowY: 'auto',
+                    }}
+                  >
+                    {/* Open orders section */}
+                    {guestOpenOrders?.items?.length > 0 && (
+                      <div style={{ padding: '12px', borderBottom: '1px solid var(--pe-border)' }}>
+                        <p style={{
+                          margin: '0 0 8px',
+                          fontSize: '11px',
+                          textTransform: 'uppercase',
+                          color: 'var(--pe-text-muted)',
+                          fontWeight: 'bold',
+                          letterSpacing: '0.05em',
+                          fontFamily: 'var(--pe-font-body)',
+                        }}>
+                          Offene Bestellungen
+                        </p>
+                        <OpenOrdersPanel items={guestOpenOrders.items} total={guestOpenOrders.total} />
+                      </div>
+                    )}
+
+                    {/* Session orders section — fills remaining space */}
+                    <div style={{ flex: 1, padding: '12px', display: 'flex', flexDirection: 'column' }}>
+                      <p style={{
+                        margin: '0 0 8px',
+                        fontSize: '11px',
+                        textTransform: 'uppercase',
+                        color: 'var(--pe-text-muted)',
+                        fontWeight: 'bold',
+                        letterSpacing: '0.05em',
+                        fontFamily: 'var(--pe-font-body)',
+                      }}>
+                        Diese Bestellung
+                      </p>
+
+                      {sessionOrders.length === 0 ? (
+                        <p style={{
+                          color: 'var(--pe-text-muted)',
+                          fontSize: '13px',
+                          textAlign: 'center',
+                          padding: '24px 0',
+                          fontFamily: 'var(--pe-font-body)',
+                        }}>
+                          Noch nichts bestellt
+                        </p>
+                      ) : (
+                        <div style={{ flex: 1, overflowY: 'auto' }}>
+                          <SessionOrderList orders={sessionOrders} onUndo={tapUndo} />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
             </>
           )}
-        </div>
+        </>
       )}
 
       {/* ===== REGISTER (KASSE) STATION ===== */}
       {station === 'register' && (
-        <div style={{ width: '100%', padding: 16 }}>
+        <div
+          style={{
+            width: '100%',
+            padding: isTablet ? '16px 24px' : '16px',
+            maxWidth: isTablet ? '960px' : undefined,
+            margin: isTablet ? '0 auto' : undefined,
+          }}
+        >
           <RegisterView
             guestOrders={guestOrders}
             settledIds={settledIds}
             onSettle={initSettle}
             loading={registerLoading}
             submitting={submitting}
+            isTablet={isTablet}
           />
         </div>
       )}


### PR DESCRIPTION
Closes #134
Partially closes #133, #135

## Changes

- **Auth redirect**: Replace the fullscreen AdminLogin overlay gate with `<Navigate to="/login" replace />`. Added a second role guard: non-admin/director tokens also redirect. Removed the now-unused `AdminLogin` import.
- **PlayersTab — client-side search**: Added a search bar above the player list with a `Search` icon and an inline clear (`X`) button. A `filteredPlayers` computed list drives both the desktop grid and the mobile list. A result count indicator shows `N von M Spielern` when a query is active. Empty states adapt to the active query.
- **MailingTab — SMTP status badge**: Loads `/mail/status` on mount; renders a green `✓ SMTP: host` or amber `⚠ Dry-Run` pill next to the heading.
- **MailingTab — delete template**: Each template card gets a `Trash2` delete button that calls `api.del(/mail/templates/:id)` and reloads the list.
- **MailingTab — placeholder chips**: Clickable monospace chip buttons below the body textarea insert `{{tournament_name}}`, `{{tournament_date}}`, `{{player_count}}`, `{{game_count}}` into the textarea.
- **MailingTab — Event-Zusammenfassung form**: Replaced the bare send button with a proper panel (email input + optional tournament selector + submit button). `handleSendEventSummary` validates the email field before sending.

## New icons imported
`Search`, `X`, `Trash2` added to the lucide-react import line.

🤖 Generated with Claude Code