### PR TITLE
feat: replace admin/director nav with icon rail + flyout panel

### DIFF
--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -1,24 +1,36 @@
 // frontend/src/components/AppShell.jsx
 import { Outlet } from 'react-router-dom';
+import { useStore } from '../store';
 import TopBar from './TopBar';
 import BottomNav from './BottomNav';
 import TopNav from './TopNav';
 
 export default function AppShell() {
+  const role = useStore(s => s.role);
+  const isRailRole = role === 'admin' || role === 'director';
+
+  if (isRailRole) {
+    // Rail layout: nav left, content right (no TopBar or BottomNav)
+    return (
+      <div style={{ display: 'flex', minHeight: '100vh', background: 'var(--pe-bg)' }}>
+        <TopNav />
+        <main style={{ flex: 1, minWidth: 0, overflowY: 'auto' }}>
+          <Outlet />
+        </main>
+      </div>
+    );
+  }
+
+  // Standard column layout for all other roles
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <TopBar />
-
-      {/* Desktop top nav — hidden on mobile via CSS */}
       <div className="pe-topnav-wrap">
         <TopNav />
       </div>
-
       <main style={{ flex: 1 }}>
         <Outlet />
       </main>
-
-      {/* Mobile bottom nav — hidden on desktop via CSS */}
       <div className="pe-bottomnav-wrap">
         <BottomNav />
       </div>

--- a/frontend/src/components/TopNav.jsx
+++ b/frontend/src/components/TopNav.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useStore } from '../store';
 
