### PR TITLE
fix: guest login button, gastro standalone view, referee walk-on

### DIFF
--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -9,6 +9,15 @@ export default function AppShell() {
   const role = useStore(s => s.role);
   const isRailRole = role === 'admin' || role === 'director';
 
+  if (role === 'gastronomy') {
+    // Gastronomy: full-screen, no shell — page handles its own logout
+    return (
+      <div style={{ minHeight: '100vh', background: 'var(--pe-bg)' }}>
+        <Outlet />
+      </div>
+    );
+  }
+
   if (isRailRole) {
     // Rail layout: nav left, content right (no TopBar or BottomNav)
     return (

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -1,5 +1,6 @@
 // frontend/src/components/TopBar.jsx
 import { useState, useRef, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { useStore } from '../store';
 
 const ROLE_PILL = {
@@ -78,6 +79,28 @@ export default function TopBar() {
           }}>
             {pill.label}
           </span>
+        )}
+        {!role && (
+          <Link
+            to="/login"
+            style={{
+              padding: '0 16px',
+              height: '36px',
+              display: 'inline-flex',
+              alignItems: 'center',
+              borderRadius: 'var(--pe-radius-md)',
+              border: '1px solid var(--pe-border)',
+              background: 'var(--pe-bg-card)',
+              color: 'var(--pe-text-sub)',
+              fontFamily: 'var(--pe-font-body)',
+              fontSize: '13px',
+              fontWeight: 'bold',
+              textDecoration: 'none',
+              flexShrink: 0,
+            }}
+          >
+            Anmelden
+          </Link>
         )}
         {role && (
           <div ref={menuRef} style={{ position: 'relative' }}>

--- a/frontend/src/components/TopNav.jsx
+++ b/frontend/src/components/TopNav.jsx
@@ -8,7 +8,6 @@ const TABS = {
   public: [
     { icon: '🏠', label: 'Home',          path: '/',                        exact: true },
     { icon: '📜', label: 'Archiv',        path: '/history',                 exact: false },
-    { icon: '👤', label: 'Anmelden',      path: '/login',                   exact: false },
   ],
   referee: [
     { icon: '📋', label: 'Meine Boards',  path: '/referee',                 exact: false },

--- a/frontend/src/pages/GastronomyPage.jsx
+++ b/frontend/src/pages/GastronomyPage.jsx
@@ -2,6 +2,7 @@
 // Stations: 'bar' (drinks + ordering), 'register' (settle)
 // Auth is handled by ProtectedRoute in App.jsx — no inline login gate here.
 import { useEffect, useState, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import StationSelector from '../components/gastro/StationSelector';
 import RegisterView from '../components/gastro/RegisterView';
@@ -12,9 +13,14 @@ import ProductGrid from '../components/gastro/ProductGrid';
 import SessionOrderList from '../components/gastro/SessionOrderList';
 import SettleDialog from '../components/gastro/SettleDialog';
 import { useToastStore } from '../store/toasts';
+import { useStore } from '../store';
 
 export default function GastronomyPage() {
   const { addToast } = useToastStore();
+  const { role, logout } = useStore();
+  const navigate = useNavigate();
+
+  const handleLogout = () => { logout(); navigate('/'); };
 
   // Tablet detection — responsive breakpoint at 768px
   const [isTablet, setIsTablet] = useState(() => window.matchMedia('(min-width: 768px)').matches);
@@ -327,6 +333,30 @@ export default function GastronomyPage() {
             </button>
           );
         })}
+        {role === 'gastronomy' && (
+          <button
+            onClick={handleLogout}
+            style={{
+              marginLeft: 'auto',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: '64px',
+              padding: '0 20px',
+              borderRadius: 'var(--pe-radius-xl)',
+              background: 'none',
+              border: '1px solid var(--pe-border)',
+              color: 'var(--pe-danger)',
+              fontFamily: 'var(--pe-font-body)',
+              fontWeight: 'bold',
+              fontSize: '14px',
+              cursor: 'pointer',
+              flexShrink: 0,
+            }}
+          >
+            Abmelden
+          </button>
+        )}
       </div>
 
       {/* ===== BAR STATION ===== */}

--- a/frontend/src/pages/RefereePage.jsx
+++ b/frontend/src/pages/RefereePage.jsx
@@ -353,6 +353,7 @@ function LastThrows({ throws = [], isTablet }) {
 
 // ── Walk-On Play Button ─────────────────────────────────────────────────────
 function WalkonPlayButton({ playerId }) {
+  const role = useStore(s => s.role);
   const [audio, setAudio] = useState(null);
   const [playing, setPlaying] = useState(false);
   const [available, setAvailable] = useState(null); // null=loading, true/false
@@ -363,6 +364,7 @@ function WalkonPlayButton({ playerId }) {
       .catch(() => setAvailable(false));
   }, [playerId]);
 
+  if (role === 'referee') return null;
   if (!available) return null;
 
   const handlePlay = () => {


### PR DESCRIPTION
## Summary
- **Guest homepage**: Removed "Anmelden" tab from public nav; added subtle login button to TopBar for unauthenticated users. Login routing already correct (admin→/admin, director→/admin, gastro→/gastronomy, referee→/referee).
- **Gastronomy**: AppShell renders no shell (no TopBar, no nav, no BottomNav) for gastronomy role. GastronomyPage shows an "Abmelden" button next to the Bar/Kasse switcher.
- **Referee**: Walk-On play button is hidden for referee role — only admin/director can trigger walk-ons.

## Test plan
- [ ] Guest (not logged in) sees tournaments page with small "Anmelden" button in top bar (no login tab in nav)
- [ ] Clicking Anmelden → /login, after login routes to correct page per role
- [ ] Login as gastronomy → /gastronomy loads with NO shell (no top bar, no nav tabs, no bottom nav)
- [ ] Gastronomy page shows "Abmelden" button next to Bar/Kasse chips → click logs out and redirects to /
- [ ] Login as referee → open a game in /referee/:boardId → walk-on play button NOT visible
- [ ] Login as admin → walk-on play button still visible in /referee/:boardId

🤖 Generated with [Claude Code](https://claude.com/claude-code)