### PR TITLE
feat: icon rail + flyout nav for admin/director + popover fix

### DIFF
--- a/frontend/src/components/TopNav.jsx
+++ b/frontend/src/components/TopNav.jsx
@@ -307,9 +307,8 @@ function RailNav({ role }) {
           {showLogout && (
             <div style={{
               position: 'absolute',
-              bottom: 'calc(100% + 8px)',
-              left: '50%',
-              transform: 'translateX(-50%)',
+              bottom: 0,
+              left: 'calc(100% + 8px)',
               background: 'var(--pe-bg-elevated)',
               border: '1px solid var(--pe-border)',
               borderRadius: 8,


### PR DESCRIPTION
## Summary
- Replaces the old two-row `AdminNav` with a permanent 60px icon rail + 220px slide-out flyout panel
- Admin and Director roles get `RailNav`; all other roles keep the existing flat top-nav unchanged
- `AppShell` branches on role: admin/director get a `flex-row` layout (no TopBar/BottomNav), others keep the column layout
- Staggered entrance animations on flyout header and items
- Small-screen fallback (<900px): flyout overlays with backdrop instead of shifting content
- **Fixes** user avatar popover being clipped at the rail edge — now opens to the right of the rail

## Test plan
- [ ] Login as admin → rail on left, flyout slides on group click
- [ ] Click same group icon again → closes flyout
- [ ] Click outside → closes flyout
- [ ] Navigate to sub-route → correct group icon stays highlighted
- [ ] Switch groups while flyout is open → content re-animates
- [ ] Login as director → director-specific rail items (no Betrieb/System groups)
- [ ] Click user avatar → popover opens to the right, not clipped
- [ ] Login as public/gastronomy → old top-nav unchanged
- [ ] Resize below 900px → flyout overlays with backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)