-// ── Flat tab definitions (public, referee, gastronomy, director) ─────────────
+// ── Flat tab definitions (public, referee, gastronomy) ───────────────────────
 const TABS = {
   public: [
     { icon: '🏠', label: 'Home',          path: '/',                        exact: true },
@@ -20,53 +20,66 @@ const TABS = {
     { icon: '📦', label: 'Produkte',      path: '/gastronomy?tab=products', exact: false },
     { icon: '📡', label: 'NFC',           path: '/nfc-scan',                exact: false },
   ],
-  director: [
-    { icon: '📊', label: 'Übersicht',     path: '/admin',                   exact: false, noQuery: true },
-    { icon: '🏆', label: 'Turniere',      path: '/admin?tab=tournaments',   exact: false },
-    { icon: '👥', label: 'Spieler',       path: '/admin?tab=players',       exact: false },
-    { icon: '🎯', label: 'Boards',        path: '/admin?tab=boards',        exact: false },
-    { icon: '📋', label: 'System-Log',    path: '/admin?tab=log',           exact: false },
-    { icon: '📜', label: 'Archiv',        path: '/history',                 exact: false },
-  ],
 };
 
-// ── Admin grouped nav definition ─────────────────────────────────────────────
-const ADMIN_GROUPS = [
-  { icon: '🏠', label: 'Home',      path: '/',      exact: true },
-  { icon: '📊', label: 'Übersicht', path: '/admin', noQuery: true },
-  {
-    label: 'Turnier',
-    items: [
-      { icon: '👑', label: 'Turnierleiter', path: '/admin?tab=director' },
-      { icon: '🏆', label: 'Turniere',      path: '/admin?tab=tournaments' },
-    ],
-  },
-  {
-    label: 'Spieler',
-    items: [
-      { icon: '👥', label: 'Spieler', path: '/admin?tab=players' },
-      { icon: '🎯', label: 'Boards',  path: '/admin?tab=boards' },
-    ],
-  },
-  {
-    label: 'Betrieb',
-    items: [
-      { icon: '🍽️', label: 'Gastro',  path: '/gastronomy', noQuery: true },
-      { icon: '📧', label: 'Mailing', path: '/admin?tab=mailing' },
-    ],
-  },
-  {
-    label: 'System',
-    items: [
-      { icon: '👤', label: 'User',          path: '/admin?tab=users' },
-      { icon: '⚙️', label: 'Einstellungen', path: '/admin?tab=settings' },
-      { icon: '📋', label: 'System-Log',    path: '/admin?tab=log' },
-      { icon: '📈', label: 'Reports',       path: '/admin/reports' },
-      { icon: '❓', label: 'Hilfe',          path: '/admin?tab=help' },
-    ],
-  },
-  { icon: '📜', label: 'Archiv', path: '/history' },
-];
+// ── Rail nav data (admin + director) ─────────────────────────────────────────
+const RAIL_GROUPS = {
+  admin: [
+    { icon: '🏠', label: 'Home',      path: '/',     exact: true },
+    { icon: '📊', label: 'Übersicht', path: '/admin', noQuery: true },
+    {
+      label: 'Turnier', icon: '🏆',
+      items: [
+        { icon: '👑', label: 'Turnierleiter', path: '/admin?tab=director' },
+        { icon: '🏆', label: 'Turniere',      path: '/admin?tab=tournaments' },
+      ],
+    },
+    {
+      label: 'Spieler', icon: '👥',
+      items: [
+        { icon: '👥', label: 'Spieler', path: '/admin?tab=players' },
+        { icon: '🎯', label: 'Boards',  path: '/admin?tab=boards' },
+      ],
+    },
+    {
+      label: 'Betrieb', icon: '⚡',
+      items: [
+        { icon: '🍽️', label: 'Gastro',  path: '/gastronomy', noQuery: true },
+        { icon: '📧', label: 'Mailing', path: '/admin?tab=mailing' },
+      ],
+    },
+    {
+      label: 'System', icon: '⚙️',
+      items: [
+        { icon: '👤', label: 'User',           path: '/admin?tab=users' },
+        { icon: '⚙️', label: 'Einstellungen',  path: '/admin?tab=settings' },
+        { icon: '📋', label: 'System-Log',     path: '/admin?tab=log' },
+        { icon: '📈', label: 'Reports',        path: '/admin/reports' },
+        { icon: '❓', label: 'Hilfe',           path: '/admin?tab=help' },
+      ],
+    },
+    { icon: '📜', label: 'Archiv', path: '/history' },
+  ],
+  director: [
+    { icon: '🏠', label: 'Home',      path: '/',     exact: true },
+    { icon: '📊', label: 'Übersicht', path: '/admin', noQuery: true },
+    {
+      label: 'Turnier', icon: '🏆',
+      items: [
+        { icon: '🏆', label: 'Turniere', path: '/admin?tab=tournaments' },
+      ],
+    },
+    {
+      label: 'Spieler', icon: '👥',
+      items: [
+        { icon: '👥', label: 'Spieler', path: '/admin?tab=players' },
+        { icon: '🎯', label: 'Boards',  path: '/admin?tab=boards' },
+      ],
+    },
+    { icon: '📋', label: 'System-Log', path: '/admin?tab=log' },
+    { icon: '📜', label: 'Archiv',     path: '/history' },
+  ],
+};
 
 // ── isActive helper ───────────────────────────────────────────────────────────
 function isActive(tab, pathname, search) {
@@ -99,183 +112,331 @@ function navBtnStyle(active, height = '100%') {
   };
 }
 
-// ── Admin nav with animated sub-nav bar ───────────────────────────────────────
-function AdminNav({ pathname, search }) {
-  const navigate = useNavigate();
-  // activeGroup: which group's sub-nav is visible (hover or pinned)
-  const [activeGroup, setActiveGroup] = useState(null);
-  // pinnedGroup: stays open after click until clicked again or route changes
-  const [pinnedGroup, setPinnedGroup] = useState(null);
-  const wrapperRef = useRef(null);
-  const closeTimer = useRef(null);
+// ── RailNav: icon rail + slide-out flyout ─────────────────────────────────────
+function RailNav({ role }) {
+  const navigate  = useNavigate();
+  const { pathname, search } = useLocation();
+  const { logout } = useStore();
+  const [openGroup, setOpenGroup] = useState(null);
+  const [animKey,   setAnimKey]   = useState(0);
+  const [showLogout, setShowLogout] = useState(false);
+  const wrapperRef  = useRef(null);
+  const logoutRef   = useRef(null);
 
-  // Close sub-nav on route change
-  useEffect(() => {
-    setActiveGroup(null);
-    setPinnedGroup(null);
-  }, [pathname, search]);
+  const groups = RAIL_GROUPS[role] ?? RAIL_GROUPS.admin;
+  const currentGroup = openGroup
+    ? groups.find(g => g.items && g.label === openGroup)
+    : null;
 
-  // Close on outside click
+  // Close flyout on route change
+  useEffect(() => { setOpenGroup(null); }, [pathname, search]);
+
+  // Outside click: close flyout
   useEffect(() => {
     const handler = (e) => {
       if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
-        setActiveGroup(null);
-        setPinnedGroup(null);
+        setOpenGroup(null);
       }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
-  // Delayed close — allows mouse to travel from main nav to sub-nav without flicker
-  const scheduleClose = useCallback(() => {
-    clearTimeout(closeTimer.current);
-    closeTimer.current = setTimeout(() => {
-      if (!pinnedGroup) setActiveGroup(null);
-    }, 120);
-  }, [pinnedGroup]);
+  // Outside click: close logout popover
+  useEffect(() => {
+    if (!showLogout) return;
+    const handler = (e) => {
+      if (logoutRef.current && !logoutRef.current.contains(e.target)) {
+        setShowLogout(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showLogout]);
 
-  const cancelClose = useCallback(() => {
-    clearTimeout(closeTimer.current);
-  }, []);
-
-  const handleGroupHover = useCallback((label) => {
-    cancelClose();
-    setActiveGroup(label);
-  }, [cancelClose]);
-
-  const handleGroupClick = useCallback((label) => {
-    if (pinnedGroup === label) {
-      setPinnedGroup(null);
-      setActiveGroup(null);
+  const handleRailClick = useCallback((entry) => {
+    if (entry.items) {
+      if (openGroup === entry.label) {
+        setOpenGroup(null);
+      } else {
+        setAnimKey(k => k + 1);
+        setOpenGroup(entry.label);
+      }
     } else {
-      setPinnedGroup(label);
-      setActiveGroup(label);
+      navigate(entry.path);
+      setOpenGroup(null);
     }
-  }, [pinnedGroup]);
+  }, [openGroup, navigate]);
 
   const handleItemClick = useCallback((path) => {
     navigate(path);
-    setPinnedGroup(null);
-    setActiveGroup(null);
+    setOpenGroup(null);
   }, [navigate]);
 
-  const currentGroup = activeGroup
-    ? ADMIN_GROUPS.find(g => g.items && g.label === activeGroup)
-    : null;
+  const isGroupActive = useCallback((entry) => {
+    if (!entry.items) return isActive(entry, pathname, search);
+    return entry.items.some(item => isActive(item, pathname, search));
+  }, [pathname, search]);
 
-  const subNavOpen = !!currentGroup;
+  const initials = role.slice(0, 2).toUpperCase();
 
   return (
-    <div ref={wrapperRef}>
-      {/* ── Main nav bar ── */}
-      <nav
-        aria-label="Hauptnavigation"
-        style={{
-          background: 'var(--pe-bg-card)',
-          borderBottom: subNavOpen ? 'none' : '1px solid var(--pe-border)',
-          display: 'flex',
-          alignItems: 'stretch',
-          padding: '0 8px',
-          height: '64px',
-          flexShrink: 0,
-          overflowX: 'auto',
-          fontFamily: 'var(--pe-font-body)',
-          scrollbarWidth: 'none',
-        }}
-      >
-        {ADMIN_GROUPS.map((entry) => {
-          if (entry.items) {
-            const isOpen = activeGroup === entry.label;
-            const anyActive = entry.items.some(item => isActive(item, pathname, search));
-            const highlight = isOpen || anyActive;
-            return (
-              <button
-                key={entry.label}
-                style={navBtnStyle(highlight)}
-                onMouseEnter={() => handleGroupHover(entry.label)}
-                onMouseLeave={scheduleClose}
-                onClick={() => handleGroupClick(entry.label)}
-                aria-expanded={isOpen}
-              >
-                {entry.label}
-                <svg
-                  width="10" height="10" viewBox="0 0 10 10" fill="currentColor"
-                  style={{
-                    transition: 'transform 200ms ease',
-                    transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
-                    flexShrink: 0,
-                    opacity: 0.7,
-                  }}
-                >
-                  <path d="M2 3l3 4 3-4H2z" />
-                </svg>
-              </button>
-            );
-          }
+    <div
+      ref={wrapperRef}
+      className={openGroup ? 'rail-no-tooltips' : ''}
+      style={{ position: 'relative', display: 'flex', flexShrink: 0 }}
+    >
+      {/* ── Icon Rail (60px) ── */}
+      <div style={{
+        width: 60,
+        background: 'var(--pe-bg-card)',
+        borderRight: '1px solid var(--pe-border)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        padding: '12px 0',
+        height: '100vh',
+        position: 'sticky',
+        top: 0,
+        flexShrink: 0,
+        zIndex: 20,
+        fontFamily: 'var(--pe-font-body)',
+      }}>
 
-          // Standalone tab
-          const active = isActive(entry, pathname, search);
+        {/* Logo */}
+        <img
+          src="/logo.jpeg"
+          alt="DartEvent"
+          style={{ width: 36, height: 36, objectFit: 'contain', borderRadius: 8, marginBottom: 16, flexShrink: 0 }}
+        />
+
+        {/* Nav items */}
+        {groups.map((entry) => {
+          const active  = isGroupActive(entry);
+          const isOpen  = !!(entry.items && openGroup === entry.label);
+          const highlight = active || isOpen;
+
           return (
             <button
               key={entry.label}
-              onClick={() => handleItemClick(entry.path)}
-              aria-current={active ? 'page' : undefined}
-              style={navBtnStyle(active)}
-              onMouseEnter={() => { cancelClose(); if (!pinnedGroup) setActiveGroup(null); }}
-              onMouseLeave={scheduleClose}
-            >
-              {entry.icon && <span style={{ fontSize: '13px' }}>{entry.icon}</span>}
-              {entry.label}
-            </button>
-          );
-        })}
-      </nav>
-
-      {/* ── Animated sub-nav bar ── */}
-      <div
-        style={{
-          height: subNavOpen ? '52px' : '0',
-          overflow: 'hidden',
-          transition: 'height 200ms ease',
-          background: 'var(--pe-bg-elevated)',
-          borderBottom: subNavOpen ? '1px solid var(--pe-border)' : 'none',
-          display: 'flex',
-          alignItems: 'stretch',
-          padding: subNavOpen ? '0 8px' : '0',
-          fontFamily: 'var(--pe-font-body)',
-          overflowX: 'auto',
-          scrollbarWidth: 'none',
-        }}
-        onMouseEnter={cancelClose}
-        onMouseLeave={scheduleClose}
-      >
-        {currentGroup?.items.map((item) => {
-          const active = isActive(item, pathname, search);
-          return (
-            <button
-              key={item.label}
-              onClick={() => handleItemClick(item.path)}
-              aria-current={active ? 'page' : undefined}
+              className="rail-btn"
+              aria-label={entry.label}
+              aria-expanded={entry.items ? isOpen : undefined}
+              aria-current={!entry.items && active ? 'page' : undefined}
+              onClick={() => handleRailClick(entry)}
               style={{
-                ...navBtnStyle(active, '52px'),
-                fontSize: '12px',
-                padding: '0 16px',
-                color: active ? 'var(--pe-cyan-bright)' : 'var(--pe-text-sub)',
+                width: 44,
+                height: 44,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: 10,
+                background: highlight
+                  ? 'linear-gradient(135deg, #00B8FF25, #1E7FEB15)'
+                  : 'none',
+                boxShadow: highlight ? '0 0 0 1px #00B8FF30' : 'none',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: 18,
+                margin: '2px 0',
+                color: highlight ? 'var(--pe-cyan-bright)' : 'var(--pe-text-muted)',
+                position: 'relative',
+                transition: 'background 120ms, box-shadow 120ms, color 120ms, transform 120ms',
+                fontFamily: 'var(--pe-font-body)',
+                flexShrink: 0,
               }}
-              onMouseEnter={e => {
-                cancelClose();
-                if (!active) e.currentTarget.style.color = 'var(--pe-text)';
-              }}
-              onMouseLeave={e => {
-                if (!active) e.currentTarget.style.color = 'var(--pe-text-sub)';
-              }}
+              onMouseEnter={e => { if (!highlight) e.currentTarget.style.transform = 'scale(1.05)'; }}
+              onMouseLeave={e => { e.currentTarget.style.transform = 'scale(1)'; }}
             >
-              {item.icon && <span style={{ fontSize: '13px' }}>{item.icon}</span>}
-              {item.label}
+              {entry.icon}
+
+              {/* Active accent bar on right edge */}
+              {highlight && (
+                <span style={{
+                  position: 'absolute',
+                  right: -1,
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  width: 3,
+                  height: 20,
+                  background: 'var(--pe-cyan-bright)',
+                  borderRadius: '3px 0 0 3px',
+                  boxShadow: '0 0 8px var(--pe-cyan-bright)',
+                }} />
+              )}
+
+              {/* Tooltip (hidden via CSS when flyout open) */}
+              <span className="rail-tooltip">{entry.label}</span>
             </button>
           );
         })}
+
+        {/* Spacer */}
+        <div style={{ flex: 1 }} />
+
+        {/* User avatar + logout popover */}
+        <div ref={logoutRef} style={{ position: 'relative', flexShrink: 0 }}>
+          <button
+            onClick={() => setShowLogout(v => !v)}
+            aria-label="Benutzermenü öffnen"
+            aria-expanded={showLogout}
+            aria-haspopup="true"
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: '50%',
+              background: 'var(--pe-gradient)',
+              border: 'none',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 12,
+              fontWeight: 700,
+              color: 'white',
+              fontFamily: 'var(--pe-font-body)',
+              transition: 'opacity 150ms',
+              flexShrink: 0,
+            }}
+            onMouseEnter={e => { e.currentTarget.style.opacity = '0.85'; }}
+            onMouseLeave={e => { e.currentTarget.style.opacity = '1'; }}
+          >
+            {initials}
+          </button>
+
+          {showLogout && (
+            <div style={{
+              position: 'absolute',
+              bottom: 'calc(100% + 8px)',
+              left: '50%',
+              transform: 'translateX(-50%)',
+              background: 'var(--pe-bg-elevated)',
+              border: '1px solid var(--pe-border)',
+              borderRadius: 8,
+              padding: 8,
+              minWidth: 140,
+              boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+              zIndex: 300,
+              fontFamily: 'var(--pe-font-body)',
+            }}>
+              <div style={{
+                padding: '6px 10px 8px',
+                fontSize: 11,
+                color: 'var(--pe-cyan-bright)',
+                fontWeight: 700,
+                borderBottom: '1px solid var(--pe-border)',
+                marginBottom: 6,
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+              }}>
+                {role}
+              </div>
+              <button
+                onClick={() => { setShowLogout(false); logout(); navigate('/'); }}
+                style={{
+                  width: '100%',
+                  minHeight: 44,
+                  padding: '8px 10px',
+                  background: 'none',
+                  border: '1px solid var(--pe-border)',
+                  borderRadius: 6,
+                  color: 'var(--pe-danger)',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  fontWeight: 700,
+                  fontFamily: 'var(--pe-font-body)',
+                  textAlign: 'left',
+                  transition: 'background 150ms',
+                }}
+                onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,69,96,0.1)'; }}
+                onMouseLeave={e => { e.currentTarget.style.background = 'none'; }}
+              >
+                Abmelden
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Flyout Panel ── width transitions 0→220px, pushing content right in flex layout */}
+      <div
+        role="navigation"
+        aria-label="Unternavigation"
+        style={{
+          width: currentGroup ? 220 : 0,
+          overflow: 'hidden',
+          transition: 'width 220ms cubic-bezier(0.4,0,0.2,1)',
+          background: 'var(--pe-bg-elevated)',
+          borderRight: currentGroup ? '1px solid var(--pe-border)' : 'none',
+          height: '100vh',
+          position: 'sticky',
+          top: 0,
+          flexShrink: 0,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {currentGroup && (
+          <div key={animKey} style={{ width: 220, display: 'flex', flexDirection: 'column', height: '100%' }}>
+            {/* Header */}
+            <div style={{
+              padding: '16px 16px 10px',
+              borderBottom: '1px solid var(--pe-border)',
+              flexShrink: 0,
+              animation: 'rail-flyout-header-in 200ms 50ms cubic-bezier(0.4,0,0.2,1) both',
+            }}>
+              <div style={{
+                fontSize: 10,
+                textTransform: 'uppercase',
+                letterSpacing: '0.12em',
+                color: 'var(--pe-text-muted)',
+                marginBottom: 4,
+              }}>
+                Navigation
+              </div>
+              <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--pe-text)' }}>
+                {currentGroup.label}
+              </div>
+            </div>
+
+            {/* Items */}
+            <div style={{ flex: 1, overflowY: 'auto', scrollbarWidth: 'none', padding: '8px 0' }}>
+              {currentGroup.items.map((item, i) => {
+                const active = isActive(item, pathname, search);
+                return (
+                  <button
+                    key={item.label}
+                    aria-current={active ? 'page' : undefined}
+                    onClick={() => handleItemClick(item.path)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      width: '100%',
+                      padding: '0 16px',
+                      height: 40,
+                      fontSize: 13,
+                      color: active ? 'var(--pe-cyan-bright)' : 'var(--pe-text-sub)',
+                      background: active ? '#00B8FF10' : 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      textAlign: 'left',
+                      fontFamily: 'var(--pe-font-body)',
+                      transition: 'background 120ms, color 120ms',
+                      animation: 'rail-flyout-item-in 220ms cubic-bezier(0.4,0,0.2,1) both',
+                      animationDelay: `${70 + i * 40}ms`,
+                    }}
+                    onMouseEnter={e => { if (!active) { e.currentTarget.style.background = '#ffffff08'; e.currentTarget.style.color = 'var(--pe-text)'; } }}
+                    onMouseLeave={e => { if (!active) { e.currentTarget.style.background = 'none'; e.currentTarget.style.color = 'var(--pe-text-sub)'; } }}
+                  >
+                    <span style={{ fontSize: 14, width: 20, textAlign: 'center', flexShrink: 0 }}>{item.icon}</span>
+                    {item.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -287,8 +448,8 @@ export default function TopNav() {
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
 
-  if (role === 'admin') {
-    return <AdminNav pathname={pathname} search={search} />;
+  if (role === 'admin' || role === 'director') {
+    return <RailNav role={role} />;
   }
 
   return (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -213,3 +213,44 @@ body {
   letter-spacing: 0.08em;
   color: var(--pe-text-muted);
 }
+
+/* ── Rail Nav: flyout animations ────────────────────────── */
+@keyframes rail-flyout-header-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes rail-flyout-item-in {
+  from { opacity: 0; transform: translateX(-10px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* ── Rail Nav: tooltip on hover ─────────────────────────── */
+.rail-btn .rail-tooltip {
+  position: absolute;
+  left: 52px;
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+  background: var(--pe-bg-elevated);
+  border: 1px solid var(--pe-border);
+  color: var(--pe-text);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--pe-font-body);
+  padding: 5px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 200;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+  transition: opacity 120ms 120ms, transform 120ms 120ms;
+}
+.rail-btn:hover .rail-tooltip {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+/* Hide tooltips when flyout is open (controlled via .rail-no-tooltips class on wrapper) */
+.rail-no-tooltips .rail-tooltip {
+  display: none;
+}


### PR DESCRIPTION
## Summary

- Replaces `AdminNav` (two-row animated top-nav) with `RailNav` — a 60px sticky icon rail with an animated 220px flyout panel for `admin` and `director` roles
- Director role now correctly routes to `RailNav` (previously used a flat tab nav via `TABS.director`)
- Flyout panel uses CSS `width` transition as a flex sibling (not `position: absolute`), so content naturally shifts right when flyout opens
- Header and items in flyout use `@keyframes` entrance animations with staggered delays
- Group-switch re-animation via React `key` prop (`animKey`) — reliably re-triggers CSS animations without DOM manipulation
- `AppShell` branches on role: flex-row (rail + content, no TopBar/BottomNav) for admin/director; existing column layout for all other roles
- All other role navigations (public, referee, gastronomy) unchanged

## Test plan

- [ ] Admin login: 60px rail visible, logo at top, avatar at bottom
- [ ] Group icons (Turnier, Spieler, Betrieb, System) open flyout with stagger animations
- [ ] Standalone items (Home, Übersicht, Archiv) navigate directly, no flyout
- [ ] Switching groups re-animates flyout content
- [ ] Close-then-reopen same group replays animations
- [ ] Outside click and route change both close flyout
- [ ] Active group icon stays highlighted when on a sub-route (flyout closed)
- [ ] Director login: subset nav (no Betrieb/System groups visible)
- [ ] Logout via avatar popover works for both roles
- [ ] Public/referee/gastronomy: flat top nav and TopBar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)